### PR TITLE
fix: checkout peer.service, loadgen syntax error, secureapp initial attack

### DIFF
--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -98,6 +98,10 @@ data:
       return shuffled.slice(0, numProducts);
     }
 
+    // Throttle quick prompts — parsed from env, default 5 min
+    const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
+    let lastQuickPromptTime = 0;
+
     function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
 
     /** Wait until innerText of the page contains a substring */
@@ -221,10 +225,6 @@ data:
                 console.log('⚠️ AI response timeout, continuing...');
               });
               await delay(1500); // Allow response to fully render
-          }
-
-          } else {
-            console.log('⏭️ Skipping quick prompts (next run in ' + Math.round((QUICK_PROMPT_INTERVAL_MS - (now - lastQuickPromptTime)) / 1000) + 's)');
           }
 
           } else {

--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -201,36 +201,40 @@ func main() {
 
 	svc := new(checkout)
 	svc.httpClient = &http.Client{
-		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Transport: otelhttp.NewTransport(http.DefaultTransport,
+			otelhttp.WithSpanOptions(trace.WithAttributes(
+				semconv.PeerServiceKey.String("shipping"),
+			)),
+		),
 	}
 
 	mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_ADDR")
-	c := mustCreateClient(svc.shippingSvcAddr)
+	c := mustCreateClient(svc.shippingSvcAddr, "shipping")
 	svc.shippingSvcClient = pb.NewShippingServiceClient(c)
 	defer c.Close()
 
 	mustMapEnv(&svc.productCatalogSvcAddr, "PRODUCT_CATALOG_ADDR")
-	c = mustCreateClient(svc.productCatalogSvcAddr)
+	c = mustCreateClient(svc.productCatalogSvcAddr, "product-catalog")
 	svc.productCatalogSvcClient = pb.NewProductCatalogServiceClient(c)
 	defer c.Close()
 
 	mustMapEnv(&svc.cartSvcAddr, "CART_ADDR")
-	c = mustCreateClient(svc.cartSvcAddr)
+	c = mustCreateClient(svc.cartSvcAddr, "cart")
 	svc.cartSvcClient = pb.NewCartServiceClient(c)
 	defer c.Close()
 
 	mustMapEnv(&svc.currencySvcAddr, "CURRENCY_ADDR")
-	c = mustCreateClient(svc.currencySvcAddr)
+	c = mustCreateClient(svc.currencySvcAddr, "currency")
 	svc.currencySvcClient = pb.NewCurrencyServiceClient(c)
 	defer c.Close()
 
 	mustMapEnv(&svc.emailSvcAddr, "EMAIL_ADDR")
-	c = mustCreateClient(svc.emailSvcAddr)
+	c = mustCreateClient(svc.emailSvcAddr, "email")
 	svc.emailSvcClient = pb.NewEmailServiceClient(c)
 	defer c.Close()
 
 	mustMapEnv(&svc.paymentSvcAddr, "PAYMENT_ADDR")
-	c = mustCreateClient(svc.paymentSvcAddr)
+	c = mustCreateClient(svc.paymentSvcAddr, "payment")
 	svc.paymentSvcClient = pb.NewPaymentServiceClient(c)
 	defer c.Close()
 
@@ -455,10 +459,14 @@ func (cs *checkout) prepareOrderItemsAndShippingQuoteFromCart(ctx context.Contex
 	return out, nil
 }
 
-func mustCreateClient(svcAddr string) *grpc.ClientConn {
+func mustCreateClient(svcAddr string, peerService string) *grpc.ClientConn {
 	c, err := grpc.NewClient(svcAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+			otelgrpc.WithSpanOptions(trace.WithAttributes(
+				semconv.PeerServiceKey.String(peerService),
+			)),
+		)),
 	)
 	if err != nil {
 		logger.Error(fmt.Sprintf("could not connect to %s service, err: %+v", svcAddr, err))
@@ -574,7 +582,7 @@ func (cs *checkout) chargeCard(ctx context.Context, amount *pb.Money, paymentInf
 	// Check for intentional failure mode (uses existing paymentUnreachable flag)
 	if cs.isFeatureFlagEnabled(ctx, "paymentUnreachable") {
 		badAddress := "badAddress:50051"
-		c := mustCreateClient(badAddress)
+		c := mustCreateClient(badAddress, "payment")
 		paymentService = pb.NewPaymentServiceClient(c)
 	} else {
 		var paymentAddr string
@@ -618,7 +626,7 @@ func (cs *checkout) chargeCard(ctx context.Context, amount *pb.Money, paymentInf
 		}
 
 		// Create client for selected version
-		c := mustCreateClient(paymentAddr)
+		c := mustCreateClient(paymentAddr, "payment")
 		defer c.Close()
 		paymentService = pb.NewPaymentServiceClient(c)
 	}

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -42,6 +42,39 @@ from metrics import (
 cached_ids = []
 first_run = True
 
+
+class PeerServiceInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+):
+    """gRPC client interceptor that sets peer.service on the active OTel span."""
+
+    def __init__(self, peer_service):
+        self._peer_service = peer_service
+
+    def _set_peer_service(self):
+        span = trace.get_current_span()
+        if span and span.is_recording():
+            span.set_attribute("peer.service", self._peer_service)
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        self._set_peer_service()
+        return continuation(client_call_details, request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        self._set_peer_service()
+        return continuation(client_call_details, request)
+
+    def intercept_stream_unary(self, continuation, client_call_details, request_iterator):
+        self._set_peer_service()
+        return continuation(client_call_details, request_iterator)
+
+    def intercept_stream_stream(self, continuation, client_call_details, request_iterator):
+        self._set_peer_service()
+        return continuation(client_call_details, request_iterator)
+
 # DBMon Cartesian Demo - PostgreSQL queries
 # Bad query: ON 1=1 creates Cartesian product (5000 x 100000 = 500M rows)
 CARTESIAN_BAD_QUERY = '''
@@ -312,7 +345,10 @@ if __name__ == "__main__":
     logger.addHandler(handler)
 
     catalog_addr = must_map_env('PRODUCT_CATALOG_ADDR')
-    pc_channel = grpc.insecure_channel(catalog_addr)
+    pc_channel = grpc.intercept_channel(
+        grpc.insecure_channel(catalog_addr),
+        PeerServiceInterceptor("product-catalog"),
+    )
     product_catalog_stub = demo_pb2_grpc.ProductCatalogServiceStub(pc_channel)
 
     # Create gRPC server

--- a/src/secureapp-loadgen/loadgen.sh
+++ b/src/secureapp-loadgen/loadgen.sh
@@ -122,28 +122,26 @@ CURRENT_PACE=$(get_pace)
 echo "  flagd pace: $CURRENT_PACE"
 echo "  flagd url:  $FLAGD_URL"
 
-now=$(date +%s)
-startup_delay=$(rand_between 30 120)
-echo "  Initial delay: $(fmt_duration $startup_delay)"
-base_time=$((now + startup_delay))
+# --- Immediate first shot: fire one random attack endpoint ---
+# Skip index 0 (shipping) and 1 (health) — pick from real attacks (indices 2-7)
+initial_idx=$(rand_between 2 $((NUM_ENDPOINTS - 1)))
+echo ""
+echo "=== Initial attack ==="
+fire_endpoint "$initial_idx"
+echo ""
 
+# --- Schedule subsequent fires based on pace ---
+now=$(date +%s)
 declare -a next_fire
 declare -a hit_count
 for i in $(seq 0 $((NUM_ENDPOINTS - 1))); do
-  IFS='|' read -r path label _rest <<< "${ALL_ENTRIES[$i]}"
   read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$i]}" "$CURRENT_PACE")"
-  # Stagger first fire: shipping starts soon, others spread out
-  if (( i == 0 )); then
-    offset=$(rand_between 10 30)
-  else
-    offset=$(rand_between $((i * 120)) $(( (i + 1) * 300 )))
-  fi
-  next_fire[$i]=$((base_time + offset))
+  next_fire[$i]=$(( now + $(rand_between "$mn" "$mx") ))
   hit_count[$i]=0
 done
+hit_count[$initial_idx]=1
 
 print_schedule
-sleep "$startup_delay"
 
 # --- Main loop ---
 fire_count=0


### PR DESCRIPTION
## Summary
- **checkout**: Set `peer.service=shipping` on HTTP client spans via `otelhttp` transport options. Without this, Splunk shows "shipping:8080" as an inferred service instead of linking to the actual shipping service.
- **astronomy-loadgen**: Fix `SyntaxError: Unexpected token 'else'` — duplicate `} else {` block and missing `QUICK_PROMPT_INTERVAL_MS`/`lastQuickPromptTime` variable declarations. This completely broke load generation (no orders, no browsing, no traces).
- **secureapp-loadgen**: Fire one random attack endpoint immediately at startup before entering the paced schedule.

## Test plan
- [ ] Checkout → shipping traces show `peer.service=shipping` instead of inferred "shipping:8080"
- [ ] Astronomy loadgen runs without syntax errors, places orders, browses products
- [ ] Secureapp loadgen fires one attack immediately on pod start