### PR TITLE
db-instrumentation-latest-version

### DIFF
--- a/src/fraud-detection/Dockerfile
+++ b/src/fraud-detection/Dockerfile
@@ -15,7 +15,7 @@ RUN gradle shadowJar
 
 FROM gcr.io/distroless/java17-debian12:nonroot
 
-ARG SPLUNK_OTEL_JAVA_VERSION=2.20.1
+ARG SPLUNK_OTEL_JAVA_VERSION=2.27.0
 WORKDIR /usr/src/app/
 
 ADD --chmod=644 https://github.com/signalfx/splunk-otel-java/releases/download/v${SPLUNK_OTEL_JAVA_VERSION}/splunk-otel-javaagent.jar /usr/src/app/splunk-otel-javaagent.jar

--- a/src/recommendation/requirements.txt
+++ b/src/recommendation/requirements.txt
@@ -1,7 +1,7 @@
 grpcio-health-checking==1.78.0
 openfeature-hooks-opentelemetry==0.3.1
 openfeature-provider-flagd==0.2.3
-splunk-opentelemetry==2.9.0
+splunk-opentelemetry==2.10.1
 psutil==7.0.0 # Importing this will also import opentelemetry-instrumentation-system-metrics when running opentelemetry-bootstrap
 python-dotenv==1.2.2
 python-json-logger==4.0.0

--- a/src/shop-dc-shim/Dockerfile
+++ b/src/shop-dc-shim/Dockerfile
@@ -49,8 +49,8 @@ RUN cd /tmp && \
 
 # Download the specific Splunk OpenTelemetry Java agent CSA version and replace it within the AppDynamics directory
 RUN cd /tmp && \
-    SPLUNK_OTEL_CSA_URL="https://repo1.maven.org/maven2/com/splunk/splunk-otel-javaagent-csa/2.21.1/splunk-otel-javaagent-csa-2.21.1.jar" && \
-    SPLUNK_OTEL_CSA_FILENAME="splunk-otel-javaagent-csa-2.21.1.jar" && \
+    SPLUNK_OTEL_CSA_URL="https://repo1.maven.org/maven2/com/splunk/splunk-otel-javaagent-csa/2.27.0/splunk-otel-javaagent-csa-2.27.0.jar" && \
+    SPLUNK_OTEL_CSA_FILENAME="splunk-otel-javaagent-csa-2.27.0.jar" && \
     curl -L -f "$SPLUNK_OTEL_CSA_URL" -o "$SPLUNK_OTEL_CSA_FILENAME" && \
     echo "Downloaded Splunk OpenTelemetry CSA agent." && \
     ls -la "$SPLUNK_OTEL_CSA_FILENAME" && \


### PR DESCRIPTION
## Summary
- Bump `splunk-otel-javaagent` from 2.20.1 to 2.27.0 (fraud-detection)
- Bump `splunk-otel-javaagent-csa` from 2.21.1 to 2.27.0 (shop-dc-shim)
- Bump `splunk-opentelemetry` Python SDK from 2.9.0 to 2.10.1 (recommendation)

## Test plan
- [ ] Build fraud-detection image and verify agent loads
- [ ] Build shop-dc-shim image and verify CSA agent loads with AppDynamics dual mode
- [ ] Build recommendation image and verify splunk-opentelemetry installs cleanly
- [ ] Deploy and confirm traces flow to Splunk Observability