### PR TITLE
fix(promote): add contents:write for PROMOTED-VERSION push

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   promote:
     # Only run in the main splunk/opentelemetry-demo repo, not in forks


### PR DESCRIPTION
The promote workflow's `Commit promoted version to source repo` step fails with 403 because
the default GITHUB_TOKEN lacks write permission. Adds `permissions: contents: write` at workflow level.

Error: `Permission to splunk/opentelemetry-demo.git denied to github-actions[bot]`
Failed run: https://github.com/splunk/opentelemetry-demo/actions/runs/24836581900