### PR TITLE
chore: bump deprecated Node.js 20 GitHub Actions to latest

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -30,7 +30,7 @@ jobs:
           echo "✓ Version format valid: $VERSION"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
           pod install
 
       - name: Setup Java (for Android build)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -74,7 +74,7 @@ jobs:
           ./build-saucelabs.sh "${{ inputs.version }}"
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mobile-release-v${{ inputs.version }}
           path: releases/mobile/astronomy-shop-saucelabs-v${{ inputs.version }}.zip

--- a/.github/workflows/prod-build-manifest.yml
+++ b/.github/workflows/prod-build-manifest.yml
@@ -335,7 +335,7 @@ jobs:
           echo "Manifests attached as release assets." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ steps.version.outputs.new_version }}${{ inputs.beta_build == true && '-beta' || '' }}
           path: |

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -685,7 +685,7 @@ jobs:
           echo "Stitched manifests will be attached to the release automatically." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ needs.determine-version.outputs.version }}
           path: |

--- a/.github/workflows/test-build-manifest.yml
+++ b/.github/workflows/test-build-manifest.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ steps.version.outputs.test_version }}
           path: |

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -424,7 +424,7 @@ jobs:
           fi
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ inputs.version }}-beta
           path: |


### PR DESCRIPTION
## Summary
- `upload-artifact` v4 → v7 (5 workflows)
- `setup-node` v4 → v6 (mobile-release)
- `setup-java` v4 → v5 (mobile-release)

Node.js 20 actions are deprecated June 2nd and removed September 16th. All usages bumped to latest major versions.

## Test plan
- [ ] Run a test or prod build to verify artifact upload still works with v7
- [ ] Verify mobile-release workflow still resolves setup-node@v6 and setup-java@v5