### PR TITLE
feat: add secureapp-loadgen for SecureApp agent testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ docker-compose.override.yml
 src/frontend/cypress/videos
 src/frontend/cypress/screenshots
 src/shipping/target/
+src/secureapp-loadgen/target/
 test/tracetesting/tracetesting-vars.yaml
 
 !src/currency/build

--- a/services.yaml
+++ b/services.yaml
@@ -189,6 +189,12 @@ services:
     manifest: false # false till we sorted out thousand eyes instance and secret issue
     replace_registry: false  # Uses thousandeyes/enterprise-agent
 
+  - name: secureapp-loadgen
+    build: true
+    manifest: true
+    group: secureapp
+    platform: "linux/amd64"
+
   - name: valkey-cart
     build: false
     manifest: true

--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -164,6 +164,16 @@
         "off": false
       },
       "defaultVariant": "off"
+    },
+    "secureappAttack": {
+      "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",
+      "state": "ENABLED",
+      "variants": {
+        "minimal": "minimal",
+        "targeted": "targeted",
+        "max": "max"
+      },
+      "defaultVariant": "minimal"
     }
   }
 }

--- a/src/secureapp-loadgen/Dockerfile
+++ b/src/secureapp-loadgen/Dockerfile
@@ -1,0 +1,44 @@
+# SecureApp loadgen — Java vulnerability test app + randomized attack trigger.
+# Exercises 5 vulnerability classes (RCE, SSRF, SQLi, Log4Shell, Deserialization)
+# detected by the Splunk OTel Java agent's SecureApp feature.
+#
+# To skip Maven build and use a pre-built jar:
+#   docker build --build-arg SKIP_BUILD=true -f src/secureapp-loadgen/Dockerfile .
+
+# --- Build stage ---
+FROM maven:3.9-eclipse-temurin-17 AS builder
+ARG SKIP_BUILD=false
+WORKDIR /build
+
+COPY ./src/secureapp-loadgen/pom.xml .
+RUN if [ "$SKIP_BUILD" = "false" ]; then mvn dependency:go-offline -B; fi
+
+COPY ./src/secureapp-loadgen/src src
+RUN if [ "$SKIP_BUILD" = "false" ]; then \
+      mvn clean package -B -DskipTests; \
+    else \
+      mkdir -p target; \
+    fi
+
+# --- Runtime stage ---
+FROM eclipse-temurin:17-jre
+
+# Splunk OTel Java agent (non-CSA — SecureApp needs the standard agent)
+ADD --chmod=644 https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent.jar /app/splunk-otel-javaagent.jar
+
+WORKDIR /app
+
+# Install curl for the loadgen script
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/java-secureapp-test-app.jar .
+COPY ./src/secureapp-loadgen/entrypoint.sh .
+COPY ./src/secureapp-loadgen/loadgen.sh .
+RUN chmod +x entrypoint.sh loadgen.sh
+
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+ENV OTEL_METRICS_EXPORTER=otlp
+
+EXPOSE 8080
+ENTRYPOINT ["./entrypoint.sh"]

--- a/src/secureapp-loadgen/entrypoint.sh
+++ b/src/secureapp-loadgen/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Entrypoint: start the Java secureapp test app, then launch the loadgen.
+set -euo pipefail
+
+# JAVA_TOOL_OPTIONS is set by k8s manifest (includes -javaagent and argento flags).
+# When running standalone (docker run), set JAVA_TOOL_OPTIONS in env or it runs without agent.
+echo "Starting SecureApp test app..."
+echo "  JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:-<not set>}"
+java -jar /app/java-secureapp-test-app.jar &
+JAVA_PID=$!
+
+# Wait for the app to become healthy
+echo "Waiting for health check..."
+retries=0
+until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
+  retries=$((retries + 1))
+  if [ $retries -ge 60 ]; then
+    echo "ERROR: App failed to start after 120s"
+    exit 1
+  fi
+  sleep 2
+done
+echo "App is healthy. Starting loadgen..."
+
+# Launch the loadgen in background
+/app/loadgen.sh &
+LOADGEN_PID=$!
+
+# If Java dies, kill loadgen and exit
+trap "kill $LOADGEN_PID 2>/dev/null; exit" EXIT
+wait $JAVA_PID

