### PR TITLE
feat: shipping-api endpoint with trace chain and loadgen integration

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -30,7 +30,7 @@ jobs:
           echo "✓ Version format valid: $VERSION"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
           pod install
 
       - name: Setup Java (for Android build)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -74,7 +74,7 @@ jobs:
           ./build-saucelabs.sh "${{ inputs.version }}"
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mobile-release-v${{ inputs.version }}
           path: releases/mobile/astronomy-shop-saucelabs-v${{ inputs.version }}.zip

--- a/.github/workflows/prod-build-images.yml
+++ b/.github/workflows/prod-build-images.yml
@@ -273,7 +273,6 @@ jobs:
   build-images:
     needs: [determine-version, prepare-matrix]
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/prod-build-manifest.yml
+++ b/.github/workflows/prod-build-manifest.yml
@@ -335,7 +335,7 @@ jobs:
           echo "Manifests attached as release assets." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ steps.version.outputs.new_version }}${{ inputs.beta_build == true && '-beta' || '' }}
           path: |

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -235,7 +235,6 @@ jobs:
   build-images:
     needs: [determine-version, prepare-matrix]
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -685,7 +685,7 @@ jobs:
           echo "Stitched manifests will be attached to the release automatically." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ needs.determine-version.outputs.version }}
           path: |

--- a/.github/workflows/test-build-manifest.yml
+++ b/.github/workflows/test-build-manifest.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ steps.version.outputs.test_version }}
           path: |

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -424,7 +424,7 @@ jobs:
           fi
 
       - name: Upload manifests as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: astronomy-shop-manifests-${{ inputs.version }}-beta
           path: |

--- a/kubernetes/example-secrets.yaml
+++ b/kubernetes/example-secrets.yaml
@@ -20,5 +20,6 @@ stringData:
   flagd_auth: "true/false"
   flagd_user: "user"
   flagd_pw: "pw"
+  shipping_api: "true/false"
 data:
   TEAGENT_ACCOUNT_TOKEN:[TEAGent-Token]

--- a/kubernetes/splunk-astronomy-shop-2.0.2-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.2-values.yaml
@@ -214,8 +214,11 @@ agent:
           - attributes["rpc.method"] == "ResolveInt"
           - attributes["http.url"] == "http://flagd:8016/ofrep/v1/evaluate/flags/loadGeneratorFloodHomepage"
           - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v1.Service/ResolveBoolean"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v2.Service/ResolveBoolean"
           - attributes["otel.scope.name"] == "flagd.evaluation.v1"
+          - attributes["otel.scope.name"] == "flagd.evaluation.v2"
           - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v1.Service/EventStream"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v2.Service/EventStream"
           - attributes["url.path"] == "/live/longpoll"
       transform/dc_not_error:
         error_mode: ignore

--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -102,7 +102,41 @@ data:
     const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
     let lastQuickPromptTime = 0;
 
+    // Throttle shipping info checks — every 2 minutes
+    const SHIPPING_INFO_INTERVAL_MS = parseInt(process.env.SHIPPING_INFO_INTERVAL_MS || '120000', 10);
+    let lastShippingInfoTime = 0;
+    const SHIPPING_API_ENABLED = (process.env.SHIPPING_API || '').toLowerCase() === 'true';
+
     function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
+
+    /** Generate a random shipping tracking number */
+    function randomTrackingNumber() {
+      const num = Math.floor(Math.random() * 99999) + 10000;
+      return `SHIP-${num}`;
+    }
+
+    /** Fetch shipping info via the frontend-proxy /shipping/ route */
+    async function fetchShippingInfo(page) {
+      if (!SHIPPING_API_ENABLED) return;
+      const now = Date.now();
+      if (now - lastShippingInfoTime < SHIPPING_INFO_INTERVAL_MS) return;
+      lastShippingInfoTime = now;
+
+      const tracking = randomTrackingNumber();
+      const base = buildBaseUrl();
+      const url = `${base}shipping/?tracking=${tracking}`;
+      console.log(`📦 Fetching shipping info for ${tracking}...`);
+      try {
+        const result = await page.evaluate(async (fetchUrl) => {
+          const resp = await fetch(fetchUrl);
+          return { status: resp.status, body: await resp.text() };
+        }, url);
+        console.log(`📦 Shipping info: HTTP ${result.status}`);
+        if (debugEnabled) console.log(`[DEBUG] Shipping response: ${result.body}`);
+      } catch (e) {
+        console.log(`⚠️ Shipping info fetch failed: ${e.message}`);
+      }
+    }
 
     /** Wait until innerText of the page contains a substring */
     async function waitForText(page, text, timeoutMs = 30000, pollMs = 200) {
@@ -258,6 +292,9 @@ data:
           await delay(500);
           console.log('✅ Error modal closed.');
         }
