### PR TITLE
fix: resolve cart build and product-catalog deploy failures

### DIFF
--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -20,12 +20,12 @@
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.67.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.15.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.15.1-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/product-catalog/product-catalog-k8s.yaml
+++ b/src/product-catalog/product-catalog-k8s.yaml
@@ -80,8 +80,6 @@ spec:
           value: "host=postgresql user=otelu password=otelp dbname=otel sslmode=disable"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://$(OTEL_COLLECTOR_NAME):4317
-        - name: OTEL_CONFIG_FILE
-          value: /etc/otel/otel-config.yml
         - name: GOMEMLIMIT
           value: 200MiB
         - name: OTEL_RESOURCE_ATTRIBUTES
@@ -92,15 +90,10 @@ spec:
         volumeMounts:
         - name: product-catalog-products
           mountPath: /usr/src/app/products
-        - name: otel-config
-          mountPath: /etc/otel
       volumes:
       - name: product-catalog-products
         configMap:
           name: product-catalog-products
-      - name: otel-config
-        configMap:
-          name: otel-config
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Summary

- **Cart build failure**: Three OTel .NET instrumentation packages pinned to `1.15.3` don't exist on NuGet yet. Downgraded to latest available:
  - `OpenTelemetry.Instrumentation.AspNetCore` → 1.15.2
  - `OpenTelemetry.Instrumentation.Http` → 1.15.1
  - `OpenTelemetry.Instrumentation.Runtime` → 1.15.1
  - Core OTel packages (Exporter, Extensions.Hosting) remain at 1.15.3 as those versions exist

- **Product-catalog deploy failure**: Manifest referenced ConfigMap `otel-config` that was never defined. Pod fails to schedule. The `OTEL_CONFIG_FILE` env var and volume mount were leftover from the upstream docker-compose setup — upstream Helm chart doesn't use them either. Go SDK falls back to env var configuration, which is already set.

## Test plan

- [ ] `docker build` cart service succeeds with updated package versions
- [ ] `kubectl apply` product-catalog manifest no longer fails on missing ConfigMap
- [ ] Product-catalog traces/metrics still flow via env var OTel configuration