### PR TITLE
June 3 updates: payment A/B reporting, fraud-detection DB bounded growth, demo prune script

### DIFF
--- a/.github/scripts/show-image-versions.py
+++ b/.github/scripts/show-image-versions.py
@@ -110,8 +110,21 @@ def get_service_versions() -> List[Tuple[str, str, str]]:
         if not service_dir.is_dir():
             continue
 
-        # Look for [service]-k8s.yaml
         service_name = service_dir.name
+
+        # Payment uses A/B variants stitched into the released manifest;
+        # the single payment-k8s.yaml is a legacy fallback never deployed.
+        # Report the variants that actually ship.
+        if service_name == 'payment':
+            variant_a = service_dir / 'payment-vA-k8s.yaml'
+            variant_b = service_dir / 'payment-vB-k8s.yaml'
+            if variant_a.exists() and variant_b.exists():
+                for variant_path in (variant_a, variant_b):
+                    service, image, version = extract_image_from_manifest(variant_path)
+                    versions.append((service, image, version))
+                continue
+
+        # Look for [service]-k8s.yaml
         manifest_path = service_dir / f"{service_name}-k8s.yaml"
 
         if manifest_path.exists():

--- a/.github/scripts/update-manifest-images.py
+++ b/.github/scripts/update-manifest-images.py
@@ -11,42 +11,46 @@ import sys
 import re
 import os
 
-def update_manifest_image(service, registry, image_name, version):
-    """Update the image line in a service's k8s manifest."""
-    manifest_path = f"src/{service}/{service}-k8s.yaml"
-
+def _patch_file(manifest_path, new_image):
+    """Rewrite the image line in a single manifest file."""
     if not os.path.exists(manifest_path):
         print(f"Warning: Manifest not found: {manifest_path}")
         return False
 
-    # Read the manifest
     with open(manifest_path, 'r') as f:
         content = f.read()
 
-    # New image reference
-    new_image = f"{registry}/{image_name}:{version}"
-
-    # Pattern to match image lines (handles various registry formats)
     # Matches: image: ghcr.io/*/anything:any-tag
     pattern = r'(\s+image:\s+)ghcr\.io/[^\s]+:\S+'
-
-    # Replace with new image
-    updated_content, count = re.subn(
-        pattern,
-        rf'\1{new_image}',
-        content
-    )
+    updated_content, count = re.subn(pattern, rf'\1{new_image}', content)
 
     if count > 0:
-        # Write back
         with open(manifest_path, 'w') as f:
             f.write(updated_content)
         print(f"✅ Updated {manifest_path}")
         print(f"   New image: {new_image}")
         return True
-    else:
-        print(f"⚠️  No image line found in {manifest_path}")
-        return False
+
+    print(f"⚠️  No image line found in {manifest_path}")
+    return False
+
+
+def update_manifest_image(service, registry, image_name, version):
+    """Update the image line in a service's k8s manifest(s)."""
+    new_image = f"{registry}/{image_name}:{version}"
+
+    # Payment ships as A/B variants; stitch reads payment-vA / payment-vB.
+    # Keep payment-k8s.yaml in sync too (legacy fallback path).
+    if service == 'payment':
+        targets = [
+            f"src/{service}/payment-vA-k8s.yaml",
+            f"src/{service}/payment-vB-k8s.yaml",
+            f"src/{service}/{service}-k8s.yaml",
+        ]
+        results = [_patch_file(p, new_image) for p in targets]
+        return any(results)
+
+    return _patch_file(f"src/{service}/{service}-k8s.yaml", new_image)
 
 def main():
     if len(sys.argv) != 5:

