### PR TITLE
fix permission for pr

### DIFF
--- a/.github/workflows/prod-build-images.yml
+++ b/.github/workflows/prod-build-images.yml
@@ -304,6 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/prod-build-manifest.yml
+++ b/.github/workflows/prod-build-manifest.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
To make sure we can create new images and manifest, they get crated in a pr that needs to be approved, allows for reviews