### PR TITLE
fix: use CSA agent for secureapp-loadgen, bump ad agent to 2.27.0

### DIFF
--- a/.github/scripts/stitch-manifests.sh
+++ b/.github/scripts/stitch-manifests.sh
@@ -117,18 +117,21 @@ stitch_service() {
     echo "# === $SERVICE ===" >> "$OUT_FILE"
 
     # Process manifest: replace registry URLs (if needed) and version numbers
+    # Version regex: match semver (digits+dots) plus any suffix (-beta, -hotfix-*, etc.)
+    # The full tag is replaced wholesale by SERVICE_VERSION — no trailing capture group,
+    # which previously caused double-suffix bugs (e.g., 2.0.1-beta-beta).
     if [ -n "$REGISTRY_URL" ] && [ "$SHOULD_REPLACE" = "true" ]; then
         sed -e "s|ghcr.io/[^/]*/[^/]*|${REGISTRY_URL}|g" \
-            -e "s|\(${REGISTRY_URL}/[^:]*\):[0-9][0-9.]*\([^[:space:]]*\)|\1:${SERVICE_VERSION}\2|" \
-            -e "s|app.kubernetes.io/version: [0-9][0-9.]*\([^\"[:space:]]*\)|app.kubernetes.io/version: ${SERVICE_VERSION}\1|g" \
-            -e "s|service.version=[0-9][0-9.]*\([^,[:space:]]*\)|service.version=${SERVICE_VERSION}\1|g" \
+            -e "s|\(${REGISTRY_URL}/[^:]*\):[0-9][0-9.]*[^[:space:]]*|\1:${SERVICE_VERSION}|" \
+            -e "s|app.kubernetes.io/version: [0-9][0-9.]*[^\"[:space:]]*|app.kubernetes.io/version: ${SERVICE_VERSION}|g" \
+            -e "s|service.version=[0-9][0-9.]*[^,[:space:]]*|service.version=${SERVICE_VERSION}|g" \
             "$MANIFEST_FILE" >> "$OUT_FILE"
     elif [ "$SHOULD_REPLACE" = "false" ]; then
         cat "$MANIFEST_FILE" >> "$OUT_FILE"
         echo "  (using original registry and versions)"
     else
-        sed -e "s|app.kubernetes.io/version: [0-9][0-9.]*\([^\"[:space:]]*\)|app.kubernetes.io/version: ${SERVICE_VERSION}\1|g" \
-            -e "s|service.version=[0-9][0-9.]*\([^,[:space:]]*\)|service.version=${SERVICE_VERSION}\1|g" \
+        sed -e "s|app.kubernetes.io/version: [0-9][0-9.]*[^\"[:space:]]*|app.kubernetes.io/version: ${SERVICE_VERSION}|g" \
+            -e "s|service.version=[0-9][0-9.]*[^,[:space:]]*|service.version=${SERVICE_VERSION}|g" \
             "$MANIFEST_FILE" >> "$OUT_FILE"
     fi
 
@@ -179,15 +182,15 @@ stitch_payment() {
 
         if [ -n "$REGISTRY_URL" ] && [ "$SHOULD_REPLACE" = "true" ]; then
             sed -e "s|ghcr.io/[^/]*/[^/]*|${REGISTRY_URL}|g" \
-                -e "s|\(${REGISTRY_URL}/[^:]*\):[0-9][0-9.]*\([^[:space:]]*\)|\1:${SERVICE_VERSION}\2|" \
-                -e "s|app.kubernetes.io/version: [0-9][0-9.]*\([^\"[:space:]]*\)|app.kubernetes.io/version: ${SERVICE_VERSION}\1|g" \
-                -e "s|service.version=[0-9][0-9.]*\([^,[:space:]]*\)|service.version=${SERVICE_VERSION}\1|g" \
+                -e "s|\(${REGISTRY_URL}/[^:]*\):[0-9][0-9.]*[^[:space:]]*|\1:${SERVICE_VERSION}|" \
+                -e "s|app.kubernetes.io/version: [0-9][0-9.]*[^\"[:space:]]*|app.kubernetes.io/version: ${SERVICE_VERSION}|g" \
+                -e "s|service.version=[0-9][0-9.]*[^,[:space:]]*|service.version=${SERVICE_VERSION}|g" \
                 "$CURRENT_MANIFEST" >> "$OUT_FILE"
         elif [ "$SHOULD_REPLACE" = "false" ]; then
             cat "$CURRENT_MANIFEST" >> "$OUT_FILE"
         else
-            sed -e "s|app.kubernetes.io/version: [0-9][0-9.]*\([^\"[:space:]]*\)|app.kubernetes.io/version: ${SERVICE_VERSION}\1|g" \
-                -e "s|service.version=[0-9][0-9.]*\([^,[:space:]]*\)|service.version=${SERVICE_VERSION}\1|g" \
+            sed -e "s|app.kubernetes.io/version: [0-9][0-9.]*[^\"[:space:]]*|app.kubernetes.io/version: ${SERVICE_VERSION}|g" \
+                -e "s|service.version=[0-9][0-9.]*[^,[:space:]]*|service.version=${SERVICE_VERSION}|g" \
                 "$CURRENT_MANIFEST" >> "$OUT_FILE"
         fi
 

--- a/src/ad/Dockerfile
+++ b/src/ad/Dockerfile
@@ -23,7 +23,7 @@ FROM eclipse-temurin:21-jre
 
 # Grab the latest Splunk OpenTelemetry Java agent (because "latest" is apparently a lifestyle)
 # ADD --chmod=644 https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent.jar /usr/src/app/splunk-otel-javaagent.jar
-ADD --chmod=644 https://repo1.maven.org/maven2/com/splunk/splunk-otel-javaagent-csa/2.21.1/splunk-otel-javaagent-csa-2.21.1.jar  /usr/src/app/splunk-otel-javaagent-csa.jar
+ADD --chmod=644 https://repo1.maven.org/maven2/com/splunk/splunk-otel-javaagent-csa/2.27.0/splunk-otel-javaagent-csa-2.27.0.jar  /usr/src/app/splunk-otel-javaagent-csa.jar
 
 WORKDIR /usr/src/app/
 COPY --from=builder /usr/src/app/ ./

--- a/src/secureapp-loadgen/Dockerfile
+++ b/src/secureapp-loadgen/Dockerfile
@@ -23,8 +23,8 @@ RUN if [ "$SKIP_BUILD" = "false" ]; then \
 # --- Runtime stage ---
 FROM eclipse-temurin:17-jre
 
-# Splunk OTel Java agent (non-CSA — SecureApp needs the standard agent)
-ADD --chmod=644 https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent.jar /app/splunk-otel-javaagent.jar
+# Splunk OTel Java agent — CSA build (Cisco Secure Application) includes SecureApp/Argento hooks
+ADD --chmod=644 https://repo1.maven.org/maven2/com/splunk/splunk-otel-javaagent-csa/2.27.0/splunk-otel-javaagent-csa-2.27.0.jar /app/splunk-otel-javaagent.jar
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Switch secureapp-loadgen Dockerfile from standard `splunk-otel-javaagent.jar` to `splunk-otel-javaagent-csa` (Cisco Secure Application build) — the standard agent lacks SecureApp/Argento hooks, so no attack events were being generated
- Bump ad service CSA agent from 2.21.1 to 2.27.0
- Fix double-suffix bug in stitch-manifests.sh version replacement

## Root cause
The secureapp-loadgen Dockerfile was downloading from `github.com/signalfx/splunk-otel-java/releases/latest` which is the standard agent (27MB, no `Cisco-Secure-Application-Version` manifest entry). The CSA build on Maven Central (`splunk-otel-javaagent-csa`) includes the Argento hooks needed for SecureApp attack detection.

## Test plan
- [ ] Rebuild secureapp-loadgen image — verify agent jar contains `Cisco-Secure-Application-Version` in MANIFEST.MF
- [ ] Deploy — attack events (EXPLOITED) should appear in Splunk O11y SecureApp UI
- [ ] Verify ad service still works with 2.27.0 agent