--- a/scripts/prune-demo.sh
+++ b/scripts/prune-demo.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Demo maintenance — bound volume growth on long-running k3d clusters.
+#
+# Safe to run on cron (e.g. hourly). Default mode is non-destructive:
+#   - prune unused containerd images + exited containers on each k3d node
+#   - report DB sizes
+#   - run online maintenance (PostgreSQL VACUUM, SQL Server tlog shrink if SIMPLE)
+#
+# --aggressive flag additionally:
+#   - DBCC SHRINKFILE on SQL Server data file (brief I/O spike)
+#   - PostgreSQL VACUUM FULL (locks tables — pods may stall briefly)
+#   - Kafka pod restart to drop topic backlog (ephemeral, no PVC)
+#
+# Usage:
+#   ./prune-demo.sh                          # safe maintenance
+#   ./prune-demo.sh --aggressive             # also do disruptive reclaim
+#   ./prune-demo.sh --cluster other-cluster  # different k3d cluster name
+#
+# Requires: kubectl context pointing at the target cluster, sudo docker
+# access for k3d node exec.
+
+set -euo pipefail
+
+CLUSTER="${CLUSTER:-astronomyshop-eu}"
+AGGRESSIVE=0
+SQL_USER="${SQL_USER:-sa}"
+SQL_PASS="${SQL_PASS:-ChangeMe_SuperStrong123!}"
+SQL_DB="${SQL_DB:-FraudDetection}"
+PG_USER="${PG_USER:-otelu}"
+PG_DB="${PG_DB:-otel}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --aggressive)  AGGRESSIVE=1; shift ;;
+    --cluster)     CLUSTER="$2"; shift 2 ;;
+    -h|--help)     sed -n '2,25p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+# ----------------------------------------------------------------------
+log "k3d node prune — containerd unused images + exited containers"
+# ----------------------------------------------------------------------
+NODES=$(sudo docker ps --filter "name=k3d-${CLUSTER}-cluster-(server|agent)" \
+        --format '{{.Names}}' | sort)
+for n in $NODES; do
+  echo "-- $n --"
+  sudo docker exec "$n" sh -c '
+    BEFORE=$(du -sh /var/lib/rancher/k3s/agent/containerd 2>/dev/null | cut -f1)
+    crictl rmi --prune 2>&1 | grep -c "^Deleted:" | xargs -I{} echo "images pruned: {}"
+    EX=$(crictl ps -a -q --state exited 2>/dev/null)
+    if [ -n "$EX" ]; then
+      crictl rm $EX >/dev/null 2>&1
+      echo "exited containers removed: $(echo "$EX" | wc -l)"
+    fi
+    AFTER=$(du -sh /var/lib/rancher/k3s/agent/containerd 2>/dev/null | cut -f1)
+    echo "containerd: $BEFORE -> $AFTER"
+  '
+done
+
+# ----------------------------------------------------------------------
+log "SQL Server (fraud-detection) — sizes + tlog maintenance"
+# ----------------------------------------------------------------------
+SQLCMD='kubectl exec sql-server-fraud-0 -- /opt/mssql-tools18/bin/sqlcmd -S localhost -U '"$SQL_USER"' -P '"$SQL_PASS"' -C -h -1 -W'
+
+eval "$SQLCMD -Q \"SET NOCOUNT ON;
+  SELECT name, recovery_model_desc FROM sys.databases WHERE name='${SQL_DB}';
+  USE ${SQL_DB};
+  SELECT name + ' ' + type_desc + ' ' + FORMAT(size*8.0/1024,'N1') + ' MB'
+    FROM sys.database_files;
+  SELECT 'OrderLogs rows='+FORMAT(COUNT(*),'N0') FROM OrderLogs;
+  SELECT 'FraudAlerts rows='+FORMAT(COUNT(*),'N0') FROM FraudAlerts;\""
+
+# Ensure SIMPLE recovery (idempotent — no-op if already SIMPLE)
+eval "$SQLCMD -Q \"ALTER DATABASE ${SQL_DB} SET RECOVERY SIMPLE;\""
+
+# Shrink the transaction log (always safe under SIMPLE — only reclaims free space)
+eval "$SQLCMD -d ${SQL_DB} -Q \"DBCC SHRINKFILE (${SQL_DB}_log, 64);\"" \
+  | tail -2
+
+if [ "$AGGRESSIVE" -eq 1 ]; then
+  echo "-- aggressive: shrink data file (brief I/O hit) --"
+  eval "$SQLCMD -d ${SQL_DB} -Q \"DBCC SHRINKFILE (${SQL_DB}, 0, TRUNCATEONLY);\"" \
+    | tail -2
+fi
+
+# ----------------------------------------------------------------------
+log "PostgreSQL (product-catalog) — sizes + VACUUM"
+# ----------------------------------------------------------------------
+PSQL='kubectl exec deploy/postgresql -- psql -U '"$PG_USER"' -d '"$PG_DB"' -t -A -c'
+
+eval "$PSQL \"SELECT datname || ' ' || pg_size_pretty(pg_database_size(datname))
+              FROM pg_database WHERE datname NOT IN ('template0','template1');\""
+
+if [ "$AGGRESSIVE" -eq 1 ]; then
+  echo "-- aggressive: VACUUM FULL (locks tables briefly) --"
+  eval "$PSQL 'VACUUM FULL;'"
+else
+  # Online vacuum — no locks, reclaims dead tuples back to the file system
+  # only when at the table tail (otherwise marks space reusable in-place).
+  eval "$PSQL 'VACUUM (ANALYZE);'"
+fi
+
+# ----------------------------------------------------------------------
+log "Valkey (cart) — memory + key count"
+# ----------------------------------------------------------------------
+kubectl exec deploy/valkey-cart -- valkey-cli INFO memory \
+  | grep -E '^used_memory_human|^maxmemory_human' || true
+kubectl exec deploy/valkey-cart -- valkey-cli DBSIZE
+
+# ----------------------------------------------------------------------
+log "Kafka — log dir sizes"
+# ----------------------------------------------------------------------
+kubectl exec deploy/kafka -- sh -c '
+  echo "topic data: $(du -sh /tmp/kafka-logs 2>/dev/null | cut -f1)"
+  echo "broker logs: $(du -sh /opt/kafka/logs 2>/dev/null | cut -f1)"
+'
+
+if [ "$AGGRESSIVE" -eq 1 ]; then
+  echo "-- aggressive: restarting kafka to drop topic backlog (ephemeral, no PVC) --"
+  kubectl rollout restart deploy/kafka
+  kubectl rollout status  deploy/kafka --timeout=120s
+fi
+
+log "done. Re-run \`du -sh /var/lib/docker/volumes/*\` on the host to confirm reclaim."

