### PR TITLE
fix: handle empty matrix in prod-build-images workflow

### DIFF
--- a/.github/workflows/prod-build-images.yml
+++ b/.github/workflows/prod-build-images.yml
@@ -195,8 +195,12 @@ jobs:
                       'dockerfile': dockerfile
                   })
 
-          # Create matrix
-          matrix = {'include': services_to_build}
+          # Create matrix - ensure at least a dummy entry to avoid GitHub Actions error
+          if not services_to_build:
+              # Add dummy entry that will be skipped
+              matrix = {'include': [{'name': '_skip', 'platform': 'linux/amd64', 'dockerfile': 'none'}]}
+          else:
+              matrix = {'include': services_to_build}
 
           # Output to GitHub Actions
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
@@ -205,8 +209,11 @@ jobs:
 
           print(f"Registry: {registry}")
           print(f"Services to build: {len(services_to_build)}")
-          for svc in services_to_build:
-              print(f"  - {svc['name']} (platform: {svc['platform']})")
+          if services_to_build:
+              for svc in services_to_build:
+                  print(f"  - {svc['name']} (platform: {svc['platform']})")
+          else:
+              print("  (none - dummy matrix entry added)")
           PYTHON_SCRIPT
 
       - name: Summary
@@ -220,7 +227,6 @@ jobs:
 
   build-images:
     needs: [determine-version, prepare-matrix]
-    if: needs.prepare-matrix.outputs.matrix != '{"include":[]}'
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -232,13 +238,26 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      - name: Check if this is a dummy run
+        id: check-skip
+        run: |
+          if [[ "${{ matrix.name }}" == "_skip" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "This is a dummy matrix entry - skipping all steps"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
+        if: steps.check-skip.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        if: steps.check-skip.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: steps.check-skip.outputs.skip != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -246,6 +265,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Extract image name
+        if: steps.check-skip.outputs.skip != 'true'
         id: image
         run: |
           SERVICE_NAME="${{ matrix.name }}"
@@ -270,6 +290,7 @@ jobs:
           echo "Building: ${FULL_IMAGE}"
 
       - name: Check for Dockerfile
+        if: steps.check-skip.outputs.skip != 'true'
         id: check
         run: |
           if [ -f "${{ matrix.dockerfile }}" ]; then


### PR DESCRIPTION
Add dummy matrix entry when no services are buildable to prevent GitHub Actions matrix evaluation error. The dummy entry is detected and skipped during execution.

Fixes: matrix must define at least one vector error

