### PR TITLE
fix: infrastructure manifest display + combined release workflow

### DIFF
--- a/.github/scripts/show-image-versions.py
+++ b/.github/scripts/show-image-versions.py
@@ -26,9 +26,9 @@ def extract_image_from_manifest(manifest_path: Path) -> Tuple[str, str, str]:
         with open(manifest_path, 'r') as f:
             docs = list(yaml.safe_load_all(f))
 
-        # Find Deployment resource
+        # Find Deployment or StatefulSet resource
         for doc in docs:
-            if doc and doc.get('kind') == 'Deployment':
+            if doc and doc.get('kind') in ('Deployment', 'StatefulSet'):
                 service_name = doc.get('metadata', {}).get('name', 'unknown')
                 containers = doc.get('spec', {}).get('template', {}).get('spec', {}).get('containers', [])
 
@@ -42,7 +42,10 @@ def extract_image_from_manifest(manifest_path: Path) -> Tuple[str, str, str]:
 
                     return service_name, image, version
 
-        return ('unknown', '', 'unknown')
+        # No Deployment/StatefulSet found — this is an infrastructure manifest
+        # Use the directory name as the service name
+        service_name = manifest_path.parent.name
+        return (service_name, '', '-')
 
     except Exception as e:
         print(f"Warning: Could not parse {manifest_path}: {e}", file=sys.stderr)
