### PR TITLE
fix: capture lambda and dc-shim manifests in prod-release workflow

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -399,12 +399,18 @@ jobs:
 
           MANIFEST_FILE="${OUTPUT_DIR}/splunk-astronomy-shop-${VERSION}.yaml"
           MANIFEST_FILE_DIAB="${OUTPUT_DIR}/splunk-astronomy-shop-${VERSION}-diab.yaml"
+          MANIFEST_LAMBDA="${OUTPUT_DIR}/splunk-astronomy-shop-${VERSION}-lambda.yaml"
+          MANIFEST_DC_SHIM="${OUTPUT_DIR}/splunk-astronomy-shop-${VERSION}-dc-shim.yaml"
 
           echo "manifest_file=$MANIFEST_FILE" >> $GITHUB_OUTPUT
           echo "manifest_file_diab=$MANIFEST_FILE_DIAB" >> $GITHUB_OUTPUT
+          echo "manifest_lambda=$MANIFEST_LAMBDA" >> $GITHUB_OUTPUT
+          echo "manifest_dc_shim=$MANIFEST_DC_SHIM" >> $GITHUB_OUTPUT
 
-          echo "✅ Regular: $MANIFEST_FILE"
-          echo "✅ DIAB: $MANIFEST_FILE_DIAB"
+          echo "Generated manifests:"
+          for MFILE in "$MANIFEST_FILE" "$MANIFEST_FILE_DIAB" "$MANIFEST_LAMBDA" "$MANIFEST_DC_SHIM"; do
+            [ -f "$MFILE" ] && echo "  [ok] $(basename $MFILE)" || echo "  [--] $(basename $MFILE) (not generated)"
+          done
 
       - name: Ensure values.yaml exists for this version
         id: values
@@ -448,11 +454,14 @@ jobs:
 
       - name: Validate manifest YAML
         run: |
-          MANIFEST_FILE="${{ steps.stitch.outputs.manifest_file }}"
-          MANIFEST_FILE_DIAB="${{ steps.stitch.outputs.manifest_file_diab }}"
-
-          python3 -c "import yaml; docs=list(yaml.safe_load_all(open('$MANIFEST_FILE'))); print(f'Regular: {len(docs)} documents')"
-          python3 -c "import yaml; docs=list(yaml.safe_load_all(open('$MANIFEST_FILE_DIAB'))); print(f'DIAB: {len(docs)} documents')"
+          for MFILE in "${{ steps.stitch.outputs.manifest_file }}" \
+                       "${{ steps.stitch.outputs.manifest_file_diab }}" \
+                       "${{ steps.stitch.outputs.manifest_lambda }}" \
+                       "${{ steps.stitch.outputs.manifest_dc_shim }}"; do
+            if [ -f "$MFILE" ]; then
+              python3 -c "import yaml; docs=list(yaml.safe_load_all(open('$MFILE'))); print(f'$(basename $MFILE): {len(docs)} documents')"
+            fi
+          done
 
       - name: Show image version breakdown
         run: |
@@ -507,6 +516,8 @@ jobs:
           # Stage source manifests, stitched manifests, and values file
           git add src/*/*-k8s.yaml
           git add "$MANIFEST_FILE" "$MANIFEST_FILE_DIAB"
+          [ -f "${{ steps.stitch.outputs.manifest_lambda }}" ] && git add "${{ steps.stitch.outputs.manifest_lambda }}"
+          [ -f "${{ steps.stitch.outputs.manifest_dc_shim }}" ] && git add "${{ steps.stitch.outputs.manifest_dc_shim }}"
           git add kubernetes/splunk-astronomy-shop-*-values.yaml 2>/dev/null || true
 
           if git diff --staged --quiet; then
@@ -595,6 +606,8 @@ jobs:
           path: |
             ${{ steps.stitch.outputs.manifest_file }}
             ${{ steps.stitch.outputs.manifest_file_diab }}
+            ${{ steps.stitch.outputs.manifest_lambda }}
+            ${{ steps.stitch.outputs.manifest_dc_shim }}
           retention-days: 90
 
   # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

After the lambda/dc-shim manifest split (`services.yaml` `group:` field + `stitch-manifests.sh` per-group iteration), the stitcher now emits four files per release:

- `splunk-astronomy-shop-${VERSION}.yaml`
- `splunk-astronomy-shop-${VERSION}-diab.yaml`
- `splunk-astronomy-shop-${VERSION}-lambda.yaml`
- `splunk-astronomy-shop-${VERSION}-dc-shim.yaml`

But `prod-release.yml` was still wired only for the regular + DIAB pair. The lambda and dc-shim files were generated on the runner, then silently discarded — never validated, never committed to the release PR, never uploaded as artifacts.

This PR teaches `prod-release.yml` about the two new manifests, end-to-end:

- **`Stitch production manifests` step:** declares the two new file paths, exposes them as step outputs, and prints a `[ok]/[--]` line per file so future "missing manifest" issues are visible in the run log.
- **`Validate manifest YAML` step:** loops through all four manifest paths and validates each one that exists.
- **`Create single Pull Request` step:** stages the lambda and dc-shim manifests (guarded with `[ -f ... ]` so the workflow stays compatible if a future release has no group manifests).
- **`Upload manifests as artifacts` step:** adds the two new paths to the artifact bundle.

The guards (`[ -f ... ]`) keep the workflow forward/backward-compatible — if `services.yaml` ever drops a group, or a release legitimately has no group manifests, those steps simply skip the missing files instead of failing.

## Test plan

- [ ] Trigger `Build Prod Release` against this branch.
- [ ] Confirm the `Stitch production manifests` step's "Generated manifests:" log shows `[ok]` for all four files.
- [ ] Confirm the `Validate manifest YAML` step prints a document count for all four files.
- [ ] Confirm the auto-created release PR contains all four `kubernetes/splunk-astronomy-shop-${VERSION}*.yaml` files.
- [ ] Confirm the workflow's artifact bundle (`astronomy-shop-manifests-${VERSION}`) contains all four files.

## Background

This was found while investigating a prod-release run on 2026-04-15 where only the regular + DIAB manifests appeared in the resulting PR — root-caused to the workflow side, not the stitcher.