--- a/src/fraud-detection/fraud-detection-k8s.yaml
+++ b/src/fraud-detection/fraud-detection-k8s.yaml
@@ -71,9 +71,9 @@ spec:
         - name: FRAUD_DETECTION_RATE
           value: '80'
         - name: CLEANUP_RETENTION_DAYS
-          value: '7'
+          value: '4'
         - name: CLEANUP_INTERVAL_HOURS
-          value: '24'
+          value: '6'
         - name: FRAUD_MUTATION_PERCENTAGE
           value: '25'
         - name: BAD_QUERY_PERCENTAGE

--- a/src/fraud-detection/sql/init-database.sql
+++ b/src/fraud-detection/sql/init-database.sql
@@ -11,6 +11,14 @@ BEGIN
 END
 GO
 
+-- Demo workload: no point-in-time recovery needed. SIMPLE recovery lets
+-- the transaction log auto-truncate at every checkpoint so it stays
+-- bounded. Under FULL recovery (SQL Server default) the tlog grows
+-- forever until a log backup runs — on this demo it hit 392MB / 200MB
+-- data within 5 days.
+ALTER DATABASE FraudDetection SET RECOVERY SIMPLE;
+GO
+
 USE FraudDetection;
 GO
 

--- a/src/fraud-detection/src/main/kotlin/frauddetection/DatabaseCleanup.kt
+++ b/src/fraud-detection/src/main/kotlin/frauddetection/DatabaseCleanup.kt
@@ -7,15 +7,34 @@ package frauddetection
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.sql.Connection
+import java.sql.SQLException
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
+data class CleanupResult(val orderLogsDeleted: Int, val fraudAlertsDeleted: Int) {
+    val total: Int get() = orderLogsDeleted + fraudAlertsDeleted
+}
+
 class DatabaseCleanup {
     private val logger: Logger = LogManager.getLogger(DatabaseCleanup::class.java)
-    private val scheduler = Executors.newSingleThreadScheduledExecutor()
+    private val scheduler = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "db-cleanup").apply {
+            isDaemon = true
+            // Low priority so Kafka consume loop preempts under contention.
+            priority = Thread.MIN_PRIORITY
+        }
+    }
 
