### PR TITLE
updated payment service to avoid setting status on client span

### DIFF
--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -259,8 +259,6 @@ module.exports.charge = async request => {
         lastErr = err;
         clientSpan.addEvent('attempt.failure', { attempt, code: String(err.code || 401) });
         clientSpan.setAttributes({ 'http.status_code': String(err.code || 401) });
-        // Mark this attempt span as an error
-        clientSpan.setStatus({ code: SpanStatusCode.ERROR, message: String(err.code || 401) });
 
 
         // Flag the root span for every 401 attempt (not just the final failure)


### PR DESCRIPTION
The payment service was setting the status of the client span to "error" when an error occurred, resulting in ButtercupPayments showing up as a root cause service on the service map. 

With this change, the service map now shows the payment service as the root cause error, rather than ButtercupPayments. 

<img width="1204" height="676" alt="updated service map" src="https://github.com/user-attachments/assets/05e717a1-2606-4e73-806f-b4b17a506b0f" />
<img width="1234" height="677" alt="updated trace" src="https://github.com/user-attachments/assets/7329d705-f454-44da-bc75-1f4ecbec0699" />
