### PR TITLE
fix: bump OTel .NET packages to resolve CVE vulnerabilities

### DIFF
--- a/src/accounting/Accounting.csproj
+++ b/src/accounting/Accounting.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-		<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.14.1" />
+		<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.15.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -18,16 +18,16 @@
     <!-- Keeping Grpc.AspNetCore* to 2.67 due to https://github.com/grpc/grpc/issues/38538 -->
     <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.67.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.15.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.15.1-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
     <PackageReference Include="OpenFeature.Providers.Flagd" Version="0.6.0" />
     <PackageReference Include="OpenFeature" Version="2.12.0" />


### PR DESCRIPTION
## Summary
- Bump accounting `OpenTelemetry.AutoInstrumentation` 1.14.1 → 1.15.0 (pulls patched core 1.15.3, fixes NuGet audit build failure)
- Bump cart OTel packages to latest (1.15.3 stable, 1.15.1-beta.1 contrib)

Resolves 5 CVEs flagged by NuGet audit (TreatWarningsAsErrors):
- GHSA-g94r-2vxg-569j (OpenTelemetry.Api, Extensions.Propagators)
- GHSA-mr8r-92fq-pj8p (Exporter.OpenTelemetryProtocol)
- GHSA-q834-8qmm-v933 (Exporter.OpenTelemetryProtocol)
- GHSA-88hf-wf7h-7w4m (Exporter.Zipkin)
- GHSA-vc24-j8c5-2vw4 (Resources.Azure)

## Test plan
- [ ] Accounting image builds successfully (NuGet audit passes)
- [ ] Cart image builds successfully
- [ ] Deploy and verify traces flow for both services