### PR TITLE
fix: stop Slack spam from build-images deployment events

### DIFF
--- a/.github/workflows/prod-build-images.yml
+++ b/.github/workflows/prod-build-images.yml
@@ -273,7 +273,6 @@ jobs:
   build-images:
     needs: [determine-version, prepare-matrix]
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -235,7 +235,6 @@ jobs:
   build-images:
     needs: [determine-version, prepare-matrix]
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Remove `environment: production` from `build-images` matrix jobs in `prod-release.yml` and `prod-build-images.yml`
- These jobs build/push container images — they don't deploy anything
- The matrix strategy creates a separate GitHub deployment event per service (~20), each triggering a Slack "Deployment to production" notification

## Test plan
- [ ] Run a release build and verify Slack no longer receives per-container deployment notifications
- [ ] Verify images still build and push correctly (no functional change — only metadata removed)