@@ -58,6 +61,9 @@ def categorize_version(version: str, base_version: str) -> str:
     """
     if not version or version == 'latest':
         return 'external'
+
+    if version == '-':
+        return 'infrastructure'
 
     # Check if it's a hotfix version (e.g., 1.1.0-payment.1)
     if '-' in version and '.' in version.split('-')[-1]:
@@ -140,6 +146,8 @@ def print_version_table(versions: List[Tuple[str, str, str]], base_version: str,
                 status = f"⚠️ Older"
             elif category == 'newer':
                 status = f"🆕 Newer"
+            elif category == 'infrastructure':
+                status = f"🔧 Infrastructure"
             elif category == 'external':
                 status = f"📦 External"
             else:
@@ -165,6 +173,8 @@ def print_version_table(versions: List[Tuple[str, str, str]], base_version: str,
                 status = f"Older"
             elif category == 'newer':
                 status = f"Newer"
+            elif category == 'infrastructure':
+                status = f"Infrastructure"
             elif category == 'external':
                 status = f"External"
             else:
@@ -185,6 +195,7 @@ def get_version_summary(versions: List[Tuple[str, str, str]], base_version: str)
         'hotfix': 0,
         'older': 0,
         'newer': 0,
+        'infrastructure': 0,
         'external': 0,
         'unknown': 0
     }
@@ -236,6 +247,7 @@ def main():
         print(f"  - Hotfixes: {summary['hotfix']}")
         print(f"  - Older versions: {summary['older']}")
         print(f"  - Newer versions: {summary['newer']}")
+        print(f"  - Infrastructure: {summary['infrastructure']}")
         print(f"  - External images: {summary['external']}")
         if summary['unknown'] > 0:
             print(f"  - Unknown: {summary['unknown']}")

--- a/.github/scripts/show-image-versions.py
+++ b/.github/scripts/show-image-versions.py
@@ -72,6 +72,8 @@ def categorize_version(version: str, base_version: str) -> str:
         def parse_version(v):
             # Remove any suffix after '-'
             base = v.split('-')[0]
+            # Strip leading 'v' prefix (e.g., v0.12.8 → 0.12.8)
+            base = base.lstrip('v')
             parts = base.split('.')
             return tuple(int(p) for p in parts)
 
@@ -84,8 +86,8 @@ def categorize_version(version: str, base_version: str) -> str:
             return 'newer'
         else:
             return 'current'
-    except:
-        return 'unknown'
+    except (ValueError, TypeError):
+        return 'external'
 
 
 def get_service_versions() -> List[Tuple[str, str, str]]:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -1,0 +1,589 @@
+name: Production Release (Build + Manifest)
+# Combined workflow: builds images, updates versions, stitches manifests, creates ONE PR
+# Replaces the two-step flow of prod-build-images.yml → (merge PR) → prod-build-manifest.yml
+
+"on":
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - none (keep current)
+          - custom
+        default: 'patch'
+      custom_version:
+        description: 'Custom version (only when version_bump=custom, requires single service)'
+        required: false
+        type: string
+        default: ''
+      services:
+        description: 'Services to build (comma-separated, or "all")'
+        required: false
+        type: string
+        default: 'all'
+      no_cache:
+        description: 'Disable build cache'
+        required: false
+        type: boolean
+        default: false
+      beta_build:
+        description: 'Beta build (adds -beta suffix to manifests)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  # ─────────────────────────────────────────────
+  # Step 1: Determine the version
+  # ─────────────────────────────────────────────
+  determine-version:
+    if: github.repository == 'splunk/opentelemetry-demo'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_hotfix: ${{ steps.version.outputs.is_hotfix }}
+      is_full_release: ${{ steps.version.outputs.is_full_release }}
+      is_custom: ${{ steps.version.outputs.is_custom }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - run: pip install pyyaml
+
+      - name: Make scripts executable
+        run: |
+          chmod +x .github/scripts/bump-version.py
+          chmod +x .github/scripts/manage-hotfix.py
+
+      - name: Determine version
+        id: version
+        run: |
+          CURRENT_VERSION=$(cat SPLUNK-VERSION)
+          BUMP_TYPE="${{ inputs.version_bump }}"
+          SERVICES="${{ inputs.services }}"
+          CUSTOM_VERSION="${{ inputs.custom_version }}"
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Services to build: $SERVICES"
+
+          # Validate custom version usage
+          if [[ "$BUMP_TYPE" == "custom" ]]; then
+            if [[ "$SERVICES" == "all" ]]; then
+              echo "❌ ERROR: Custom version requires a single service, not 'all'"
+              exit 1
+            fi
+            if [[ -z "$CUSTOM_VERSION" ]]; then
+              echo "❌ ERROR: Custom version selected but no version provided"
+              exit 1
+            fi
+            SERVICE_COUNT=$(echo "$SERVICES" | tr ',' '\n' | wc -l)
+            if [[ "$SERVICE_COUNT" -gt 1 ]]; then
+              echo "❌ ERROR: Custom version requires exactly one service, got: $SERVICES"
+              exit 1
+            fi
+          fi
+
+          # Determine if this is a hotfix build
+          IS_HOTFIX="false"
+          if [[ "$SERVICES" != "all" ]] && [[ "$BUMP_TYPE" == "none (keep current)" ]]; then
+            IS_HOTFIX="true"
+          fi
+
+          # Calculate version
+          if [[ "$BUMP_TYPE" == "custom" ]]; then
+            VERSION="$CUSTOM_VERSION"
+            VERSION_STATUS="custom"
+          elif [[ "$IS_HOTFIX" == "true" ]]; then
+            SERVICE_NAME=$(echo "$SERVICES" | tr ',' '\n' | head -1 | xargs)
+            VERSION=$(python3 .github/scripts/manage-hotfix.py add "$SERVICE_NAME")
+            VERSION_STATUS="hotfix"
+          elif [[ "$BUMP_TYPE" == "none (keep current)" ]]; then
+            VERSION="$CURRENT_VERSION"
+            VERSION_STATUS="unchanged"
+          else
+            VERSION=$(python3 .github/scripts/bump-version.py "$CURRENT_VERSION" "$BUMP_TYPE")
+            VERSION_STATUS="bumped"
+          fi
+
+          IS_FULL_RELEASE="false"
+          if [[ "$SERVICES" == "all" && "$VERSION_STATUS" == "bumped" ]]; then
+            IS_FULL_RELEASE="true"
+          fi
+
+          IS_CUSTOM="false"
+          if [[ "$VERSION_STATUS" == "custom" ]]; then
+            IS_CUSTOM="true"
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_hotfix=$IS_HOTFIX" >> $GITHUB_OUTPUT
+          echo "is_full_release=$IS_FULL_RELEASE" >> $GITHUB_OUTPUT
+          echo "is_custom=$IS_CUSTOM" >> $GITHUB_OUTPUT
+
+          echo "### Version Information" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Type | Version |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Current | \`$CURRENT_VERSION\` |" >> $GITHUB_STEP_SUMMARY
+          if [[ "$VERSION_STATUS" == "bumped" ]]; then
+            echo "| **New** | **\`$VERSION\`** |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| **Using** | **\`$VERSION\`** ($VERSION_STATUS) |" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "| Bump | ${{ inputs.version_bump }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Services | ${{ inputs.services }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ─────────────────────────────────────────────
+  # Step 2: Prepare build matrix
+  # ─────────────────────────────────────────────
+  prepare-matrix:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      registry: ${{ steps.set-matrix.outputs.registry }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - run: pip install pyyaml
+
+      - name: Generate build matrix
+        id: set-matrix
+        run: |
+          python3 << 'PYTHON_SCRIPT'
+          import yaml, json, os
+
+          with open('services.yaml', 'r') as f:
+              config = yaml.safe_load(f)
+
+          prod_registry = config.get('registry', {}).get('prod', 'ghcr.io/splunk/opentelemetry-demo')
+          requested = "${{ inputs.services }}".strip()
+          services_to_build = []
+
+          for svc in config.get('services', []):
+              name = svc.get('name')
+              if not svc.get('build', False):
+                  continue
+
+              if requested == 'all':
+                  include = True
+              else:
+                  include = name in [s.strip() for s in requested.split(',')]
+
+              if include:
+                  platform = svc.get('platform', 'linux/amd64,linux/arm64')
+                  dockerfile = svc.get('dockerfile', f'src/{name}/Dockerfile')
+
+                  if name == 'payment':
+                      for variant, args in [('A', 'VERSION=A'), ('B', 'VERSION=B')]:
+                          services_to_build.append({
+                              'name': name, 'variant': variant, 'platform': platform,
+                              'dockerfile': dockerfile, 'build_args': args
+                          })
+                  else:
+                      services_to_build.append({
+                          'name': name, 'variant': '', 'platform': platform,
+                          'dockerfile': dockerfile, 'build_args': ''
+                      })
+
+          if not services_to_build:
+              matrix = {'include': [{'name': '_skip', 'variant': '', 'platform': 'linux/amd64', 'dockerfile': 'none', 'build_args': ''}]}
+          else:
+              matrix = {'include': services_to_build}
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'matrix={json.dumps(matrix)}\n')
+              f.write(f'registry={prod_registry}\n')
+
+          print(f"Registry: {prod_registry}")
+          print(f"Services to build: {len(services_to_build)}")
+          for svc in services_to_build:
+              v = f" (variant: {svc['variant']})" if svc['variant'] else ""
+              print(f"  - {svc['name']}{v}")
+          PYTHON_SCRIPT
+
+  # ─────────────────────────────────────────────
+  # Step 3: Build and push images
+  # ─────────────────────────────────────────────
+  build-images:
+    needs: [determine-version, prepare-matrix]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Check if skip
+        id: check-skip
+        run: |
+          if [[ "${{ matrix.name }}" == "_skip" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.check-skip.outputs.skip != 'true'
+
+      - uses: docker/setup-buildx-action@v4
+        if: steps.check-skip.outputs.skip != 'true'
+
+      - name: Log in to GHCR
+        if: steps.check-skip.outputs.skip != 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract image name
+        if: steps.check-skip.outputs.skip != 'true'
+        id: image
+        run: |
+          REGISTRY="${{ needs.prepare-matrix.outputs.registry }}"
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          IMAGE_NAME="otel-${{ matrix.name }}"
+
+          if [ -n "${{ matrix.variant }}" ]; then
+            VERSION_TAG="${VERSION}-$(echo '${{ matrix.variant }}' | tr '[:upper:]' '[:lower:]')"
+          else
+            VERSION_TAG="${VERSION}"
+          fi
+
+          echo "full_image=${REGISTRY}/${IMAGE_NAME}:${VERSION_TAG}" >> $GITHUB_OUTPUT
+          echo "version_tag=${VERSION_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Check for Dockerfile
+        if: steps.check-skip.outputs.skip != 'true'
+        id: check
+        run: |
+          if [ -f "${{ matrix.dockerfile }}" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push image
+        if: steps.check.outputs.exists == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.image.outputs.full_image }}
+          build-args: ${{ matrix.build_args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          no-cache: ${{ inputs.no_cache }}
+
+      - name: Image info
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          echo "### ✅ Built: ${{ matrix.name }}${{ matrix.variant && format(' ({0})', matrix.variant) || '' }}" >> $GITHUB_STEP_SUMMARY
+          echo "Image: \`${{ steps.image.outputs.full_image }}\`" >> $GITHUB_STEP_SUMMARY
+
+  # ─────────────────────────────────────────────
+  # Step 4: Update versions + stitch manifests + single PR
+  # ─────────────────────────────────────────────
+  update-and-release:
+    needs: [determine-version, prepare-matrix, build-images]
+    if: ${{ success() && github.repository == 'splunk/opentelemetry-demo' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - run: pip install pyyaml
+
+      - name: Make scripts executable
+        run: |
+          chmod +x .github/scripts/manage-hotfix.py
+          chmod +x .github/scripts/update-manifest-images.py
+          chmod +x .github/scripts/show-image-versions.py
+          chmod +x .github/scripts/stitch-manifests.sh
+          chmod +x .github/scripts/get-services.py
+
+      - name: Update SPLUNK-VERSION
+        if: ${{ needs.determine-version.outputs.is_hotfix == 'false' && inputs.version_bump != 'none (keep current)' && inputs.version_bump != 'custom' }}
+        run: |
+          CURRENT=$(cat SPLUNK-VERSION)
+          NEW="${{ needs.determine-version.outputs.version }}"
+          echo "$NEW" > SPLUNK-VERSION
+          echo "✅ SPLUNK-VERSION: $CURRENT → $NEW"
+
+      - name: Clear hotfixes on full releases
+        if: ${{ needs.determine-version.outputs.is_full_release == 'true' }}
+        run: |
+          python3 .github/scripts/manage-hotfix.py clear
+          echo "✅ Hotfixes cleared"
+
+      - name: Update hotfix tracking
+        if: ${{ needs.determine-version.outputs.is_hotfix == 'true' }}
+        run: echo "Hotfix already tracked in determine-version step"
+
+      - name: Update source manifests with new image references
+        run: |
+          REGISTRY="${{ needs.prepare-matrix.outputs.registry }}"
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          SERVICES_INPUT="${{ inputs.services }}"
+
+          if [ "$SERVICES_INPUT" = "all" ]; then
+            SERVICES_TO_UPDATE=$(python3 <<'PYTHON_SCRIPT'
+          import yaml
+          with open('services.yaml', 'r') as f:
+              config = yaml.safe_load(f)
+          services = [svc['name'] for svc in config.get('services', []) if svc.get('build', False)]
+          print(' '.join(services))
+          PYTHON_SCRIPT
+          )
+          else
+            SERVICES_TO_UPDATE=$(echo "$SERVICES_INPUT" | tr ',' ' ')
+          fi
+
+          echo "Updating source manifests for: $SERVICES_TO_UPDATE"
+
+          for SERVICE in $SERVICES_TO_UPDATE; do
+            if [ "$SERVICE" = "payment" ]; then
+              for VARIANT_FILE in payment-vA-k8s.yaml payment-vB-k8s.yaml; do
+                MANIFEST_PATH="src/payment/$VARIANT_FILE"
+                if [ -f "$MANIFEST_PATH" ]; then
+                  VARIANT_SUFFIX=$(echo "$VARIANT_FILE" | grep -oP 'v[AB]' | tr '[:upper:]' '[:lower:]' | sed 's/v//')
+                  NEW_IMAGE="${REGISTRY}/otel-payment:${VERSION}-${VARIANT_SUFFIX}"
+                  sed -i.bak -E "s|image:[ ]+[^ ]+/otel-payment:[^ ]+|image: ${NEW_IMAGE}|g" "$MANIFEST_PATH"
+                  rm -f "${MANIFEST_PATH}.bak"
+                  echo "  ✅ $MANIFEST_PATH → $NEW_IMAGE"
+                fi
+              done
+            else
+              python3 .github/scripts/update-manifest-images.py "$SERVICE" "$REGISTRY" "otel-${SERVICE}" "$VERSION"
+            fi
+          done
+
+      - name: Stitch production manifests
+        id: stitch
+        run: |
+          VERSION=$(cat SPLUNK-VERSION)
+
+          if [[ "${{ inputs.beta_build }}" == "true" ]]; then
+            OUTPUT_DIR="kubernetes/beta"
+            EXTRA_SUFFIX="-beta"
+            mkdir -p "$OUTPUT_DIR"
+          else
+            OUTPUT_DIR="kubernetes"
+            EXTRA_SUFFIX=""
+          fi
+
+          echo "Stitching regular manifest..."
+          .github/scripts/stitch-manifests.sh prod "" "$OUTPUT_DIR" "$EXTRA_SUFFIX"
+
+          echo "Stitching DIAB manifest..."
+          .github/scripts/stitch-manifests.sh prod diab "$OUTPUT_DIR" "$EXTRA_SUFFIX"
+
+          MANIFEST_FILE="${OUTPUT_DIR}/splunk-astronomy-shop-${VERSION}${EXTRA_SUFFIX}.yaml"
+          MANIFEST_FILE_DIAB="${OUTPUT_DIR}/splunk-astronomy-shop-${VERSION}-diab${EXTRA_SUFFIX}.yaml"
+
+          echo "manifest_file=$MANIFEST_FILE" >> $GITHUB_OUTPUT
+          echo "manifest_file_diab=$MANIFEST_FILE_DIAB" >> $GITHUB_OUTPUT
+
+          echo "✅ Regular: $MANIFEST_FILE"
+          echo "✅ DIAB: $MANIFEST_FILE_DIAB"
+
+      - name: Validate manifest YAML
+        run: |
+          MANIFEST_FILE="${{ steps.stitch.outputs.manifest_file }}"
+          MANIFEST_FILE_DIAB="${{ steps.stitch.outputs.manifest_file_diab }}"
+
+          python3 -c "import yaml; docs=list(yaml.safe_load_all(open('$MANIFEST_FILE'))); print(f'Regular: {len(docs)} documents')"
+          python3 -c "import yaml; docs=list(yaml.safe_load_all(open('$MANIFEST_FILE_DIAB'))); print(f'DIAB: {len(docs)} documents')"
+
+      - name: Show image version breakdown
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📦 Image Versions in Manifest" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          python3 .github/scripts/show-image-versions.py \
+            --base-version "$VERSION" \
+            --format github >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Summary:**" >> $GITHUB_STEP_SUMMARY
+          python3 .github/scripts/show-image-versions.py \
+            --base-version "$VERSION" \
+            --summary-only >> $GITHUB_STEP_SUMMARY
+
+      - name: Create single Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          IS_HOTFIX="${{ needs.determine-version.outputs.is_hotfix }}"
+          IS_FULL_RELEASE="${{ needs.determine-version.outputs.is_full_release }}"
+          IS_CUSTOM="${{ needs.determine-version.outputs.is_custom }}"
+          SERVICES="${{ inputs.services }}"
+          MANIFEST_FILE="${{ steps.stitch.outputs.manifest_file }}"
+          MANIFEST_FILE_DIAB="${{ steps.stitch.outputs.manifest_file_diab }}"
+
+          BRANCH_NAME="release/${VERSION}"
+
+          # Stage all changes
+          if [[ "$IS_HOTFIX" == "true" ]]; then
+            git add .hotfix.yaml
+          fi
+
+          if [[ "$IS_HOTFIX" == "false" && "$IS_CUSTOM" == "false" && "${{ inputs.version_bump }}" != "none (keep current)" ]]; then
+            git add SPLUNK-VERSION
+          fi
+
+          if [[ "$IS_FULL_RELEASE" == "true" ]]; then
+            if ! [ -f .hotfix.yaml ]; then
+              git rm --ignore-unmatch .hotfix.yaml 2>/dev/null || true
+            fi
+          fi
+
+          # Stage source manifests, stitched manifests
+          git add src/*/*-k8s.yaml
+          git add "$MANIFEST_FILE" "$MANIFEST_FILE_DIAB"
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+
+          # Commit message
+          if [[ "$IS_HOTFIX" == "true" ]]; then
+            COMMIT_TITLE="hotfix: ${VERSION} (${SERVICES})"
+            PR_TITLE="Hotfix: ${SERVICES} @ ${VERSION}"
+          elif [[ "$IS_CUSTOM" == "true" ]]; then
+            COMMIT_TITLE="build: ${SERVICES} @ ${VERSION} (custom)"
+            PR_TITLE="Custom Build: ${SERVICES} @ ${VERSION}"
+          elif [[ "$IS_FULL_RELEASE" == "true" ]]; then
+            COMMIT_TITLE="release: ${VERSION}"
+            PR_TITLE="Release ${VERSION}"
+          else
+            COMMIT_TITLE="build: ${VERSION} (${SERVICES})"
+            PR_TITLE="Production Build: ${VERSION}"
+          fi
+
+          git commit -m "$COMMIT_TITLE" \
+            -m "" \
+            -m "Services: ${SERVICES}" \
+            -m "Bump: ${{ inputs.version_bump }}" \
+            -m "" \
+            -m "Includes:" \
+            -m "- Container images built and pushed" \
+            -m "- SPLUNK-VERSION updated" \
+            -m "- Source k8s manifests updated" \
+            -m "- Production manifests stitched (regular + DIAB)"
+
+          # Delete remote branch if exists
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+          git push -u origin "$BRANCH_NAME"
+
+          # Build PR body
+          PR_BODY=$(printf '%s\n' \
+            "## ${PR_TITLE}" \
+            "" \
+            "**Version:** \`${VERSION}\`" \
+            "**Services:** ${SERVICES}" \
+            "**Bump:** ${{ inputs.version_bump }}" \
+            "" \
+            "### What's included" \
+            "- ✅ Container images built and pushed to \`ghcr.io/splunk/opentelemetry-demo\`" \
+            "- ✅ SPLUNK-VERSION updated" \
+            "- ✅ Source k8s manifests updated with new image references" \
+            "- ✅ Production manifests stitched: \`${MANIFEST_FILE}\` + DIAB" \
+            "" \
+            "### Deploy" \
+            "\`\`\`bash" \
+            "kubectl apply -f ${MANIFEST_FILE}" \
+            "\`\`\`" \
+            "" \
+            "See the **Image Versions in Manifest** section in the workflow summary for the full breakdown." \
+            "" \
+            "---" \
+            "🤖 Generated by Production Release workflow"
+          )
+
+          gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base main \
+            --head "$BRANCH_NAME"
+
+          PR_URL=$(gh pr view "$BRANCH_NAME" --json url -q .url)
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### ✅ Pull Request Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**[$PR_TITLE]($PR_URL)**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Branch: \`$BRANCH_NAME\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Merge this PR to apply all changes at once." >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload manifests as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: astronomy-shop-manifests-${{ needs.determine-version.outputs.version }}${{ inputs.beta_build == true && '-beta' || '' }}
+          path: |
+            ${{ steps.stitch.outputs.manifest_file }}
+            ${{ steps.stitch.outputs.manifest_file_diab }}
+          retention-days: 90
+
+  # ─────────────────────────────────────────────
+  # Summary
+  # ─────────────────────────────────────────────
+  summary:
+    needs: [determine-version, prepare-matrix, build-images, update-and-release]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Summary
+        run: |
+          echo "## 🎉 Production Release Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Version** | \`${{ needs.determine-version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Bump** | ${{ inputs.version_bump }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Services** | ${{ inputs.services }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Registry** | \`${{ needs.prepare-matrix.outputs.registry }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Images built → ✅ Versions updated → ✅ Manifests stitched → ✅ PR created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> **One PR to review and merge. No second workflow needed.**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/weekly-otel-check.yml
+++ b/.github/workflows/weekly-otel-check.yml
@@ -1,0 +1,137 @@
+name: Weekly OTel Upstream Sync Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+  workflow_dispatch:       # Allow manual trigger
+
+jobs:
+  check-upstream-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Add OTel remote and fetch
+        run: |
+          git remote add otel https://github.com/open-telemetry/opentelemetry-demo.git
+          git fetch otel --tags --quiet
+
+      - name: Check sync status
+        id: sync_status
+        run: |
+          # Find latest OTel release tag (numeric only, e.g., 2.2.0)
+          LATEST_TAG=$(git tag -l '[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -1)
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+          # Count commits behind latest tag
+          BEHIND_TAG=$(git log --oneline HEAD..$LATEST_TAG 2>/dev/null | wc -l | tr -d ' ')
+          echo "behind_tag=$BEHIND_TAG" >> $GITHUB_OUTPUT
+
+          # Count commits behind otel/main
+          BEHIND_MAIN=$(git log --oneline HEAD..otel/main 2>/dev/null | wc -l | tr -d ' ')
+          echo "behind_main=$BEHIND_MAIN" >> $GITHUB_OUTPUT
+
+          # Count commits ahead
+          AHEAD=$(git log --oneline otel/main..HEAD 2>/dev/null | wc -l | tr -d ' ')
+          echo "ahead=$AHEAD" >> $GITHUB_OUTPUT
+
+          # Find merge base to determine which OTel tag we're synced to
+          MERGE_BASE=$(git merge-base HEAD otel/main 2>/dev/null || echo "none")
+          if [ "$MERGE_BASE" != "none" ]; then
+            SYNCED_TO=$(git describe --tags --abbrev=0 $MERGE_BASE 2>/dev/null || echo "unknown")
+          else
+            SYNCED_TO="unknown"
+          fi
+          echo "synced_to=$SYNCED_TO" >> $GITHUB_OUTPUT
+
+          echo "Latest OTel tag: $LATEST_TAG"
+          echo "Currently synced to: $SYNCED_TO"
+          echo "Behind latest tag: $BEHIND_TAG commits"
+          echo "Behind otel/main: $BEHIND_MAIN commits"
+          echo "Ahead of otel/main: $AHEAD commits (Splunk customizations)"
+
+      - name: Dry-run merge to count conflicts
+        id: conflict_check
+        run: |
+          LATEST_TAG=${{ steps.sync_status.outputs.latest_tag }}
+
+          # Attempt merge without committing
+          git merge --no-commit --no-ff $LATEST_TAG 2>/dev/null || true
+
+          # Count conflict files
+          CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null | wc -l | tr -d ' ')
+          echo "conflicts=$CONFLICTS" >> $GITHUB_OUTPUT
+
+          # Capture conflict file list
+          if [ "$CONFLICTS" -gt 0 ]; then
+            CONFLICT_FILES=$(git diff --name-only --diff-filter=U 2>/dev/null | head -30)
+            echo "conflict_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$CONFLICT_FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+          # Abort the merge
+          git merge --abort 2>/dev/null || git reset --hard HEAD
+
+          echo "Conflict files if merged with $LATEST_TAG: $CONFLICTS"
+
+      - name: Generate summary
+        run: |
+          LATEST_TAG=${{ steps.sync_status.outputs.latest_tag }}
+          SYNCED_TO=${{ steps.sync_status.outputs.synced_to }}
+          BEHIND_TAG=${{ steps.sync_status.outputs.behind_tag }}
+          BEHIND_MAIN=${{ steps.sync_status.outputs.behind_main }}
+          AHEAD=${{ steps.sync_status.outputs.ahead }}
+          CONFLICTS=${{ steps.conflict_check.outputs.conflicts }}
+
+          # Determine urgency
+          if [ "$BEHIND_TAG" -eq 0 ]; then
+            URGENCY="✅ Up to date with latest release"
+          elif [ "$BEHIND_TAG" -lt 20 ]; then
+            URGENCY="🟡 Minor drift — sync when convenient"
+          elif [ "$BEHIND_TAG" -lt 100 ]; then
+            URGENCY="🟠 Moderate drift — plan a sync soon"
+          else
+            URGENCY="🔴 Significant drift — sync recommended"
+          fi
+
+          cat >> $GITHUB_STEP_SUMMARY << SUMMARY
+          ## 🔄 OTel Upstream Sync Status
+
+          **Status:** $URGENCY
+
+          | Metric | Value |
+          |--------|-------|
+          | Latest OTel release | \`$LATEST_TAG\` |
+          | Currently synced to | \`$SYNCED_TO\` |
+          | Commits behind \`$LATEST_TAG\` | **$BEHIND_TAG** |
+          | Commits behind \`otel/main\` | **$BEHIND_MAIN** |
+          | Splunk commits ahead | $AHEAD |
+          | Conflict files (dry-run merge with \`$LATEST_TAG\`) | **$CONFLICTS** |
+
+          SUMMARY
+
+          if [ "$CONFLICTS" -gt 0 ]; then
+            cat >> $GITHUB_STEP_SUMMARY << 'CONFLICTS_HEADER'
+
+          <details>
+          <summary>Conflict files (click to expand)</summary>
+
+          ```
+          CONFLICTS_HEADER
+            echo "${{ steps.conflict_check.outputs.conflict_files }}" >> $GITHUB_STEP_SUMMARY
+            cat >> $GITHUB_STEP_SUMMARY << 'CONFLICTS_FOOTER'
+          ```
+
+          </details>
+          CONFLICTS_FOOTER
+          fi
+
+          cat >> $GITHUB_STEP_SUMMARY << FOOTER
+
+          ---
+          *To sync, create a branch from \`main\` and run \`git merge $LATEST_TAG\`.*
+          *Safety: tag the current state first with \`git tag pre-otel-sync-\$(date +%Y%m%d)\`.*
+          FOOTER

--- a/src/payment/payment-k8s.yaml
+++ b/src/payment/payment-k8s.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: opentelemetry-demo
       containers:
       - name: payment
-        image: ghcr.io/hagen-p/opentelemetry-demo-splunk/otel-payment:test-1.7
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:1.8.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Summary
- Fix 7 'unknown' entries in manifest version summary — now show as '🔧 Infrastructure' with service name
- Add combined Production Release workflow (`prod-release.yml`)

## Changes

### 1. Fix `show-image-versions.py` — infrastructure manifests
- Manifests without a Deployment (namespace, configmap, ingress, etc.) now show by name with `🔧 Infrastructure` status
- Picks up StatefulSet resources (sql-server-fraud)
- Adds infrastructure count to summary output

### 2. Combined Production Release workflow (`prod-release.yml`)
- Single workflow: build images → update SPLUNK-VERSION → update source manifests → stitch production manifests → one PR
- Default bump is `patch` (1.8.0 → 1.8.1 → 1.8.2)
- Eliminates timing issue where manifest build could read stale SPLUNK-VERSION
- One branch (`release/{version}`), one PR, one merge

## Test plan
- [x] Ran `show-image-versions.py` locally — 0 unknowns, 7 infrastructure entries shown correctly
- [ ] Run combined release workflow to verify end-to-end