### PR TITLE
fix: secureapp-loadgen minimal pace attacks fire within 12 hours

### DIFF
--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -306,6 +306,22 @@ spec:
       labels:
         app: astronomy-loadgen
     spec:
+      initContainers:
+      - name: wait-for-frontend
+        image: curlimages/curl:8.1.2
+        command: ['sh', '-c']
+        args:
+        - |
+          echo "Waiting for frontend-proxy to be ready..."
+          until curl -f --connect-timeout 5 --max-time 10 http://frontend-proxy:8080; do
+            echo "Frontend not ready, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Frontend is ready, starting loadgen..."
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "50m"
       containers:
       - name: astronomy-loadgen
         image: ghcr.io/splunk/online-boutique/rumloadgen:5.6

--- a/src/secureapp-loadgen/entrypoint.sh
+++ b/src/secureapp-loadgen/entrypoint.sh
@@ -20,7 +20,21 @@ until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
   fi
   sleep 2
 done
-echo "App is healthy. Starting loadgen..."
+echo "App is healthy."
+
+# Wait for shipping service before starting loadgen
+SHIPPING_ADDR="${SHIPPING_ADDR:-http://shipping:8080}"
+echo "Waiting for shipping service at ${SHIPPING_ADDR}..."
+retries=0
+until curl -sf "${SHIPPING_ADDR}/health" -o /dev/null --max-time 5 2>/dev/null; do
+  retries=$((retries + 1))
+  if [ $retries -ge 90 ]; then
+    echo "WARNING: Shipping service not ready after 180s, starting loadgen anyway"
+    break
+  fi
+  sleep 2
+done
+echo "Starting loadgen..."
 
 # Launch the loadgen in background
 /app/loadgen.sh &

--- a/src/secureapp-loadgen/loadgen.sh
+++ b/src/secureapp-loadgen/loadgen.sh
@@ -29,13 +29,13 @@ CURRENT_PACE=""
 SHIPPING_ENTRY="/api/v1/shipping/estimate|Shipping quote|180|300|180|300|180|300"
 
 ATTACK_ENTRIES=(
-  "/health|Health check|21600|43200|21600|43200|120|300"
-  "/api/v1/documents/convert|RCE (Struts2 CVE-2017-5638)|72000|172800|72000|172800|180|600"
-  "/api/v1/users/search|SQL Injection|80000|158400|600|900|240|600"
-  "/api/v1/links/preview|SSRF (cloud metadata)|86400|172800|86400|172800|180|540"
-  "/api/v1/auth/login|Log4Shell (CVE-2021-44228)|100800|172800|600|900|240|720"
-  "/api/v1/sessions/import|Deserialization (CVE-2020-1714)|115200|187200|115200|187200|300|720"
-  "/api/v1/workspace/sync|All attacks combined|144000|216000|144000|216000|300|900"
+  "/health|Health check|7200|14400|7200|14400|120|300"
+  "/api/v1/documents/convert|RCE (Struts2 CVE-2017-5638)|10800|28800|10800|28800|180|600"
+  "/api/v1/users/search|SQL Injection|14400|36000|600|900|240|600"
+  "/api/v1/links/preview|SSRF (cloud metadata)|18000|39600|18000|39600|180|540"
+  "/api/v1/auth/login|Log4Shell (CVE-2021-44228)|21600|43200|600|900|240|720"
+  "/api/v1/sessions/import|Deserialization (CVE-2020-1714)|25200|43200|25200|43200|300|720"
+  "/api/v1/workspace/sync|All attacks combined|28800|43200|28800|43200|300|900"
 )
 
 # Combine into single array (shipping first)


### PR DESCRIPTION
## Summary
Minimal pace attack intervals were 20-60 hours, meaning most attacks never fired within a day. Reduced all intervals so every attack fires at least once within 12 hours.

| Attack | Before | After |
|--------|--------|-------|
| Health check | 6-12h | 2-4h |
| RCE (Struts2) | 20-48h | 3-8h |
| SQL Injection | 22-44h | 4-10h |
| SSRF | 24-48h | 5-11h |
| Log4Shell | 28-48h | 6-12h |
| Deserialization | 32-52h | 7-12h |
| All combined | 40-60h | 8-12h |

Targeted and max paces unchanged.

## Test plan
- [ ] Deploy with flagd `secureappAttack=minimal` — all attack types fire within 12h
- [ ] Attacks remain staggered (not clustered)