+
+        // Periodic shipping info fetch (every 2 minutes, gated by SHIPPING_API)
+        await fetchShippingInfo(page);
       } finally {
         console.log('🧹 Cleaning up page resources...');
         try {
@@ -335,6 +372,12 @@ spec:
           value: ""  # Set to "true" to enable debug logging
         - name: QUICK_PROMPT_INTERVAL_MS
           value: "300000"  # How often AI quick prompts run (ms). Default 300000 (5min). Set "0" for every cycle.
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
         resources:
           requests:
             memory: "768Mi"

--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -102,9 +102,10 @@ data:
     const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
     let lastQuickPromptTime = 0;
 
-    // Throttle shipping info checks — every 2 minutes
-    const SHIPPING_INFO_INTERVAL_MS = parseInt(process.env.SHIPPING_INFO_INTERVAL_MS || '120000', 10);
-    let lastShippingInfoTime = 0;
+    // Shipping API — random interval between 34s and 1m45s
+    const SHIPPING_MIN_MS = parseInt(process.env.SHIPPING_MIN_MS || '34000', 10);
+    const SHIPPING_MAX_MS = parseInt(process.env.SHIPPING_MAX_MS || '105000', 10);
+    let nextShippingTime = 0;
     const SHIPPING_API_ENABLED = (process.env.SHIPPING_API || '').toLowerCase() === 'true';
 
     function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
@@ -115,12 +116,18 @@ data:
       return `SHIP-${num}`;
     }
 
+    /** Schedule next shipping call at a random interval */
+    function scheduleNextShipping() {
+      const interval = SHIPPING_MIN_MS + Math.floor(Math.random() * (SHIPPING_MAX_MS - SHIPPING_MIN_MS));
+      nextShippingTime = Date.now() + interval;
+      if (debugEnabled) console.log(`[DEBUG] Next shipping call in ${Math.round(interval/1000)}s`);
+    }
+
     /** Fetch shipping info via the frontend-proxy /shipping/ route */
     async function fetchShippingInfo(page) {
       if (!SHIPPING_API_ENABLED) return;
-      const now = Date.now();
-      if (now - lastShippingInfoTime < SHIPPING_INFO_INTERVAL_MS) return;
-      lastShippingInfoTime = now;
+      if (Date.now() < nextShippingTime) return;
+      scheduleNextShipping();
 
       const tracking = randomTrackingNumber();
       const base = buildBaseUrl();

--- a/src/frontend-proxy/envoy.tmpl.yaml
+++ b/src/frontend-proxy/envoy.tmpl.yaml
@@ -128,6 +128,10 @@ static_resources:
                                     end
                                     -- Auth OK -> continue
                                   end                       
+                        - match: { path: "/shipping" }
+                          redirect: { path_redirect: "/shipping/" }
+                        - match: { prefix: "/shipping/" }
+                          route: { cluster: secureapp-loadgen, prefix_rewrite: "/api/v1/shipping/info" }
                         - match: { prefix: "/" }
                           route: { cluster: frontend }
                 http_filters:
@@ -293,6 +297,18 @@ static_resources:
                     socket_address:
                       address: ${LOCUST_WEB_HOST}
                       port_value: ${LOCUST_WEB_PORT}
+    - name: secureapp-loadgen
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: secureapp-loadgen
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: ${SECUREAPP_HOST}
+                      port_value: ${SECUREAPP_PORT}
     # - name: grafana
     #   type: STRICT_DNS
     #   lb_policy: ROUND_ROBIN

--- a/src/frontend-proxy/frontend-proxy-k8s.yaml
+++ b/src/frontend-proxy/frontend-proxy-k8s.yaml
@@ -100,6 +100,10 @@ spec:
           value: '4318'
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.1.3,service.kafka=no
+        - name: SECUREAPP_HOST
+          value: secureapp-loadgen
+        - name: SECUREAPP_PORT
+          value: '8080'
         - name: FEATURE_AUTH_ENABLED
           valueFrom:
             secretKeyRef:

--- a/src/frontend-proxy/start.sh
+++ b/src/frontend-proxy/start.sh
@@ -11,5 +11,9 @@ export FEATURE_AUTH_ENABLED="${FEATURE_AUTH_ENABLED:-false}"
 export FEATURE_USER="${FEATURE_USER:-}"
 export FEATURE_PASS="${FEATURE_PASS:-}"
 
+# Shipping API proxy (secureapp-loadgen backend)
+export SECUREAPP_HOST="${SECUREAPP_HOST:-secureapp-loadgen}"
+export SECUREAPP_PORT="${SECUREAPP_PORT:-8080}"
+
 # Run envsubst to generate config from template, then start envoy
 envsubst < envoy.tmpl.yaml > envoy.yaml && envoy -c envoy.yaml

--- a/src/secureapp-loadgen/entrypoint.sh
+++ b/src/secureapp-loadgen/entrypoint.sh
@@ -22,18 +22,22 @@ until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
 done
 echo "App is healthy."
 
-# Wait for shipping service before starting loadgen
-SHIPPING_ADDR="${SHIPPING_ADDR:-http://shipping:8080}"
-echo "Waiting for shipping service at ${SHIPPING_ADDR}..."
-retries=0
-until curl -sf "${SHIPPING_ADDR}/health" -o /dev/null --max-time 5 2>/dev/null; do
-  retries=$((retries + 1))
-  if [ $retries -ge 90 ]; then
-    echo "WARNING: Shipping service not ready after 180s, starting loadgen anyway"
-    break
-  fi
-  sleep 2
-done
+# Wait for shipping service before starting loadgen (skip if SHIPPING_ADDR not set)
+SHIPPING_ADDR="${SHIPPING_ADDR:-}"
+if [ -n "$SHIPPING_ADDR" ]; then
+  echo "Waiting for shipping service at ${SHIPPING_ADDR}..."
+  retries=0
+  until curl -sf "${SHIPPING_ADDR}/health" -o /dev/null --max-time 5 2>/dev/null; do
+    retries=$((retries + 1))
+    if [ $retries -ge 90 ]; then
+      echo "WARNING: Shipping service not ready after 180s, starting loadgen anyway"
+      break
+    fi
+    sleep 2
+  done
+else
+  echo "SHIPPING_ADDR not set, skipping shipping wait."
+fi
 echo "Starting loadgen..."
 
 # Launch the loadgen in background

--- a/src/secureapp-loadgen/loadgen.sh
+++ b/src/secureapp-loadgen/loadgen.sh
@@ -27,9 +27,9 @@ CURRENT_PACE=""
 # targeted = minimal background + SQLi & Log4Shell every ~10-15 min
 # (the two most recognizable attack signatures)
 SHIPPING_ENTRY="/api/v1/shipping/estimate|Shipping quote|180|300|180|300|180|300"
+HEALTH_ENTRY="/health|Health check|120|240|120|240|120|240"
 
 ATTACK_ENTRIES=(
-  "/health|Health check|7200|14400|7200|14400|120|300"
   "/api/v1/documents/convert|RCE (Struts2 CVE-2017-5638)|10800|28800|10800|28800|180|600"
   "/api/v1/users/search|SQL Injection|14400|36000|600|900|240|600"
   "/api/v1/links/preview|SSRF (cloud metadata)|18000|39600|18000|39600|180|540"
@@ -38,8 +38,8 @@ ATTACK_ENTRIES=(
   "/api/v1/workspace/sync|All attacks combined|28800|43200|28800|43200|300|900"
 )
 
-# Combine into single array (shipping first)
-ALL_ENTRIES=("$SHIPPING_ENTRY" "${ATTACK_ENTRIES[@]}")
+# Combine into single array (shipping=0, health=1, attacks=2+)
+ALL_ENTRIES=("$SHIPPING_ENTRY" "$HEALTH_ENTRY" "${ATTACK_ENTRIES[@]}")
 NUM_ENDPOINTS=${#ALL_ENTRIES[@]}
 
 # Random integer in [min, max]
@@ -174,8 +174,8 @@ while true; do
     if [[ "$new_pace" != "$CURRENT_PACE" ]]; then
       echo "*** Pace changed: $CURRENT_PACE -> $new_pace ***"
       CURRENT_PACE="$new_pace"
-      # Reschedule all attack endpoints (not shipping) with new intervals
-      for i in $(seq 1 $((NUM_ENDPOINTS - 1))); do
+      # Reschedule attack endpoints only (skip shipping=0 and health=1)
+      for i in $(seq 2 $((NUM_ENDPOINTS - 1))); do
         read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$i]}" "$CURRENT_PACE")"
         next_fire[$i]=$(( now + $(rand_between "$mn" "$mx") ))
       done

--- a/src/secureapp-loadgen/loadgen.sh
+++ b/src/secureapp-loadgen/loadgen.sh
@@ -26,7 +26,9 @@ CURRENT_PACE=""
 #
 # targeted = minimal background + SQLi & Log4Shell every ~10-15 min
 # (the two most recognizable attack signatures)
-SHIPPING_ENTRY="/api/v1/shipping/estimate|Shipping quote|180|300|180|300|180|300"
+#
+# NOTE: Shipping calls are now driven by inbound traffic from astronomy-loadgen
+# via /api/v1/shipping/info (which calls shipping internally). No separate timer needed.
 HEALTH_ENTRY="/health|Health check|120|240|120|240|120|240"
 
 ATTACK_ENTRIES=(
@@ -38,8 +40,8 @@ ATTACK_ENTRIES=(
   "/api/v1/workspace/sync|All attacks combined|28800|43200|28800|43200|300|900"
 )
 
-# Combine into single array (shipping=0, health=1, attacks=2+)
-ALL_ENTRIES=("$SHIPPING_ENTRY" "$HEALTH_ENTRY" "${ATTACK_ENTRIES[@]}")
+# Combine into single array (health=0, attacks=1+)
+ALL_ENTRIES=("$HEALTH_ENTRY" "${ATTACK_ENTRIES[@]}")
 NUM_ENDPOINTS=${#ALL_ENTRIES[@]}
 
 # Random integer in [min, max]
@@ -123,8 +125,8 @@ echo "  flagd pace: $CURRENT_PACE"
 echo "  flagd url:  $FLAGD_URL"
 
 # --- Immediate first shot: fire one random attack endpoint ---
-# Skip index 0 (shipping) and 1 (health) — pick from real attacks (indices 2-7)
-initial_idx=$(rand_between 2 $((NUM_ENDPOINTS - 1)))
+# Skip index 0 (health) — pick from real attacks (indices 1+)
+initial_idx=$(rand_between 1 $((NUM_ENDPOINTS - 1)))
 echo ""
 echo "=== Initial attack ==="
 fire_endpoint "$initial_idx"
@@ -174,8 +176,8 @@ while true; do
     if [[ "$new_pace" != "$CURRENT_PACE" ]]; then
       echo "*** Pace changed: $CURRENT_PACE -> $new_pace ***"
       CURRENT_PACE="$new_pace"
-      # Reschedule attack endpoints only (skip shipping=0 and health=1)
-      for i in $(seq 2 $((NUM_ENDPOINTS - 1))); do
+      # Reschedule attack endpoints only (skip health=0)
+      for i in $(seq 1 $((NUM_ENDPOINTS - 1))); do
         read -r mn mx <<< "$(get_intervals "${ALL_ENTRIES[$i]}" "$CURRENT_PACE")"
         next_fire[$i]=$(( now + $(rand_between "$mn" "$mx") ))
       done

--- a/src/secureapp-loadgen/pom.xml
+++ b/src/secureapp-loadgen/pom.xml
@@ -139,6 +139,14 @@
             <version>5.10.0</version>
         </dependency>
 
+        <!-- OpenTelemetry API — for manual span instrumentation.
+             The Java agent provides the implementation at runtime. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.44.1</version>
+        </dependency>
+
         <!-- Vulnerable: CVE-2020-1714 (deserialization in KerberosSerializationUtils) -->
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/src/secureapp-loadgen/secureapp-loadgen-k8s.yaml
+++ b/src/secureapp-loadgen/secureapp-loadgen-k8s.yaml
@@ -1,6 +1,8 @@
-# SecureApp loadgen — Java vulnerability test app reporting as "ad" service.
+# SecureApp loadgen — Java vulnerability test app.
+# Reports as whatever OTEL_SERVICE_NAME is set to (currently "shipping-api").
 # Exercises 5 vulnerability classes for Splunk SecureApp agent detection.
 # Deployed via separate manifest group (secureapp).
+# See usage.md for configuration details.
 ---
 apiVersion: v1
 kind: Service
@@ -64,6 +66,12 @@ spec:
             secretKeyRef:
               name: workshop-secret
               key: env
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
         - name: OTEL_SERVICE_NAME
           value: "shipping-api"
         - name: NODE_IP

--- a/src/secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
+++ b/src/secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
@@ -15,6 +15,12 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
 
 /**
  * Team Portal — a Jetty servlet-based collaboration application with
@@ -285,9 +291,14 @@ public class JavaSecureAppTestApp {
 
     // --- Shipping delivery info (simulated delivery schedule) ---
     // Returns a mock delivery schedule for a given tracking number.
+    // Calls the real shipping service for a quote, then builds the
+    // delivery schedule JSON in an instrumented span.
+    // Trace: frontend-proxy → shipping-api → shipping
+    //                                      → buildDeliverySchedule (internal span)
     // Only active when SHIPPING_API env var is "true".
     public static class ShippingInfoServlet extends HttpServlet {
         private static final String SHIPPING_API = System.getenv("SHIPPING_API");
+        private static final Tracer tracer = GlobalOpenTelemetry.getTracer("shipping-api");
 
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -305,22 +316,52 @@ public class JavaSecureAppTestApp {
                 tracking = "SHIP-00000";
             }
 
-            String result = "{\"tracking\": \"" + tracking + "\","
-                + "\"status\": \"in_transit\","
-                + "\"carrier\": \"FastShip Logistics\","
-                + "\"service_type\": \"ground\","
-                + "\"estimated_delivery\": \"2026-06-03T17:00:00Z\","
-                + "\"origin\": {\"city\": \"San Francisco\", \"state\": \"CA\", \"country\": \"US\"},"
-                + "\"destination\": {\"city\": \"New York\", \"state\": \"NY\", \"country\": \"US\"},"
-                + "\"stops\": ["
-                + "{\"location\": \"San Francisco, CA\", \"timestamp\": \"2026-05-26T08:00:00Z\", \"status\": \"picked_up\"},"
-                + "{\"location\": \"Denver, CO\", \"timestamp\": \"2026-05-27T14:30:00Z\", \"status\": \"departed\"},"
-                + "{\"location\": \"Chicago, IL\", \"timestamp\": \"2026-05-28T22:15:00Z\", \"status\": \"arrived\"},"
-                + "{\"location\": \"New York, NY\", \"timestamp\": \"2026-06-03T17:00:00Z\", \"status\": \"scheduled\"}"
-                + "]}";
+            // Call real shipping service — creates outbound span in this trace
+            String quoteResult = ShippingQuoteServlet.getShippingQuote();
+
+            // Build delivery schedule — instrumented internal span
+            String result = buildDeliverySchedule(tracking, quoteResult);
 
             resp.setStatus(200);
             resp.getWriter().write(result);
+        }
+
+        /**
+         * Assembles the delivery schedule JSON from the shipping quote.
+         * Instrumented with a manual span to show processing time in traces.
+         */
+        private String buildDeliverySchedule(String tracking, String quoteResult) {
+            Span span = tracer.spanBuilder("buildDeliverySchedule")
+                .setAttribute("shipping.tracking", tracking)
+                .startSpan();
+            try {
+                // Simulate processing time (1-2ms)
+                Thread.sleep(ThreadLocalRandom.current().nextInt(1, 3));
+
+                String result = "{\"tracking\": \"" + tracking + "\","
+                    + "\"status\": \"in_transit\","
+                    + "\"carrier\": \"FastShip Logistics\","
+                    + "\"service_type\": \"ground\","
+                    + "\"estimated_delivery\": \"2026-06-03T17:00:00Z\","
+                    + "\"origin\": {\"city\": \"San Francisco\", \"state\": \"CA\", \"country\": \"US\"},"
+                    + "\"destination\": {\"city\": \"New York\", \"state\": \"NY\", \"country\": \"US\"},"
+                    + "\"shipping_quote\": " + quoteResult + ","
+                    + "\"stops\": ["
+                    + "{\"location\": \"San Francisco, CA\", \"timestamp\": \"2026-05-26T08:00:00Z\", \"status\": \"picked_up\"},"
+                    + "{\"location\": \"Denver, CO\", \"timestamp\": \"2026-05-27T14:30:00Z\", \"status\": \"departed\"},"
+                    + "{\"location\": \"Chicago, IL\", \"timestamp\": \"2026-05-28T22:15:00Z\", \"status\": \"arrived\"},"
+                    + "{\"location\": \"New York, NY\", \"timestamp\": \"2026-06-03T17:00:00Z\", \"status\": \"scheduled\"}"
+                    + "]}";
+
+                span.setStatus(StatusCode.OK);
+                return result;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                span.setStatus(StatusCode.ERROR, "interrupted");
+                return "{\"error\": \"interrupted\"}";
+            } finally {
+                span.end();
+            }
         }
     }
 

--- a/src/secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
+++ b/src/secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
@@ -283,6 +283,47 @@ public class JavaSecureAppTestApp {
         }
     }
 
+    // --- Shipping delivery info (simulated delivery schedule) ---
+    // Returns a mock delivery schedule for a given tracking number.
+    // Only active when SHIPPING_API env var is "true".
+    public static class ShippingInfoServlet extends HttpServlet {
+        private static final String SHIPPING_API = System.getenv("SHIPPING_API");
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+
+            if (!"true".equalsIgnoreCase(SHIPPING_API)) {
+                resp.setStatus(200);
+                resp.getWriter().write("{\"status\": \"skipped\", \"reason\": \"SHIPPING_API not enabled\"}");
+                return;
+            }
+
+            String tracking = req.getParameter("tracking");
+            if (tracking == null || tracking.isEmpty()) {
+                tracking = "SHIP-00000";
+            }
+
+            String result = "{\"tracking\": \"" + tracking + "\","
+                + "\"status\": \"in_transit\","
+                + "\"carrier\": \"FastShip Logistics\","
+                + "\"service_type\": \"ground\","
+                + "\"estimated_delivery\": \"2026-06-03T17:00:00Z\","
+                + "\"origin\": {\"city\": \"San Francisco\", \"state\": \"CA\", \"country\": \"US\"},"
+                + "\"destination\": {\"city\": \"New York\", \"state\": \"NY\", \"country\": \"US\"},"
+                + "\"stops\": ["
+                + "{\"location\": \"San Francisco, CA\", \"timestamp\": \"2026-05-26T08:00:00Z\", \"status\": \"picked_up\"},"
+                + "{\"location\": \"Denver, CO\", \"timestamp\": \"2026-05-27T14:30:00Z\", \"status\": \"departed\"},"
+                + "{\"location\": \"Chicago, IL\", \"timestamp\": \"2026-05-28T22:15:00Z\", \"status\": \"arrived\"},"
+                + "{\"location\": \"New York, NY\", \"timestamp\": \"2026-06-03T17:00:00Z\", \"status\": \"scheduled\"}"
+                + "]}";
+
+            resp.setStatus(200);
+            resp.getWriter().write(result);
+        }
+    }
+
     // --- Workspace sync (triggers all attack types in a single transaction) ---
     // A single HTTP request that exercises RCE, SSRF, SQLi, Log4Shell, and
     // deserialization in one web transaction so all events are grouped under
@@ -385,6 +426,11 @@ public class JavaSecureAppTestApp {
         context.addServlet(new ServletHolder(new WorkspaceSyncServlet()), "/api/v1/workspace/sync");
         context.addServlet(new ServletHolder(new ShippingQuoteServlet()), "/api/v1/shipping/estimate");
 
+        // Shipping delivery info — only register if SHIPPING_API is enabled
+        if ("true".equalsIgnoreCase(System.getenv("SHIPPING_API"))) {
+            context.addServlet(new ServletHolder(new ShippingInfoServlet()), "/api/v1/shipping/info");
+        }
+
         // Legacy aliases for backward compatibility
         context.addServlet(new ServletHolder(new DocumentConvertServlet()), "/attack/rce-struts");
         context.addServlet(new ServletHolder(new LinkPreviewServlet()), "/attack/ssrf");
@@ -402,6 +448,9 @@ public class JavaSecureAppTestApp {
         System.out.println("  GET  /api/v1/sessions/import    - Session restore");
         System.out.println("  GET  /api/v1/workspace/sync     - Workspace sync (all attacks in one)");
         System.out.println("  GET  /api/v1/shipping/estimate  - Shipping quote (calls shipping service)");
+        if ("true".equalsIgnoreCase(System.getenv("SHIPPING_API"))) {
+            System.out.println("  GET  /api/v1/shipping/info      - Shipping delivery schedule");
+        }
         System.out.println("  GET  /health                    - Health check");
 
         // Set up H2 in-memory DB (done once at startup, NOT per-request,

--- a/src/secureapp-loadgen/usage.md
+++ b/src/secureapp-loadgen/usage.md
@@ -1,0 +1,109 @@
+# SecureApp Loadgen — Usage Guide
+
+## Overview
+
+This is a Java (Jetty 9.4) application that exercises vulnerability classes for Splunk SecureApp agent detection. It serves as both a **security test target** and a **configurable service impersonator** — it can appear as any service in the Splunk Observability APM dependency map by changing `OTEL_SERVICE_NAME`.
+
+The app runs its own built-in loadgen (`loadgen.sh`) that hits the vulnerability endpoints on configurable schedules controlled by a flagd feature flag.
+
+## Service Identity
+
+The app is completely name-agnostic. Nothing in the Java code, endpoints, or responses changes based on the service name. The **only** thing that determines how this app appears in Splunk Observability APM is the `service.name` OpenTelemetry resource attribute, set via `OTEL_RESOURCE_ATTRIBUTES`:
+
+```
+OTEL_RESOURCE_ATTRIBUTES="service.name=shipping-api,service.namespace=opentelemetry-demo,service.version=2.1.3,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+```
+
+The k8s manifest uses a helper env var `OTEL_SERVICE_NAME` that gets interpolated into this string at container startup. To change identity, change the `service.name` value — the app appears as a different service in APM. Same code, same endpoints, different identity. No code changes needed.
+
+## Running as shipping-api (Astronomy Shop)
+
+The default k8s manifest configures this app to appear as `shipping-api` in the Splunk Astronomy Shop's APM dependency map. This is purely a configuration choice — the app behavior is identical regardless of name. The following env vars shape how it integrates with the shop topology:
+
+| Env Var | Value | What it does in APM |
+|---------|-------|---------------------|
+| `service.name` (in `OTEL_RESOURCE_ATTRIBUTES`) | `shipping-api` | Service identity — how it appears in APM service map and traces |
+| `SHIPPING_ADDR` | `http://shipping:8080` | Enables outbound calls to shipping service → creates `shipping-api` -> `shipping` dependency edge |
+| `SHIPPING_API` | `true` (from `workshop-secret`) | Registers `/api/v1/shipping/info` endpoint → enables inbound traffic from `frontend-proxy` -> `shipping-api` |
+| `peer-service-mapping` | `shipping:8080=shipping` | Labels outbound dependency edge with friendly name `shipping` instead of raw `shipping:8080` |
+
+Together, these create the following topology in the APM dependency map:
+```
+frontend-proxy  -->  shipping-api  -->  shipping
+   (inbound via          (this app)        (outbound via
+    /shipping/ route)                       /get-quote call)
+```
+
+All of this is driven by environment configuration, not code. To make this app appear as a different service (e.g. `inventory-api`), just change `service.name` in `OTEL_RESOURCE_ATTRIBUTES` — the endpoints, vulnerability tests, and loadgen behavior remain exactly the same.
+
+### SHIPPING_ADDR
+
+Controls outbound HTTP calls to the shop's shipping service (`/get-quote` endpoint):
+
+| Setting | Behavior |
+|---------|----------|
+| `http://shipping:8080` (set in k8s) | ShippingQuoteServlet calls shipping, creating outbound dependency edge in APM |
+| Not set / empty | ShippingQuoteServlet returns skip JSON, no outbound call, entrypoint skips shipping wait |
+
+### SHIPPING_API
+
+Controls the `/api/v1/shipping/info` delivery schedule endpoint:
+
+| Setting | Behavior |
+|---------|----------|
+| `true` (from `workshop-secret.shipping_api`) | Endpoint registered, returns simulated delivery schedule JSON |
+| Not set / empty / anything else | Endpoint not registered (404 from Jetty), defaults to `false` |
+
+When enabled, the frontend-proxy routes `/shipping/` to this endpoint, and the astronomy-loadgen calls it every ~2 minutes. This creates inbound trace traffic visible in APM.
+
+## JAVA_TOOL_OPTIONS Breakdown
+
+The k8s manifest sets these JVM flags:
+
+| Flag | Purpose | If Missing |
+|------|---------|------------|
+| `-javaagent:/app/splunk-otel-javaagent.jar` | Splunk OTel auto-instrumentation + SecureApp agent | No traces, no security events — app still runs but is invisible to APM |
+| `-Dargento.allow.security.events=true` | Enable SecureApp security event detection | Agent loads but does not report vulnerability exploits |
+| `-Dargento.wait.events.for.first.transaction=false` | Send security events immediately, don't wait for first HTTP transaction | Events delayed until first inbound request (matters for startup-time vulns) |
+| `-Dotel.instrumentation.common.peer-service-mapping=shipping:8080=shipping` | Maps outbound calls to `shipping:8080` to peer service name `shipping` in APM | Outbound calls still traced, but APM dependency map shows raw `shipping:8080` instead of friendly name `shipping` |
+
+## Endpoints
+
+### Always registered
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/health` | GET | Health check |
+| `/api/v1/documents/convert` | GET | RCE via Struts2 CVE-2017-5638 |
+| `/api/v1/links/preview` | GET | SSRF to cloud metadata (169.254.169.254) |
+| `/api/v1/users/search` | GET | SQL injection (H2 in-memory DB) |
+| `/api/v1/auth/login` | GET | Log4Shell CVE-2021-44228 via JNDI |
+| `/api/v1/sessions/import` | GET | Deserialization CVE-2020-1714 via Keycloak |
+| `/api/v1/workspace/sync` | GET | All 5 vuln classes + shipping call in one transaction |
+| `/api/v1/shipping/estimate` | GET | Outbound HTTP to shipping service (skips if `SHIPPING_ADDR` not set) |
+
+### Conditionally registered (SHIPPING_API=true)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/shipping/info?tracking=SHIP-XXXXX` | GET | Simulated delivery schedule JSON |
+
+## Loadgen Behavior
+
+The built-in `loadgen.sh` fires vulnerability endpoints on independent schedules, controlled by the `secureappAttack` flagd feature flag:
+
+| Pace | Attack frequency | Shipping/Health |
+|------|-----------------|-----------------|
+| `minimal` (default) | Each vuln every ~3-12 hours | Every ~3-5 min |
+| `targeted` | SQLi + Log4Shell every ~10-15 min, others minimal | Every ~3-5 min |
+| `max` | All attacks every ~3-15 min | Every ~3-5 min |
+
+Shipping and health calls run at fixed intervals regardless of attack pace.
+
+## Standalone Deployment
+
+To run outside the Astronomy Shop:
+1. Remove or unset `SHIPPING_ADDR` — shipping calls will be skipped
+2. Set `OTEL_SERVICE_NAME` to whatever service name you want in APM
+3. Ensure `FLAGD_HOST` points to a reachable flagd instance, or loadgen falls back to `minimal` pace
+4. Without `SHIPPING_ADDR`, the entrypoint skips the shipping wait entirely and starts immediately


### PR DESCRIPTION
## Summary
- Add optional `/api/v1/shipping/info` endpoint to secureapp-loadgen, gated by `SHIPPING_API` env var (from `workshop-secret`)
- Endpoint calls real shipping service and wraps response in instrumented `buildDeliverySchedule` span, creating trace chain: `frontend-proxy → shipping-api → shipping`
- Frontend-proxy routes `/shipping/` to secureapp-loadgen via new envoy cluster
- Astronomy-loadgen calls shipping API randomly every 34s–1m45s via browser fetch (generates RUM spans)
- Removed shipping timer from `loadgen.sh` — shipping traffic now driven by inbound calls
- Added flagd `v2` filter rules to collector values (fixes flagd appearing in APM dependency map)
- Skip shipping wait in `entrypoint.sh` when `SHIPPING_ADDR` not set (fast standalone startup)
- Added `usage.md` documenting service identity, configuration, and JAVA_TOOL_OPTIONS

## Files changed
- `src/secureapp-loadgen/` — Java app, loadgen.sh, entrypoint.sh, k8s manifest, pom.xml, usage.md
- `src/frontend-proxy/` — envoy.tmpl.yaml, k8s manifest, start.sh
- `src/astronomy-loadgen/` — k8s manifest (ConfigMap script + deployment env)
- `kubernetes/` — example-secrets.yaml, 2.0.2-values.yaml

## Test plan
- [ ] Set `shipping_api: "true"` in workshop-secret
- [ ] `curl frontend-proxy:8080/shipping/?tracking=SHIP-99999` returns delivery schedule JSON with embedded shipping quote
- [ ] APM shows trace chain: `frontend-proxy → shipping-api → shipping` with `buildDeliverySchedule` internal span
- [ ] Astronomy-loadgen logs show `📦 Fetching shipping info` at random intervals (34s–1m45s)
- [ ] With `shipping_api` unset: endpoint returns 404, loadgen skips shipping calls
- [ ] Flagd no longer appears in APM dependency map