### PR TITLE
fix: prod-release PR step fails on gitignored manifests

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -601,14 +601,9 @@ jobs:
           fi
 
           # Stage source manifests and values file (NOT stitched manifests)
-          MANIFEST_FILE="${{ steps.stitch.outputs.manifest_file }}"
-          MANIFEST_FILE_DIAB="${{ steps.stitch.outputs.manifest_file_diab }}"
-
+          # Stage source manifests and values files only
+          # Stitched manifests are gitignored — they go to GitHub Release assets
           git add src/*/*-k8s.yaml
-          [ -n "$MANIFEST_FILE" ] && [ -f "$MANIFEST_FILE" ] && git add "$MANIFEST_FILE"
-          [ -n "$MANIFEST_FILE_DIAB" ] && [ -f "$MANIFEST_FILE_DIAB" ] && git add "$MANIFEST_FILE_DIAB"
-          [ -f "${{ steps.stitch.outputs.manifest_lambda }}" ] && git add "${{ steps.stitch.outputs.manifest_lambda }}"
-          [ -f "${{ steps.stitch.outputs.manifest_dc_shim }}" ] && git add "${{ steps.stitch.outputs.manifest_dc_shim }}"
           git add kubernetes/splunk-astronomy-shop-*-values.yaml 2>/dev/null || true
 
           if git diff --staged --quiet; then

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -600,7 +600,6 @@ jobs:
             fi
           fi
 
-          # Stage source manifests and values file (NOT stitched manifests)
           # Stage source manifests and values files only
           # Stitched manifests are gitignored — they go to GitHub Release assets
           git add src/*/*-k8s.yaml


### PR DESCRIPTION
## Summary
- `prod-release.yml` tried to `git add` stitched manifests (main, diab, lambda, dc-shim) which are gitignored
- Under `bash -e`, the ignored file warning exits non-zero, breaking the "Create Pull Request" step
- Removed the 4 `git add` lines for stitched manifests — they belong in GitHub Release assets, not git
- Source manifests (`src/*/*-k8s.yaml`) and values files still committed as before

## Root cause
`.gitignore` line: `kubernetes/splunk-astronomy-shop-*.yaml` (with `!*-values.yaml` exception)

## Test plan
- [ ] Re-run prod-release workflow — PR creation step should pass
- [ ] Verify stitched manifests still attached to GitHub Release assets
- [ ] Verify source manifests and values files still in the PR