--- a/src/secureapp-loadgen/loadgen.sh
+++ b/src/secureapp-loadgen/loadgen.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# SecureApp attack loadgen — fires each vulnerability endpoint on its own
+# independent schedule, never at the same time.  Pace controlled by flagd
+# feature flag "secureappAttack" (minimal | targeted | max).
+#
+# Shipping calls run at a fixed ~4 min interval regardless of pace to
+# keep the api-service → shipping trace link alive.
+#
+# Environment variables:
+#   ATTACK_HOST        Target host:port (default: localhost:8080)
+#   FLAGD_HOST         Flagd hostname (default: flagd)
+#   FLAGD_OFREP_PORT   Flagd OFREP port (default: 8016)
+
+set -euo pipefail
+
+HOST="${ATTACK_HOST:-localhost:8080}"
+FLAGD_HOST="${FLAGD_HOST:-flagd}"
+FLAGD_PORT="${FLAGD_OFREP_PORT:-8016}"
+BASE="http://${HOST}"
+FLAGD_URL="http://${FLAGD_HOST}:${FLAGD_PORT}/ofrep/v1/evaluate/flags/secureappAttack"
+
+CURRENT_PACE=""
+
+# --- Interval definitions per pace ---
+# Format: path|label|minimal_min|minimal_max|targeted_min|targeted_max|max_min|max_max
+#
+# targeted = minimal background + SQLi & Log4Shell every ~10-15 min
+# (the two most recognizable attack signatures)
+SHIPPING_ENTRY="/api/v1/shipping/estimate|Shipping quote|180|300|180|300|180|300"
+
+ATTACK_ENTRIES=(
+  "/health|Health check|21600|43200|21600|43200|120|300"
+  "/api/v1/documents/convert|RCE (Struts2 CVE-2017-5638)|72000|172800|72000|172800|180|600"
+  "/api/v1/users/search|SQL Injection|80000|158400|600|900|240|600"
+  "/api/v1/links/preview|SSRF (cloud metadata)|86400|172800|86400|172800|180|540"
+  "/api/v1/auth/login|Log4Shell (CVE-2021-44228)|100800|172800|600|900|240|720"
+  "/api/v1/sessions/import|Deserialization (CVE-2020-1714)|115200|187200|115200|187200|300|720"
+  "/api/v1/workspace/sync|All attacks combined|144000|216000|144000|216000|300|900"
+)
+
+# Combine into single array (shipping first)
+ALL_ENTRIES=("$SHIPPING_ENTRY" "${ATTACK_ENTRIES[@]}")
+NUM_ENDPOINTS=${#ALL_ENTRIES[@]}
+
+# Random integer in [min, max]
+rand_between() {
+  local min=$1 max=$2
+  echo $(( RANDOM % (max - min + 1) + min ))
+}
+
+fmt_duration() {
+  local secs=$1
+  if (( secs >= 86400 )); then
+    echo "$((secs / 3600))h (~$((secs / 86400))d)"
+  elif (( secs >= 3600 )); then
+    echo "$((secs / 3600))h$((secs % 3600 / 60))m"
+  else
+    echo "$((secs / 60))m"
+  fi
+}
+
+# Query flagd for current pace. Falls back to "minimal" if unreachable.
+get_pace() {
+  local resp
+  resp=$(curl -sf -X POST "$FLAGD_URL" \
+    -H "Content-Type: application/json" \
+    -d '{"context":{}}' \
+    --max-time 3 2>/dev/null) || true
+
+  if [[ -n "$resp" ]]; then
+    local val
+    val=$(echo "$resp" | sed -n 's/.*"value"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    if [[ "$val" == "max" || "$val" == "targeted" || "$val" == "minimal" ]]; then
+      echo "$val"
+      return
+    fi
+  fi
+  echo "minimal"
+}
+
+# Get min/max interval for an endpoint given current pace
+get_intervals() {
+  local entry=$1 pace=$2
+  IFS='|' read -r _path _label min_min min_max tgt_min tgt_max max_min max_max <<< "$entry"
+  case "$pace" in
+    max)      echo "$max_min $max_max" ;;
+    targeted) echo "$tgt_min $tgt_max" ;;
+    *)        echo "$min_min $min_max" ;;
+  esac
+}
+
+fire_endpoint() {
+  local idx=$1
+  IFS='|' read -r path label _rest <<< "${ALL_ENTRIES[$idx]}"
+
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${BASE}${path}" 2>/dev/null) || true
+  if [[ -z "$http_code" ]] || [[ "$http_code" == "000" ]]; then
+    status="ERR"
+  else
+    status="$http_code"
+  fi
+  printf "[%s] %-40s %s  (pace=%s)\n" "$(date '+%Y-%m-%d %H:%M:%S')" "${label}" "${status}" "$CURRENT_PACE"
+}
+
+print_schedule() {
+  echo "--- Schedule (pace=$CURRENT_PACE) ---"
+  for i in $(seq 0 $((NUM_ENDPOINTS - 1))); do
+    IFS='|' read -r _p label _rest <<< "${ALL_ENTRIES[$i]}"
+    read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$i]}" "$CURRENT_PACE")"
+    next_at=$(date -d "@${next_fire[$i]}" '+%Y-%m-%d %H:%M' 2>/dev/null \
+      || date -r "${next_fire[$i]}" '+%Y-%m-%d %H:%M' 2>/dev/null \
+      || echo "?")
+    printf "  %-40s every %s–%s  hits: %-4d  next: %s\n" \
+      "$label" "$(fmt_duration $mn)" "$(fmt_duration $mx)" "${hit_count[$i]}" "$next_at"
+  done
+  echo ""
+}
+
+# --- Initialize ---
+echo "SecureApp loadgen starting"
+CURRENT_PACE=$(get_pace)
+echo "  flagd pace: $CURRENT_PACE"
+echo "  flagd url:  $FLAGD_URL"
+
+now=$(date +%s)
+startup_delay=$(rand_between 30 120)
+echo "  Initial delay: $(fmt_duration $startup_delay)"
+base_time=$((now + startup_delay))
+
+declare -a next_fire
+declare -a hit_count
+for i in $(seq 0 $((NUM_ENDPOINTS - 1))); do
+  IFS='|' read -r path label _rest <<< "${ALL_ENTRIES[$i]}"
+  read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$i]}" "$CURRENT_PACE")"
+  # Stagger first fire: shipping starts soon, others spread out
+  if (( i == 0 )); then
+    offset=$(rand_between 10 30)
+  else
+    offset=$(rand_between $((i * 120)) $(( (i + 1) * 300 )))
+  fi
+  next_fire[$i]=$((base_time + offset))
+  hit_count[$i]=0
+done
+
+print_schedule
+sleep "$startup_delay"
+
+# --- Main loop ---
+fire_count=0
+last_flag_check=$(date +%s)
+FLAG_CHECK_INTERVAL=60  # Re-check flagd every 60 seconds
+
+while true; do
+  # Find endpoint with earliest next_fire
+  earliest_idx=0
+  earliest_time=${next_fire[0]}
+  for i in $(seq 1 $((NUM_ENDPOINTS - 1))); do
+    if (( next_fire[i] < earliest_time )); then
+      earliest_idx=$i
+      earliest_time=${next_fire[i]}
+    fi
+  done
+
+  # Sleep until it's time
+  now=$(date +%s)
+  wait_secs=$((earliest_time - now))
+  if (( wait_secs > 0 )); then
+    sleep "$wait_secs"
+  fi
+
+  # Check flagd for pace changes (at most every FLAG_CHECK_INTERVAL seconds)
+  now=$(date +%s)
+  if (( now - last_flag_check >= FLAG_CHECK_INTERVAL )); then
+    new_pace=$(get_pace)
+    last_flag_check=$now
+    if [[ "$new_pace" != "$CURRENT_PACE" ]]; then
+      echo "*** Pace changed: $CURRENT_PACE -> $new_pace ***"
+      CURRENT_PACE="$new_pace"
+      # Reschedule all attack endpoints (not shipping) with new intervals
+      for i in $(seq 1 $((NUM_ENDPOINTS - 1))); do
+        read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$i]}" "$CURRENT_PACE")"
+        next_fire[$i]=$(( now + $(rand_between "$mn" "$mx") ))
+      done
+      print_schedule
+    fi
+  fi
+
+  # Fire
+  fire_endpoint "$earliest_idx"
+  hit_count[$earliest_idx]=$(( hit_count[earliest_idx] + 1 ))
+  fire_count=$((fire_count + 1))
+
+  # Reschedule fired endpoint
+  read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$earliest_idx]}" "$CURRENT_PACE")"
+  next_fire[$earliest_idx]=$(( $(date +%s) + $(rand_between "$mn" "$mx") ))
+
+  # Periodic summary
+  summary_interval=$( [[ "$CURRENT_PACE" == "minimal" ]] && echo 5 || echo 20 )
+  if (( fire_count % summary_interval == 0 )); then
+    print_schedule
+  fi
+done

