### PR TITLE
feat: payment-vB failure driven by API token prefix

### DIFF
--- a/src/payment/charge.js
+++ b/src/payment/charge.js
@@ -37,6 +37,10 @@ const SUCCESS_VERSION = versionConfig.versionString || versionConfig.displayVers
 const FAILURE_VERSION = versionConfig.versionString || versionConfig.displayVersion.replace(/(\d+)$/, (match) => `${parseInt(match) + 1}`);
 const API_TOKEN_SUCCESS_TOKEN = versionConfig.apiToken;
 const API_TOKEN_FAILURE_TOKEN = versionConfig.apiToken.replace('prod', 'test');
+// In vB mode, the token prefix determines success/failure:
+// - "prod-*" token = succeed (simulates fix by replacing the bad API key)
+// - "test-*" token = fail (default vB behavior)
+const isTokenBad = versionConfig.apiToken.startsWith('test');
 // Version-specific timing from config
 const SUCCESS_PAYMENT_SERVICE_DURATION_MILLIS = versionConfig.successDelayRange[1];
 const ERROR_PAYMENT_SERVICE_DURATION_MILLIS = versionConfig.failureDelayRange[1];
@@ -265,9 +269,10 @@ module.exports.charge = async request => {
   const RETRY_BASE_DELAY_MS = versionConfig.retryBaseDelayMs;
 
   // Version-specific behavior:
-  // - Version A: Normal operation (succeeds)
-  // - Version B: Always fails (error testing pod)
-  const shouldFailRequest = versionConfig.alwaysFail || false;
+  // - Version A: Normal operation (always succeeds)
+  // - Version B: Fails when using a bad (test-*) API token.
+  //   Replacing the token in the k8s secret with a prod-* token fixes it.
+  const shouldFailRequest = versionConfig.alwaysFail ? isTokenBad : false;
 
   // If this request is destined to fail, pre-calculate timing to ensure 4-8 seconds total
   let failureTimings = null;


### PR DESCRIPTION
## Summary
- Payment-vB no longer hardcodes `alwaysFail: true` behavior
- Instead, vB checks the `PAYMENT_API_TOKEN` secret prefix: `test-*` = fail, `prod-*` = succeed
- Enables AI-assisted remediation demo: detect payment errors → recommend replacing the bad API key → errors resolve
- Reverting the secret back to a `test-*` token restores the failure behavior
- Payment-vA behavior completely unchanged

## Demo scenario
1. Payment-vB starts with default `test-*` token → errors (same as today)
2. AI/LLM detects errors, recommends replacing the API token
3. Update k8s secret to `prod-*` token, restart pod → vB succeeds
4. Revert secret → errors return

## Test plan
- [ ] Deploy payment-vB with default `test-*` secret → verify errors occur
- [ ] Update secret to `prod-*` token, restart pod → verify payments succeed
- [ ] Revert to `test-*` token → verify errors return
- [ ] Verify payment-vA is unaffected
- [ ] Verify `paymentFailure` flag routing still works correctly