-    fun startCleanupScheduler(retentionDays: Int = 7, intervalHours: Long = 24) {
-        logger.info("Starting database cleanup scheduler: retentionDays=$retentionDays, intervalHours=$intervalHours")
+    fun startCleanupScheduler(retentionDays: Int = 4, intervalHours: Long = 6) {
+        val firstFireAt = Instant.now().plus(intervalHours, ChronoUnit.HOURS)
+        logger.info(
+            "Database cleanup scheduler started: retentionDays=$retentionDays, " +
+                "intervalHours=$intervalHours, firstFireAt=$firstFireAt " +
+                "(batched DELETE TOP($BATCH_SIZE), lockTimeout=${LOCK_TIMEOUT_MS}ms)"
+        )
 
         scheduler.scheduleAtFixedRate({
             try {
@@ -23,55 +42,79 @@ class DatabaseCleanup {
             } catch (e: Exception) {
                 logger.error("Error during scheduled cleanup", e)
             }
-        }, 1, intervalHours, TimeUnit.HOURS)
+        }, intervalHours, intervalHours, TimeUnit.HOURS)
     }
 
-    fun cleanupOldRecords(retentionDays: Int): Int {
-        return try {
+    fun cleanupOldRecords(retentionDays: Int): CleanupResult {
+        val orderLogsDeleted = deleteOlderThan("OrderLogs", "consumed_at", retentionDays)
+        val fraudAlertsDeleted = deleteOlderThan("FraudAlerts", "created_at", retentionDays)
+        logger.info(
+            "Cleanup run complete: OrderLogs deleted=$orderLogsDeleted, " +
+                "FraudAlerts deleted=$fraudAlertsDeleted, retentionDays=$retentionDays"
+        )
+        return CleanupResult(orderLogsDeleted, fraudAlertsDeleted)
+    }
+
+    private fun deleteOlderThan(table: String, timestampCol: String, retentionDays: Int): Int {
+        var total = 0
+        try {
             DatabaseConfig.getConnection().use { conn ->
-                val sql = """
-                    DELETE FROM OrderLogs
-                    WHERE consumed_at < DATEADD(DAY, -?, GETDATE())
-                """.trimIndent()
+                conn.createStatement().use { it.execute("SET LOCK_TIMEOUT $LOCK_TIMEOUT_MS") }
 
-                conn.prepareStatement(sql).use { stmt ->
-                    stmt.setInt(1, retentionDays)
-                    val deletedCount = stmt.executeUpdate()
+                val sql = "DELETE TOP ($BATCH_SIZE) FROM $table " +
+                    "WHERE $timestampCol < DATEADD(DAY, -?, GETDATE())"
 
-                    if (deletedCount > 0) {
-                        logger.info("Cleaned up $deletedCount old records (older than $retentionDays days)")
-                    } else {
-                        logger.debug("No old records to clean up")
+                while (true) {
+                    val rows = try {
+                        conn.prepareStatement(sql).use { stmt ->
+                            stmt.setInt(1, retentionDays)
+                            stmt.executeUpdate()
+                        }
+                    } catch (e: SQLException) {
+                        // SQL Server lock timeout = error 1222. Abandon batch,
+                        // retry next interval to avoid blocking the consume loop.
+                        logger.warn(
+                            "$table cleanup hit lock timeout (deleted=$total so far) — " +
+                                "will retry next interval. ${e.message}"
+                        )
+                        return total
                     }
-
-                    deletedCount
+                    total += rows
+                    if (rows < BATCH_SIZE) break
+                    Thread.sleep(SLEEP_BETWEEN_BATCHES_MS)
                 }
             }
         } catch (e: Exception) {
-            logger.error("Failed to cleanup old records", e)
-            0
+            logger.error("Failed cleanup on $table (deleted $total before error)", e)
         }
+        return total
     }
 
     fun cleanupAllRecords(): Int {
         return try {
             DatabaseConfig.getConnection().use { conn ->
-                val sql = "TRUNCATE TABLE OrderLogs"
+                val orderCount = countRows(conn, "OrderLogs")
+                val alertCount = countRows(conn, "FraudAlerts")
+
                 conn.createStatement().use { stmt ->
-                    stmt.execute(sql)
-                    logger.info("Truncated OrderLogs table (all records deleted)")
+                    stmt.execute("TRUNCATE TABLE OrderLogs")
+                    stmt.execute("TRUNCATE TABLE FraudAlerts")
                 }
 
-                // Get count that was deleted
-                val countSql = "SELECT COUNT(*) as cnt FROM OrderLogs"
-                conn.createStatement().use { stmt ->
-                    val rs = stmt.executeQuery(countSql)
-                    if (rs.next()) rs.getInt("cnt") else 0
-                }
+                val total = orderCount + alertCount
+                logger.info("Truncated OrderLogs ($orderCount rows) and FraudAlerts ($alertCount rows)")
+                total
             }
         } catch (e: Exception) {
-            logger.error("Failed to truncate OrderLogs", e)
+            logger.error("Failed to truncate tables", e)
             0
+        }
+    }
+
+    private fun countRows(conn: Connection, table: String): Int {
+        conn.createStatement().use { stmt ->
+            val rs = stmt.executeQuery("SELECT COUNT(*) FROM $table")
+            return if (rs.next()) rs.getInt(1) else 0
         }
     }
 
@@ -85,5 +128,11 @@ class DatabaseCleanup {
         } catch (e: InterruptedException) {
             scheduler.shutdownNow()
         }
+    }
+
+    companion object {
+        private const val BATCH_SIZE = 500
+        private const val SLEEP_BETWEEN_BATCHES_MS = 200L
+        private const val LOCK_TIMEOUT_MS = 5000
     }
 }

--- a/src/fraud-detection/src/main/kotlin/frauddetection/main.kt
+++ b/src/fraud-detection/src/main/kotlin/frauddetection/main.kt
@@ -88,8 +88,8 @@ fun main() {
     val badQueryPatterns = BadQueryPatterns()
 
     // Read configuration from environment variables
-    val cleanupRetentionDays = System.getenv("CLEANUP_RETENTION_DAYS")?.toIntOrNull() ?: 7
-    val cleanupIntervalHours = System.getenv("CLEANUP_INTERVAL_HOURS")?.toLongOrNull() ?: 24
+    val cleanupRetentionDays = System.getenv("CLEANUP_RETENTION_DAYS")?.toIntOrNull() ?: 4
+    val cleanupIntervalHours = System.getenv("CLEANUP_INTERVAL_HOURS")?.toLongOrNull() ?: 6
 
     // Fraud mutation percentage (5-90%)
     val fraudMutationPercentage = System.getenv("FRAUD_MUTATION_PERCENTAGE")?.toIntOrNull()?.coerceIn(5, 90) ?: 20
@@ -98,9 +98,8 @@ fun main() {
     // Bad query execution percentage (disabled by default)
     val badQueryPercentage = System.getenv("BAD_QUERY_PERCENTAGE")?.toIntOrNull()?.coerceIn(0, 100) ?: 0
 
-    // Start cleanup scheduler
+    // Start cleanup scheduler (logs first-fire timestamp + batch config)
     databaseCleanup.startCleanupScheduler(cleanupRetentionDays, cleanupIntervalHours)
-    logger.info("Cleanup scheduler started: retentionDays=$cleanupRetentionDays, intervalHours=$cleanupIntervalHours")
 
     var totalCount = 0L
     var fraudAlertCount = 0L


### PR DESCRIPTION
## Summary

Four targeted fixes for the demo's release reporting and the fraud-detection database growth on long-running clusters:

- **`fix(release-scripts)`** — `show-image-versions.py` was scanning the legacy `src/payment/payment-k8s.yaml` (pinned at `1.8.0`) so the GH Actions manifest summary kept flagging payment as "⚠️ Older" even though stitched releases ship `payment-vA`/`payment-vB` at the current SPLUNK-VERSION. Script is now payment-aware (reports both variants) and `update-manifest-images.py` patches vA + vB + the legacy file so all three stay in sync.

- **`fix(fraud-detection): bound DB growth`** — `FraudAlerts` had no retention path and `OrderLogs` cleanup was opaque (DEBUG-level logs, no startup signal). On `astronomy-shop-eu` the 5-day-old DB had 42k OrderLogs / 68k FraudAlerts and a tlog (392 MB) almost 2x the data file. `DatabaseCleanup.kt` rewritten:
  - Deletes from both tables. Always logs INFO with per-table counts.
  - Batched `DELETE TOP(500)` loop + 200ms sleep between batches → Kafka consume loop never blocks.
  - `SET LOCK_TIMEOUT 5000` → on contention the batch abandons and retries next interval.
  - Scheduler thread daemonised at `MIN_PRIORITY` so the main thread preempts under JVM contention.
  - Startup INFO log includes `firstFireAt` timestamp + batch config so operators can confirm cleanup is wired up.
  - `cleanupAllRecords` now `SELECT COUNT` **before** `TRUNCATE` (was counting after, always returning 0) and truncates both tables.
  - Defaults: retention 7→4 days, interval 24→6h (`main.kt` + `fraud-detection-k8s.yaml`).

- **`fix(fraud-detection): SIMPLE recovery`** — `init-database.sql` now sets `RECOVERY SIMPLE` on the FraudDetection DB. Under default FULL recovery the tlog grew unbounded because no log-backup job exists in the demo. SIMPLE auto-truncates the log at every checkpoint. Loses point-in-time restore, irrelevant for demo data.

- **`chore: prune-demo.sh`** — new `scripts/prune-demo.sh` for bounded volume growth on long-running k3d clusters. Default mode (safe for hourly cron) prunes unused containerd images per node, ensures SIMPLE recovery + shrinks SQL Server tlog, online `VACUUM (ANALYZE)` on Postgres, and reports DB sizes. `--aggressive` flag additionally runs `DBCC SHRINKFILE`, `VACUUM FULL`, and restarts the Kafka pod (drops its PVC-less topic backlog).

## Existing deployments

For clusters already running, one-time SQL is needed to flip the existing DB:

```sql
ALTER DATABASE FraudDetection SET RECOVERY SIMPLE;
DBCC SHRINKFILE (FraudDetection_log, 64);
```

`scripts/prune-demo.sh` runs both idempotently if you'd rather not connect manually.

## Test plan

- [ ] `prod-build-manifest` workflow re-run: confirm `payment-va` + `payment-vb` rows in the summary table (no more single "payment 1.8.0 ⚠️ Older").
- [ ] Build the fraud-detection image off this branch, deploy, confirm pod log line `Database cleanup scheduler started: retentionDays=4, intervalHours=6, firstFireAt=...`.
- [ ] After 6h interval fires, confirm INFO log `Cleanup run complete: OrderLogs deleted=N, FraudAlerts deleted=M`.
- [ ] Connect to SQL Server, confirm `SELECT recovery_model_desc FROM sys.databases WHERE name='FraudDetection'` returns `SIMPLE`.
- [ ] Run `scripts/prune-demo.sh` against a live cluster, verify no errors and reports size deltas.