--- a/src/secureapp-loadgen/pom.xml
+++ b/src/secureapp-loadgen/pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.appd.e2e</groupId>
+    <artifactId>java-secureapp-test-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Jetty embedded server (servlet container) -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>9.4.53.v20231009</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>9.4.53.v20231009</version>
+        </dependency>
+
+        <!-- Servlet API -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <!-- JSP API (needed by Struts2 JspTemplateEngine in struts-default.xml) -->
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2021-44228 (Log4Shell) -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.12.1</version>
+        </dependency>
+
+        <!-- Vulnerable: multiple known CVEs -->
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-core</artifactId>
+            <version>2.3.12</version>
+        </dependency>
+
+        <!-- Vulnerable: older version with known issues -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>11.0</version>
+        </dependency>
+
+        <!-- H2 in-memory DB for SQL injection simulation -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2015-6420 (InvokerTransformer deserialization) -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2021-29425 -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2016-1000031 -->
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2015-7940 -->
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.19</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2019-10172 -->
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.11.0.GA</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2016-3093 -->
+        <dependency>
+            <groupId>ognl</groupId>
+            <artifactId>ognl</artifactId>
+            <version>3.0.6</version>
+        </dependency>
+
+        <!-- commons-lang3 (loaded for VA discovery) -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2017-7525 (enableDefaultTyping deserialization gadgets) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2015-5254 (deserialization via ClassLoadingAwareObjectInputStream) -->
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.10.0</version>
+        </dependency>
+
+        <!-- Vulnerable: CVE-2020-1714 (deserialization in KerberosSerializationUtils) -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-common</artifactId>
+            <version>10.0.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>java-secureapp-test-app</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.appd.e2e.JavaSecureAppTestApp</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/secureapp-loadgen/secureapp-loadgen-k8s.yaml
+++ b/src/secureapp-loadgen/secureapp-loadgen-k8s.yaml
@@ -1,0 +1,103 @@
+# SecureApp loadgen — Java vulnerability test app reporting as "ad" service.
+# Exercises 5 vulnerability classes for Splunk SecureApp agent detection.
+# Deployed via separate manifest group (secureapp).
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: secureapp-loadgen
+  labels:
+    opentelemetry.io/name: secureapp-loadgen
+    app.kubernetes.io/component: secureapp-loadgen
+    app.kubernetes.io/name: secureapp-loadgen
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: secureapp-loadgen
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secureapp-loadgen
+  labels:
+    opentelemetry.io/name: secureapp-loadgen
+    app.kubernetes.io/component: secureapp-loadgen
+    app.kubernetes.io/name: secureapp-loadgen
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: secureapp-loadgen
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: secureapp-loadgen
+        app.kubernetes.io/component: secureapp-loadgen
+        app.kubernetes.io/name: secureapp-loadgen
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: secureapp-loadgen
+        image: ghcr.io/splunk/opentelemetry-demo/otel-secureapp-loadgen:2.0.0
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.1.3,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./entrypoint.sh
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          value: "ad"
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/app/splunk-otel-javaagent.jar
+            -Dargento.allow.security.events=true
+            -Dargento.wait.events.for.first.transaction=false
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      volumes: null

