### PR TITLE
fix(astronomy-loadgen): populate Splunk RUM funnel with distinct user journeys

### DIFF
--- a/kubernetes/splunk-astronomy-shop-2.0.3-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.3-values.yaml
@@ -1,0 +1,326 @@
+clusterReceiver:
+  extraEnvs:
+  - name: WORKSHOP_REALM
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: realm
+  - name: WORKSHOP_ENVIRONMENT
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: instance
+  # Disabled eventsEnabled and k8s_objects - these generate non-HEC data
+  # that gets refused by Splunk Platform endpoints
+  eventsEnabled: true
+
+agent:
+  extraEnvs:
+  - name: WORKSHOP_REALM
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: realm
+  - name: WORKSHOP_ENVIRONMENT
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: instance
+  config:
+    receivers:
+      receiver_creator:
+        watch_observers: [k8s_observer]
+        receivers:
+          mysql/online-boutique:
+            rule: type == "port" && pod.name matches "mysql" && port == 3306
+            config:
+              tls:
+                insecure: true
+              username: root
+              password: root
+              database: LxvGChW075
+          redis:
+            rule: type == "port" && pod.name matches "(redis|valkey)-cart" && port == 6379
+            config:
+              endpoint: '`endpoint`'
+              collection_interval: 10s
+          # SQL Server receivers - discovered by agent on same node as database pod
+          sqlserver/shopshim:
+            rule: type == "port" && pod.name matches "shop-dc-shim-db" && port == 1433
+            config:
+              collection_interval: 10s
+              top_query_collection:
+                lookback_time: 300s
+              username: sa
+              password: ShopPass123!
+              server: '`host`'
+              port: 1433
+              resource_attributes:
+                sqlserver.instance.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+              metrics:
+                sqlserver.batch.request.rate:
+                  enabled: true
+                sqlserver.batch.sql_compilation.rate:
+                  enabled: true
+                sqlserver.batch.sql_recompilation.rate:
+                  enabled: true
+                sqlserver.database.count:
+                  enabled: true
+                sqlserver.database.io:
+                  enabled: true
+                sqlserver.database.latency:
+                  enabled: true
+                sqlserver.database.operations:
+                  enabled: true
+                sqlserver.deadlock.rate:
+                  enabled: true
+                sqlserver.lock.wait.count:
+                  enabled: true
+                sqlserver.lock.wait.rate:
+                  enabled: true
+                sqlserver.os.wait.duration:
+                  enabled: true
+                sqlserver.page.buffer_cache.hit_ratio:
+                  enabled: true
+                sqlserver.processes.blocked:
+                  enabled: true
+                sqlserver.resource_pool.disk.operations:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.read.rate:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.write.rate:
+                  enabled: true
+                sqlserver.user.connection.count:
+                  enabled: true
+          sqlserver/fraud:
+            rule: type == "port" && pod.name matches "sql-server-fraud" && port == 1433
+            config:
+              collection_interval: 10s
+              top_query_collection:
+                lookback_time: 120s
+              username: sa
+              password: "ChangeMe_SuperStrong123!"
+              server: '`host`'
+              port: 1433
+              resource_attributes:
+                sqlserver.instance.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+              metrics:
+                sqlserver.batch.request.rate:
+                  enabled: true
+                sqlserver.batch.sql_compilation.rate:
+                  enabled: true
+                sqlserver.batch.sql_recompilation.rate:
+                  enabled: true
+                sqlserver.database.count:
+                  enabled: true
+                sqlserver.database.io:
+                  enabled: true
+                sqlserver.database.latency:
+                  enabled: true
+                sqlserver.database.operations:
+                  enabled: true
+                sqlserver.deadlock.rate:
+                  enabled: true
+                sqlserver.lock.wait.count:
+                  enabled: true
+                sqlserver.lock.wait.rate:
+                  enabled: true
+                sqlserver.os.wait.duration:
+                  enabled: true
+                sqlserver.page.buffer_cache.hit_ratio:
+                  enabled: true
+                sqlserver.processes.blocked:
+                  enabled: true
+                sqlserver.resource_pool.disk.operations:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.read.rate:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.write.rate:
+                  enabled: true
+                sqlserver.user.connection.count:
+                  enabled: true
+          # PostgreSQL receiver - discovered by agent on same node as database pod
+          postgresql/main:
+            rule: type == "port" && pod.name matches "postgres" && port == 5432
+            resource_attributes:
+              # Inject pod name for fallback identification in transform rules
+              k8s.pod.name: '`pod.name`'
+              # Inject database name from pod annotation
+              db.name: '`pod.annotations["splunk.com/postgresql.database"]`'
+            config:
+              endpoint: '`endpoint`'
+              transport: tcp
+              username: root
+              password: otel
+              databases: '`pod.annotations["splunk.com/postgresql.database"]`'
+              tls:
+                insecure: true
+              collection_interval: 10s
+              resource_attributes:
+                postgresql.database.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+              metrics:
+                postgresql.commits:
+                  enabled: true
+                postgresql.operations:
+                  enabled: true
+                postgresql.deadlocks:
+                  enabled: true
+                postgresql.connection.max:
+                  enabled: true
+    exporters:
+      # Exports dbmon events as logs
+      otlp_http/dbmon:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+          X-splunk-instrumentation-library: dbmon
+        logs_endpoint: https://ingest.${WORKSHOP_REALM}.signalfx.com/v3/event
+        sending_queue:
+          batch:
+            flush_timeout: 15s
+            max_size: 10485760 # 10 MiB
+            sizer: bytes
+    processors:
+      # Inject environment as a resource attribute for traces
+      resource/add_environment:
+        attributes:
+          - key: deployment.environment
+            value: ${WORKSHOP_ENVIRONMENT}
+            action: upsert
+      filter/drop_flagd:
+        traces:
+          span:
+          - attributes["rpc.method"] == "EventStream"
+          - attributes["rpc.method"] == "ResolveAll"
+          - attributes["rpc.method"] == "ResolveBoolean"
+          - attributes["rpc.method"] == "ResolveFloat"
+          - attributes["rpc.method"] == "ResolveInt"
+          - attributes["http.url"] == "http://flagd:8016/ofrep/v1/evaluate/flags/loadGeneratorFloodHomepage"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v1.Service/ResolveBoolean"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v2.Service/ResolveBoolean"
+          - attributes["otel.scope.name"] == "flagd.evaluation.v1"
+          - attributes["otel.scope.name"] == "flagd.evaluation.v2"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v1.Service/EventStream"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v2.Service/EventStream"
+          - attributes["url.path"] == "/live/longpoll"
+      transform/dc_not_error:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            statements:
+              # Treat "DC" (Downstream Connection closed) as normal, not error
+              # This happens when users navigate away before response completes
+              - set(status.code, STATUS_CODE_UNSET) where attributes["response_flags"] == "DC"
+              - set(attributes["error"], "false") where attributes["response_flags"] == "DC"
+              - set(name, Concat([name, " (user navigated away)"], "")) where attributes["response_flags"] == "DC"
+              # Also handle egress cancellations (proxy cancels outbound when client disconnects)
+              - set(status.code, STATUS_CODE_UNSET) where attributes["canceled"] == "true"
+              - set(attributes["error"], "false") where attributes["canceled"] == "true"
+              - set(name, Concat([name, " (backend interaction terminated due to client disconnect)"], "")) where attributes["canceled"] == "true"
+      # Transform processor for dbmon - sets service.instance.id for database identification
+      transform/dbmon:
+        error_mode: ignore
+        metric_statements:
+          # SQL Server: use instance name for identification
+          - conditions:
+              - resource.attributes["sqlserver.instance.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["sqlserver.instance.name"]], ""))
+          # PostgreSQL database-level metrics: use database name for identification
+          - conditions:
+              - resource.attributes["postgresql.database.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["postgresql.database.name"]], ""))
+          # PostgreSQL fallback: use injected db.name from pod annotation
+          - conditions:
+              - resource.attributes["db.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["db.name"]], ""))
+          # PostgreSQL last resort: use k8s pod name
+          - conditions:
+              - resource.attributes["k8s.pod.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["db.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
+        log_statements:
+          # SQL Server: use instance name for identification
+          - conditions:
+              - resource.attributes["sqlserver.instance.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["sqlserver.instance.name"]], ""))
+          # PostgreSQL database-level logs: use database name for identification
+          - conditions:
+              - resource.attributes["postgresql.database.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["postgresql.database.name"]], ""))
+          # PostgreSQL fallback: use injected db.name from pod annotation
+          - conditions:
+              - resource.attributes["db.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["db.name"]], ""))
+          # PostgreSQL last resort: use k8s pod name
+          - conditions:
+              - resource.attributes["k8s.pod.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["db.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
+
+    service:
+      pipelines:
+        metrics:
+          exporters: [signalfx]
+          processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
+          receivers: [host_metrics, kubeletstats, otlp, receiver_creator]
+        traces:
+          exporters: [signalfx, otlp_http]
+          processors: [memory_limiter, filter/drop_flagd, transform/dc_not_error, k8s_attributes, batch, resourcedetection, resource, resource/add_environment]
+          receivers: [otlp, jaeger, zipkin]
+        # DBMon logs pipeline - sends query samples and top queries to Splunk O11y
+        logs/dbmon:
+          receivers: [receiver_creator]
+          processors: [memory_limiter, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
+          exporters: [otlp_http/dbmon]
+
+logsCollection:
+  extraFileLogs:
+    filelog/syslog:
+      include: [/var/log/syslog]
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.source: /var/log/syslog
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: syslog
+    filelog/auth_log:
+      include: [/var/log/auth.log]
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.source: /var/log/auth.log
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: auth_log

--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -40,6 +40,8 @@ data:
           '--disable-renderer-backgrounding',
           '--memory-pressure-off',
           '--aggressive-cache-discard',
+          '--ignore-certificate-errors',
+          '--allow-insecure-localhost',
           `--user-agent=${customUserAgent}`
         ]
       });
@@ -116,8 +118,13 @@ data:
     async function runOnce() {
       const browser = await ensureBrowser();
       let page;
+      let ctx;
       try {
-        page = await browser.newPage();
+        // Fresh browser context per cycle so localStorage / cookies / session
+        // ID reset between cycles. Otherwise every cycle reuses the same RUM
+        // session ID and the funnel sees a single user looping forever.
+        ctx = await browser.createBrowserContext();
+        page = await ctx.newPage();
         page.setDefaultNavigationTimeout(45000);
         page.setDefaultTimeout && page.setDefaultTimeout(30000);
 
@@ -134,6 +141,14 @@ data:
         const base = buildBaseUrl();
         const productsToOrder = getRandomProducts();
         console.log(`🛒 Ordering ${productsToOrder.length} product(s): ${productsToOrder.join(', ')}`);
+
+        // Visit homepage first so the user enters the sequential RUM funnel
+        // at step 1. Without this the loadgen lands on /product/<id> and the
+        // funnel records 0 conversions because step 1 is never satisfied.
+        const homeUrl = base.replace(/\/+$/, '/');
+        console.log(`🏠 Visiting homepage ${homeUrl}`);
+        await page.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+        await delay(1500);
 
         // Loop through each product and add to cart
         for (const productId of productsToOrder) {
@@ -272,6 +287,10 @@ data:
 
         if (orderResult === 'success') {
           console.log('🎉 Order completed successfully!');
+          // Confirmation page useEffect fires the `order.confirmed` RUM span
+          // asynchronously. Wait so the RUM batcher can flush the beacon
+          // before the page / context is torn down.
+          await delay(5000);
         } else if (orderResult === 'error-modal') {
           console.log('⚠️ Error modal detected - closing it to continue...');
           await page.click('#modal-close-btn');
@@ -285,10 +304,13 @@ data:
             page.removeAllListeners();
             await page.close({ runBeforeUnload: true }).catch(()=>{});
           }
+          if (ctx) {
+            await ctx.close().catch(()=>{});
+          }
         } catch (e) {
           console.error('⚠️ Error closing page:', e.message);
         }
-        console.log('✅ Page closed cleanly. Browser will be reused for next cycle.');
+        console.log('✅ Page + context closed cleanly. Browser will be reused for next cycle.');
       }
     }
 
@@ -331,6 +353,11 @@ spec:
         image: ghcr.io/splunk/online-boutique/rumloadgen:5.6
         imagePullPolicy: Always
         env:
+        # NOTE: For RUM funnels that filter on the public ingress URL (e.g.
+        # `https://astronomy-shop.example.com`), override this value per
+        # deployment so the loadgen browser navigates to the same origin as
+        # real users. The in-cluster default below works for traffic-only
+        # generation but produces RUM events tagged with the internal URL.
         - name: RUM_FRONTEND_IP
           value: "http://frontend-proxy:8080"
         - name: CYCLE_DELAY_MS

--- a/src/frontend/pages/order/confirmation/[orderId]/index.tsx
+++ b/src/frontend/pages/order/confirmation/[orderId]/index.tsx
@@ -48,9 +48,13 @@ const Checkout: NextPage = () => {
         span.end();
       } else if (orderId) {
         // Success case - order confirmed
-        const span = tracer.startSpan('order.confirmed', {
+        // Span name kept as CamelCase `OrderConfirmed` to stay consistent with
+        // the other RUM workflow spans (`AddToCart`, `PlaceOrder`) so DEA
+        // funnel chips that match on the literal span name still hit. The
+        // backend APM span uses dotted `order.confirmed` independently.
+        const span = tracer.startSpan('OrderConfirmed', {
           attributes: {
-            'workflow.name': 'order.confirmed',
+            'workflow.name': 'OrderConfirmed',
             'order.id': orderId,
             'order.items_count': items.length,
             'order.total_items': items.reduce((sum, item) => sum + item.item.quantity, 0),


### PR DESCRIPTION
## Summary
Puppeteer loadgen produced traffic but the Splunk RUM DEA funnel (Homepage → Product detail → Add to cart → Place order → Order confirmed) stayed empty. Four bugs in `src/astronomy-loadgen/astronomy-loadgen-k8s.yaml` kept the funnel from populating.

## Fixes
- **Per-cycle browser context** (`browser.createBrowserContext()` + `ctx.close()`): the loadgen reused one `globalBrowser`, so localStorage and the RUM session ID survived across cycles. The funnel saw one user looping for hours instead of many users completing the flow.
- **Visit homepage `/` first**: script went straight to `/product/<id>`, skipping funnel step 1. A sequential funnel that misses step 1 drops every later step to zero.
- **5s wait after order success**: the confirmation page `useEffect` fires the `order.confirmed` RUM span asynchronously; previously the page was torn down before the RUM batcher flushed the beacon.
- **`--ignore-certificate-errors` / `--allow-insecure-localhost` launch args**: lets the loadgen drive deployments whose public ingress uses a self-signed cert. Without these Chromium crashed with `TargetCloseError` on the first navigation.

Also adds a comment next to `RUM_FRONTEND_IP` documenting that any deployment whose RUM funnel filters on the public ingress URL must override this env var so the loadgen browser visits the same origin as real users — otherwise events are tagged with `http://frontend-proxy:8080` and never match the funnel filter.

## Test plan
- [x] Patched ConfigMap applied live to astronomy-shop-eu; loadgen cycles run end-to-end (`🏠 Visiting homepage` → product visits → `Add To Cart` → `Place Order` → `Order completed`)
- [x] Each cycle observed with a unique RUM session ID (`8c416478…`, `c23bd7af…`, `5cef8b63…`, …) instead of one persistent ID
- [x] `Order confirmation span created` console log observed before page teardown
- [x] RUM beacons return HTTP 200 to `rum-ingest.eu0.observability.splunkcloud.com/v1/{rumotlp,rumreplay}`
- [x] DEA funnel populated: Homepage → Product detail → Add to cart → Place order → Order confirmed steps all advance
- [ ] Verify funnel on at least one other deployment that uses the default in-cluster `RUM_FRONTEND_IP`