--- a/src/secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
+++ b/src/secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
@@ -1,0 +1,453 @@
+package com.appd.e2e;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * Team Portal — a Jetty servlet-based collaboration application with
+ * document conversion, link previews, user search, authentication,
+ * and session management.
+ *
+ * Runs on embedded Jetty 9.4 with an H2 in-memory database.
+ * Configurable port via -Dserver.port (default 8080).
+ *
+ * NOTE: This application intentionally uses vulnerable library versions
+ * for security agent e2e testing.  Each endpoint exercises a specific
+ * vulnerability class (RCE, SSRF, SQLi, Log4Shell, deserialization)
+ * that the agent should detect and classify as EXPLOITED.
+ */
+public class JavaSecureAppTestApp {
+
+    // --- Health check ---
+    public static class HealthServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            resp.setStatus(200);
+            resp.getWriter().write("OK");
+        }
+    }
+
+    // --- Document format conversion (exercises Struts2 CVE-2017-5638) ---
+    // Internally routes through JakartaMultiPartRequest.buildErrorMessage()
+    // which triggers ProcessBuilder.start().  The agent hooks ProcessBuilder,
+    // sees buildErrorMessage on the stack, matches CVE-2017-5638 -> EXPLOITED.
+    public static class DocumentConvertServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            String result;
+            try {
+                VulnMultiPartRequest vuln = new VulnMultiPartRequest();
+                vuln.triggerRce();
+                result = "{\"status\": \"converted\", \"format\": \"pdf\"}";
+            } catch (SecurityException se) {
+                result = "{\"error\": \"" + se.getMessage() + "\"}";
+            } catch (Exception e) {
+                // NPE is expected — parent's buildErrorMessage uses uninitialized Struts
+                // locale.  ProcessBuilder.start() already fired before the NPE.
+                result = "{\"status\": \"converted\", \"format\": \"pdf\"}";
+            }
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.getWriter().write(result);
+        }
+    }
+
+    /**
+     * Subclass of JakartaMultiPartRequest that does NOT override buildErrorMessage.
+     * We pass a custom Throwable whose getMessage() executes ProcessBuilder, so the
+     * parent's JakartaMultiPartRequest.buildErrorMessage appears on the stack when
+     * ProcessBuilder.start() fires — matching the CVE-2017-5638 vuln_method feed.
+     */
+    public static class VulnMultiPartRequest
+            extends org.apache.struts2.dispatcher.multipart.JakartaMultiPartRequest {
+
+        public void triggerRce() {
+            Throwable cause = new RceThrowable();
+            buildErrorMessage(cause, new Object[0]);
+        }
+    }
+
+    public static class RceThrowable extends RuntimeException {
+        @Override
+        public String getMessage() {
+            try {
+                ProcessBuilder pb = new ProcessBuilder("/bin/echo", "convert-document");
+                pb.redirectErrorStream(true);
+                Process proc = pb.start();
+                proc.waitFor();
+            } catch (Exception ex) {
+                // ignored
+            }
+            return "multipart parse error during document conversion";
+        }
+    }
+
+    // --- Link metadata preview (exercises SSRF to cloud metadata) ---
+    // Fetches a URL to generate a link preview.  The hardcoded URL targets
+    // the AWS metadata endpoint; the agent detects the socket connect to
+    // 169.254.169.254 and classifies it as SSRF -> EXPLOITED.
+    public static class LinkPreviewServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            String result;
+            try {
+                URL url = new URL("http://169.254.169.254/latest/meta-data/");
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setConnectTimeout(2000);
+                conn.setReadTimeout(2000);
+                conn.getResponseCode();
+                conn.disconnect();
+                result = "{\"status\": \"ok\", \"title\": \"Cloud Metadata\", \"url\": \"http://169.254.169.254/\"}";
+            } catch (SecurityException se) {
+                result = "{\"error\": \"" + se.getMessage() + "\"}";
+            } catch (Exception e) {
+                result = "{\"error\": \"" + e.getMessage() + "\"}";
+            }
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.getWriter().write(result);
+        }
+    }
+
+    // --- User directory search (exercises SQL injection) ---
+    // Concatenates input into a SQL query without parameterization.
+    // The agent detects contains_or_true and contains_comment signals -> EXPLOITED.
+    // NOTE: DB setup is done once at startup to avoid dedup issues.
+    public static class UserSearchServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            String result;
+            try {
+                Class.forName("org.h2.Driver");
+                Connection conn = DriverManager.getConnection(
+                    "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1", "sa", "");
+                Statement stmt = conn.createStatement();
+                String searchTerm = "' OR 1=1 --";
+                String sql = "SELECT * FROM users WHERE name = '" + searchTerm + "'";
+                ResultSet rs = stmt.executeQuery(sql);
+                int count = 0;
+                while (rs.next()) count++;
+                rs.close();
+                stmt.close();
+                conn.close();
+                result = "{\"count\": " + count + ", \"results\": []}";
+            } catch (SecurityException se) {
+                result = "{\"error\": \"" + se.getMessage() + "\"}";
+            } catch (Exception e) {
+                result = "{\"error\": \"" + e.getClass().getSimpleName() + ": " + e.getMessage() + "\"}";
+            }
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(result);
+        }
+    }
+
+    // --- User authentication (exercises Log4j CVE-2021-44228) ---
+    // Logs a username via Log4j 2.12.1 which evaluates JNDI lookup strings.
+    // The agent detects the JNDI socket resolve with JndiLookup.lookup on
+    // the stack -> EXPLOITED.
+    public static class LoginServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            String result;
+            try {
+                Class<?> logManagerClass = Class.forName("org.apache.logging.log4j.LogManager");
+                Method getLoggerMethod = logManagerClass.getMethod("getLogger", String.class);
+                Object logger = getLoggerMethod.invoke(null, "TeamPortal");
+                Method errorMethod = logger.getClass().getMethod("error", String.class);
+                errorMethod.invoke(logger, "${jndi:ldap://127.0.0.1:1389/log4j-test}");
+                result = "{\"status\": \"failed\", \"message\": \"Invalid credentials\"}";
+            } catch (SecurityException se) {
+                result = "{\"error\": \"" + se.getMessage() + "\"}";
+            } catch (Exception e) {
+                result = "{\"status\": \"failed\", \"message\": \"Authentication error\"}";
+            }
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.getWriter().write(result);
+        }
+    }
+
+    // --- Session import (exercises deserialization CVE-2020-1714) ---
+    // Deserializes a session token via Keycloak's KerberosSerializationUtils,
+    // which internally calls plain ObjectInputStream.readObject().  The agent
+    // hooks OIS.resolveClass() and sees KerberosSerializationUtils.deserialize
+    // on the stack -> matches CVE-2020-1714 -> EXPLOITED.
+    public static class SessionImportServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            String result;
+            try {
+                byte[] serializedBytes = createSerializedDiskFileItem();
+                String base64Payload = org.keycloak.common.util.Base64.encodeBytes(serializedBytes);
+                org.keycloak.common.util.KerberosSerializationUtils.deserializeCredential(base64Payload);
+                result = "{\"status\": \"imported\"}";
+            } catch (SecurityException se) {
+                result = "{\"error\": \"" + se.getMessage() + "\"}";
+            } catch (ClassCastException cce) {
+                // Expected: deserialized object is not a GSSCredential.
+                // Agent hook already fired during resolveClass().
+                result = "{\"status\": \"imported\", \"session\": \"restored\"}";
+            } catch (Exception e) {
+                Throwable cause = e;
+                while (cause.getCause() != null) cause = cause.getCause();
+                result = "{\"status\": \"imported\", \"session\": \"restored\"}";
+            }
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.getWriter().write(result);
+        }
+
+        byte[] createSerializedDiskFileItem() throws Exception {
+            Class<?> dfiClass = Class.forName(
+                "org.apache.commons.fileupload.disk.DiskFileItem");
+            Constructor<?> ctor = dfiClass.getConstructor(
+                String.class, String.class, boolean.class,
+                String.class, int.class, java.io.File.class);
+            Object dfi = ctor.newInstance(
+                "file", "application/octet-stream", false,
+                "session.dat", 10240, new java.io.File(System.getProperty("java.io.tmpdir")));
+            Method getOS = dfiClass.getMethod("getOutputStream");
+            OutputStream os = (OutputStream) getOS.invoke(dfi);
+            os.write("session-data-for-restore".getBytes());
+            os.close();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(dfi);
+            oos.close();
+            return baos.toByteArray();
+        }
+    }
+
+    // --- Shipping quote (calls the shipping service over HTTP) ---
+    // Makes an outbound HTTP POST to shipping's /get-quote endpoint.
+    // The Java agent auto-instruments HttpURLConnection, creating a child
+    // span that links this service to shipping in the trace topology.
+    // Skipped when SHIPPING_ADDR is not set (secureapp deployed standalone).
+    public static class ShippingQuoteServlet extends HttpServlet {
+        private static final String SHIPPING_ADDR = System.getenv("SHIPPING_ADDR");
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            String result = getShippingQuote();
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.getWriter().write(result);
+        }
+
+        static String getShippingQuote() {
+            if (SHIPPING_ADDR == null || SHIPPING_ADDR.isEmpty()) {
+                return "{\"status\": \"skipped\", \"reason\": \"SHIPPING_ADDR not set\"}";
+            }
+            try {
+                String body = "{\"items\":[{\"productId\":\"OLJCESPC7Z\",\"quantity\":1}],"
+                    + "\"address\":{\"streetAddress\":\"1600 Amphitheatre Parkway\","
+                    + "\"city\":\"Mountain View\",\"state\":\"CA\","
+                    + "\"country\":\"US\",\"zipCode\":\"94043\"}}";
+                URL url = new URL(SHIPPING_ADDR + "/get-quote");
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "application/json");
+                conn.setConnectTimeout(3000);
+                conn.setReadTimeout(3000);
+                conn.setDoOutput(true);
+                conn.getOutputStream().write(body.getBytes());
+                int code = conn.getResponseCode();
+                BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream()));
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) sb.append(line);
+                reader.close();
+                conn.disconnect();
+                return "{\"status\": \"ok\", \"http_code\": " + code
+                    + ", \"quote\": " + sb.toString() + "}";
+            } catch (Exception e) {
+                return "{\"status\": \"error\", \"message\": \""
+                    + e.getClass().getSimpleName() + ": " + e.getMessage() + "\"}";
+            }
+        }
+    }
+
+    // --- Workspace sync (triggers all attack types in a single transaction) ---
+    // A single HTTP request that exercises RCE, SSRF, SQLi, Log4Shell, and
+    // deserialization in one web transaction so all events are grouped under
+    // one attack summary with attackTypes = {RCE,SSRF,SQL,LOG4J,DESEREAL}.
+    public static class WorkspaceSyncServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            StringBuilder log = new StringBuilder();
+
+            // 1. RCE (Struts2 CVE-2017-5638)
+            try {
+                VulnMultiPartRequest vuln = new VulnMultiPartRequest();
+                vuln.triggerRce();
+                log.append("rce:ok ");
+            } catch (Exception e) {
+                log.append("rce:ok ");
+            }
+
+            // 2. SSRF (cloud metadata)
+            try {
+                URL url = new URL("http://169.254.169.254/latest/meta-data/");
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setConnectTimeout(2000);
+                conn.setReadTimeout(2000);
+                conn.getResponseCode();
+                conn.disconnect();
+                log.append("ssrf:ok ");
+            } catch (Exception e) {
+                log.append("ssrf:ok ");
+            }
+
+            // 3. SQL injection
+            try {
+                Class.forName("org.h2.Driver");
+                Connection conn = DriverManager.getConnection(
+                    "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1", "sa", "");
+                Statement stmt = conn.createStatement();
+                String sql = "SELECT * FROM users WHERE name = '' OR 1=1 --'";
+                ResultSet rs = stmt.executeQuery(sql);
+                rs.close();
+                stmt.close();
+                conn.close();
+                log.append("sql:ok ");
+            } catch (Exception e) {
+                log.append("sql:ok ");
+            }
+
+            // 4. Log4Shell (CVE-2021-44228)
+            try {
+                Class<?> logManagerClass = Class.forName("org.apache.logging.log4j.LogManager");
+                Method getLoggerMethod = logManagerClass.getMethod("getLogger", String.class);
+                Object logger = getLoggerMethod.invoke(null, "TeamPortal");
+                Method errorMethod = logger.getClass().getMethod("error", String.class);
+                errorMethod.invoke(logger, "${jndi:ldap://127.0.0.1:1389/log4j-test}");
+                log.append("log4j:ok ");
+            } catch (Exception e) {
+                log.append("log4j:ok ");
+            }
+
+            // 5. Deserialization (CVE-2020-1714)
+            try {
+                SessionImportServlet helper = new SessionImportServlet();
+                byte[] serializedBytes = helper.createSerializedDiskFileItem();
+                String base64Payload = org.keycloak.common.util.Base64.encodeBytes(serializedBytes);
+                org.keycloak.common.util.KerberosSerializationUtils.deserializeCredential(base64Payload);
+                log.append("deserial:ok ");
+            } catch (Exception e) {
+                log.append("deserial:ok ");
+            }
+
+            // 6. Shipping quote (outbound HTTP to shipping service)
+            try {
+                String quoteResult = ShippingQuoteServlet.getShippingQuote();
+                log.append(quoteResult.contains("\"ok\"") ? "shipping:ok " : "shipping:skip ");
+            } catch (Exception e) {
+                log.append("shipping:err ");
+            }
+
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            resp.getWriter().write("{\"status\": \"synced\", \"steps\": \"" + log.toString().trim() + "\"}");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int port = Integer.parseInt(System.getProperty("server.port", "8080"));
+
+        Server server = new Server(port);
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        server.setHandler(context);
+
+        // Primary endpoints (realistic API paths)
+        context.addServlet(new ServletHolder(new HealthServlet()), "/health");
+        context.addServlet(new ServletHolder(new DocumentConvertServlet()), "/api/v1/documents/convert");
+        context.addServlet(new ServletHolder(new LinkPreviewServlet()), "/api/v1/links/preview");
+        context.addServlet(new ServletHolder(new UserSearchServlet()), "/api/v1/users/search");
+        context.addServlet(new ServletHolder(new LoginServlet()), "/api/v1/auth/login");
+        context.addServlet(new ServletHolder(new SessionImportServlet()), "/api/v1/sessions/import");
+        context.addServlet(new ServletHolder(new WorkspaceSyncServlet()), "/api/v1/workspace/sync");
+        context.addServlet(new ServletHolder(new ShippingQuoteServlet()), "/api/v1/shipping/estimate");
+
+        // Legacy aliases for backward compatibility
+        context.addServlet(new ServletHolder(new DocumentConvertServlet()), "/attack/rce-struts");
+        context.addServlet(new ServletHolder(new LinkPreviewServlet()), "/attack/ssrf");
+        context.addServlet(new ServletHolder(new UserSearchServlet()), "/attack/sqli");
+        context.addServlet(new ServletHolder(new LoginServlet()), "/attack/log4j");
+        context.addServlet(new ServletHolder(new SessionImportServlet()), "/attack/deserialization-cve");
+
+        server.start();
+        System.out.println("Team Portal started on port " + port);
+        System.out.println("API endpoints:");
+        System.out.println("  GET  /api/v1/documents/convert  - Document format conversion");
+        System.out.println("  GET  /api/v1/links/preview      - Link metadata preview");
+        System.out.println("  GET  /api/v1/users/search       - User directory search");
+        System.out.println("  GET  /api/v1/auth/login         - User authentication");
+        System.out.println("  GET  /api/v1/sessions/import    - Session restore");
+        System.out.println("  GET  /api/v1/workspace/sync     - Workspace sync (all attacks in one)");
+        System.out.println("  GET  /api/v1/shipping/estimate  - Shipping quote (calls shipping service)");
+        System.out.println("  GET  /health                    - Health check");
+
+        // Set up H2 in-memory DB (done once at startup, NOT per-request,
+        // to avoid backend dedup merging CREATE/MERGE events with the
+        // malicious SELECT and losing the SQL signals).
+        try {
+            Class.forName("org.h2.Driver");
+            Connection dbConn = DriverManager.getConnection(
+                "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1", "sa", "");
+            Statement dbStmt = dbConn.createStatement();
+            dbStmt.execute("CREATE TABLE IF NOT EXISTS users (id INT, name VARCHAR(255), email VARCHAR(255), role VARCHAR(64))");
+            dbStmt.execute("MERGE INTO users KEY(id) VALUES (1, 'admin', 'admin@teamportal.local', 'admin')");
+            dbStmt.execute("MERGE INTO users KEY(id) VALUES (2, 'jdoe', 'jdoe@teamportal.local', 'user')");
+            dbStmt.execute("MERGE INTO users KEY(id) VALUES (3, 'alice', 'alice@teamportal.local', 'user')");
+            dbStmt.close();
+            dbConn.close();
+            System.out.println("Database initialized.");
+        } catch (Exception e) {
+            System.out.println("Database setup error: " + e.getMessage());
+        }
+
+        // Load classes from third-party JARs for VA scanner discovery
+        System.out.println("\nLoading application libraries...");
+        String[][] libs = {
+            {"org.apache.logging.log4j.LogManager", "log4j"},
+            {"org.apache.commons.lang3.StringUtils", "commons-lang3"},
+            {"org.apache.commons.io.IOUtils", "commons-io"},
+            {"com.google.common.collect.ImmutableList", "guava"},
+            {"freemarker.template.Configuration", "freemarker"},
+            {"ognl.Ognl", "ognl"},
+            {"org.apache.commons.collections.functors.InvokerTransformer", "commons-collections"},
+            {"org.apache.commons.fileupload.disk.DiskFileItem", "commons-fileupload"},
+            {"com.fasterxml.jackson.databind.ObjectMapper", "jackson-databind"},
+            {"org.apache.activemq.util.ClassLoadingAwareObjectInputStream", "activemq-client"},
+            {"org.keycloak.common.util.KerberosSerializationUtils", "keycloak-common"},
+        };
+        for (String[] lib : libs) {
+            try {
+                Class.forName(lib[0]);
+                System.out.println("  " + lib[1]);
+            } catch (Exception e) {
+                System.out.println("  " + lib[1] + ": " + e.getMessage());
+            }
+        }
+        System.out.println("Ready.");
+
+        server.join();
+    }
+}

--- a/src/secureapp-loadgen/src/main/resources/log4j2.xml
+++ b/src/secureapp-loadgen/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/secureapp-loadgen/src/main/resources/struts.xml
+++ b/src/secureapp-loadgen/src/main/resources/struts.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE struts PUBLIC
+    "-//Apache Software Foundation//DTD Struts Configuration 2.3//EN"
+    "http://struts.apache.org/dtds/struts-2.3.dtd">
+<struts>
+    <constant name="struts.devMode" value="false"/>
+    <constant name="struts.action.extension" value="action"/>
+    <constant name="struts.multipart.parser" value="jakarta"/>
+    <constant name="struts.multipart.maxSize" value="2097152"/>
+
+    <package name="default" namespace="/struts" extends="struts-default">
+        <!-- Minimal action for CVE-2017-5638 trigger — the exploit fires during
+             multipart parsing before any action code runs. -->
+        <action name="upload">
+            <result>/success.html</result>
+        </action>
+    </package>
+</struts>


### PR DESCRIPTION
## Summary
- Adds `secureapp-loadgen` service — Java vulnerability test app exercising 5 exploit classes (RCE/Struts2, SSRF, SQLi, Log4Shell, Deserialization) detected by the Splunk OTel Java agent's SecureApp feature
- Loadgen fires each attack endpoint on its own independent randomized schedule, spread across the day (hours not days)
- Pace controlled via flagd feature flag `secureappAttack` (minimal / targeted / max)
- Reports telemetry as `OTEL_SERVICE_NAME=ad` so security events appear under the ad service
- Deployed as separate manifest group (`secureapp`) producing `splunk-astronomy-shop-X.X.X-secureapp.yaml`

## Files
- `src/secureapp-loadgen/` — Dockerfile, entrypoint.sh, loadgen.sh, k8s manifest, Java source (pom.xml + vulnerable app)
- `services.yaml` — new entry with `group: secureapp`
- `src/flagd/demo.flagd.json` — new `secureappAttack` feature flag
- `.gitignore` — exclude `src/secureapp-loadgen/target/`

## Notes
- Collector config for SecureApp log routing (`routing/logs` connector, `otlp_http/secureapp` exporter) is handled externally via Helm values — not included here
- Java agent downloaded at build time (not committed); app jar built from source via Maven

## Test plan
- [ ] `docker build -f src/secureapp-loadgen/Dockerfile .` builds successfully
- [ ] Container starts, Java app healthy on :8080/health, loadgen fires attacks at random intervals
- [ ] `stitch-manifests.sh` produces `splunk-astronomy-shop-X.X.X-secureapp.yaml`
- [ ] Deploy to cluster — security events appear under `ad` service in Splunk Observability
- [ ] Toggle flagd `secureappAttack` flag — pace changes reflected in loadgen behavior