### PR TITLE
feat(planning-lambda): per-env routing through shared gateway collector

### DIFF
--- a/planning-lambda/DEPLOY_INSTRUCTIONS.md
+++ b/planning-lambda/DEPLOY_INSTRUCTIONS.md
@@ -168,15 +168,67 @@ Replace the default config with the gateway config from this repo:
 sudo cp planning-lambda/collector/gateway-config.yaml /etc/otel/collector/splunk-otel-collector.conf
 ```
 
-Set the required environment variables in `/etc/otel/collector/splunk-otel-collector.conf.d/env`:
+Set the required environment variables in `/etc/otel/collector/splunk-otel-collector.conf.d/env`.
+
+The gateway now routes telemetry per env (`deployment.environment` resource
+attribute) to one of four Splunk Observability + HEC orgs: `dev-astronomy`,
+`astronomy-shop-eu`, `astronomy-shop-us`, plus a `default` fallback for
+unmatched envs. Lambdas stamp `deployment.environment = "<env>-lambda"` per
+invocation; the gateway promotes that signal attribute to a resource
+attribute and matches it in a routing connector.
+
+Four sets of five vars (20 total):
 
 ```bash
-SPLUNK_ACCESS_TOKEN=<your-access-token>
-SPLUNK_REALM=<your-realm>
-SPLUNK_HEC_URL=https://http-inputs-<instance>.splunkcloud.com
-SPLUNK_HEC_TOKEN=<your-hec-token>
-SPLUNK_INDEX=main
+SPLUNK_LISTEN_INTERFACE=0.0.0.0
+
+# --- dev-astronomy ---
+SPLUNK_REALM_DEV=<realm>
+SPLUNK_TOKEN_DEV=<o11y-access-token>
+SPLUNK_HEC_URL_DEV=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_DEV=<hec-token>
+SPLUNK_INDEX_DEV=main
+
+# --- astronomy-shop-eu ---
+SPLUNK_REALM_EU=<realm>
+SPLUNK_TOKEN_EU=<o11y-access-token>
+SPLUNK_HEC_URL_EU=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_EU=<hec-token>
+SPLUNK_INDEX_EU=main
+
+# --- astronomy-shop-us ---
+SPLUNK_REALM_US=<realm>
+SPLUNK_TOKEN_US=<o11y-access-token>
+SPLUNK_HEC_URL_US=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_US=<hec-token>
+SPLUNK_INDEX_US=main
+
+# --- default (catch-all for unmatched env) ---
+SPLUNK_REALM_DEFAULT=<realm>
+SPLUNK_TOKEN_DEFAULT=<o11y-access-token>
+SPLUNK_HEC_URL_DEFAULT=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_DEFAULT=<hec-token>
+SPLUNK_INDEX_DEFAULT=main
 ```
+
+Tokens live in the env file for initial rollout. AWS Secrets Manager / SSM
+Parameter Store integration is a follow-up after multi-env is validated.
+
+Routing flow:
+```
+Lambda OTLP --> gateway:4317 --> transform/promote_env_* (attr->resource)
+                              --> routing/{traces,metrics,logs}
+                              --> per-env pipeline
+                              --> otlphttp/<env> + splunk_hec/<env>
+```
+
+Unmatched envs (or pre-rollout Lambdas without the `env` payload field) fall
+through to `default` pipelines and also fan out to the `debug` exporter for
+visibility during cutover.
+
+DIAB note: DIAB deployments may require a parallel `gateway-config-diab.yaml`
+with the same routing-connector shape plus DIAB-specific exporter/auth
+quirks. Flagged as a follow-up; does not block initial multi-env rollout.
 
 Restart the collector:
 

--- a/planning-lambda/Planning_Init/handlers/analytics.py
+++ b/planning-lambda/Planning_Init/handlers/analytics.py
@@ -14,11 +14,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
 from shared.tracing import create_span
 from shared.logging import get_logger
+from shared.env import STAMPED_ATTR, UNKNOWN_ENV, LAMBDA_SUFFIX
 
 logger = get_logger("Planning_Init.analytics")
 
 
-def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]:
+def handle(body: Dict[str, Any], context: Any, tracer: Tracer, env_tagged: str = f"{UNKNOWN_ENV}{LAMBDA_SUFFIX}") -> Dict[str, Any]:
     """
     Handle analytics requests.
 
@@ -32,6 +33,7 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
         body: Request body.
         context: Lambda context.
         tracer: OpenTelemetry tracer.
+        env_tagged: Source env with "-lambda" suffix.
 
     Returns:
         API Gateway response dict.
@@ -39,6 +41,7 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
     with create_span("analytics.handle", kind=SpanKind.INTERNAL) as span:
         logger.info("Analytics handler called (stub)")
 
+        span.set_attribute(STAMPED_ATTR, env_tagged)
         span.set_attribute("handler.type", "analytics")
         span.set_attribute("handler.status", "stub")
 

--- a/planning-lambda/Planning_Init/handlers/forecasting.py
+++ b/planning-lambda/Planning_Init/handlers/forecasting.py
@@ -14,11 +14,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
 from shared.tracing import create_span
 from shared.logging import get_logger
+from shared.env import STAMPED_ATTR, UNKNOWN_ENV, LAMBDA_SUFFIX
 
 logger = get_logger("Planning_Init.forecasting")
 
 
-def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]:
+def handle(body: Dict[str, Any], context: Any, tracer: Tracer, env_tagged: str = f"{UNKNOWN_ENV}{LAMBDA_SUFFIX}") -> Dict[str, Any]:
     """
     Handle forecasting requests.
 
@@ -32,6 +33,7 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
         body: Request body.
         context: Lambda context.
         tracer: OpenTelemetry tracer.
+        env_tagged: Source env with "-lambda" suffix.
 
     Returns:
         API Gateway response dict.
@@ -39,6 +41,7 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
     with create_span("forecasting.handle", kind=SpanKind.INTERNAL) as span:
         logger.info("Forecasting handler called (stub)")
 
+        span.set_attribute(STAMPED_ATTR, env_tagged)
         span.set_attribute("handler.type", "forecasting")
         span.set_attribute("handler.status", "stub")
 

--- a/planning-lambda/Planning_Init/handlers/orders.py
+++ b/planning-lambda/Planning_Init/handlers/orders.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 from shared.tracing import create_span, get_current_trace_id, get_current_span_id
 from shared.logging import get_logger
 from shared.lambda_client import invoke_lambda
+from shared.env import STAMPED_ATTR, BARE_ENV_KEY, UNKNOWN_ENV, LAMBDA_SUFFIX
 
 logger = get_logger("Planning_Init.orders")
 
@@ -22,7 +23,7 @@ logger = get_logger("Planning_Init.orders")
 DOWNSTREAM_LAMBDA_ARN = os.getenv("DOWNSTREAM_LAMBDA_ARN", "")
 
 
-def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]:
+def handle(body: Dict[str, Any], context: Any, tracer: Tracer, env_tagged: str = f"{UNKNOWN_ENV}{LAMBDA_SUFFIX}") -> Dict[str, Any]:
     """
     Handle incoming orders from the K8s planning service.
 
@@ -30,11 +31,18 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
         body: Request body containing orders data.
         context: Lambda context.
         tracer: OpenTelemetry tracer.
+        env_tagged: Source env with "-lambda" suffix (e.g. "dev-astronomy-lambda").
+            Stamped on every span so the gateway collector can route by env.
 
     Returns:
         API Gateway response dict.
     """
+    # Bare env (no suffix) — round-tripped to caller + sent to downstream Lambdas.
+    env_raw = env_tagged[:-len(LAMBDA_SUFFIX)] if env_tagged.endswith(LAMBDA_SUFFIX) else env_tagged
+
     with create_span("orders.handle", kind=SpanKind.INTERNAL) as span:
+        span.set_attribute(STAMPED_ATTR, env_tagged)
+
         # Extract order data
         service = body.get("service", "unknown")
         timestamp = body.get("timestamp", "")
@@ -56,7 +64,7 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
         # Process orders
         processed = []
         for order in orders:
-            order_result = process_order(order, tracer)
+            order_result = process_order(order, tracer, env_tagged)
             processed.append(order_result)
 
         span.set_attribute("orders.processed", len(processed))
@@ -65,16 +73,18 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
         if DOWNSTREAM_LAMBDA_ARN:
             with create_span("orders.forward_downstream", kind=SpanKind.CLIENT) as fwd_span:
                 fwd_span.set_attribute("downstream.function", DOWNSTREAM_LAMBDA_ARN)
+                fwd_span.set_attribute(STAMPED_ATTR, env_tagged)
                 try:
                     downstream_payload = {
                         "source": "Planning_Init",
+                        BARE_ENV_KEY: env_raw,
                         "orders": processed,
                         "original_timestamp": timestamp
                     }
-                    result = invoke_lambda(DOWNSTREAM_LAMBDA_ARN, downstream_payload)
+                    result = invoke_lambda(DOWNSTREAM_LAMBDA_ARN, downstream_payload, env_raw=env_raw)
                     logger.info(
                         "Forwarded orders to downstream Lambda",
-                        extra={"downstream_arn": DOWNSTREAM_LAMBDA_ARN}
+                        extra={"downstream_arn": DOWNSTREAM_LAMBDA_ARN, "env": env_raw}
                     )
                 except Exception as e:
                     logger.error(f"Failed to forward to downstream: {e}")
@@ -87,11 +97,13 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
             "message": f"Processed {len(processed)} orders",
             "processed_count": len(processed),
             "source_service": service,
+            BARE_ENV_KEY: env_raw,
             "downstream_forwarded": bool(DOWNSTREAM_LAMBDA_ARN),
             "lambda": {
                 "function_name": function_name,
                 "trace_id": get_current_trace_id(),
                 "span_id": get_current_span_id(),
+                STAMPED_ATTR: env_tagged,
             },
             "orders_summary": [
                 {
@@ -108,13 +120,14 @@ def handle(body: Dict[str, Any], context: Any, tracer: Tracer) -> Dict[str, Any]
         }
 
 
-def process_order(order: Dict[str, Any], tracer: Tracer) -> Dict[str, Any]:
+def process_order(order: Dict[str, Any], tracer: Tracer, env_tagged: str = f"{UNKNOWN_ENV}{LAMBDA_SUFFIX}") -> Dict[str, Any]:
     """
     Process a single order.
 
     Args:
         order: Order data dict.
         tracer: OpenTelemetry tracer.
+        env_tagged: Source env with "-lambda" suffix.
 
     Returns:
         Processed order result.
@@ -122,6 +135,7 @@ def process_order(order: Dict[str, Any], tracer: Tracer) -> Dict[str, Any]:
     order_id = order.get("order_id", "unknown")
 
     with create_span(f"orders.process_single", kind=SpanKind.INTERNAL) as span:
+        span.set_attribute(STAMPED_ATTR, env_tagged)
         span.set_attribute("order.id", order_id)
 
         logger.info(f"Processing order: {order_id}")

--- a/planning-lambda/Planning_Init/lambda_function.py
+++ b/planning-lambda/Planning_Init/lambda_function.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 
 from shared.tracing import init_tracer, extract_context, create_span, force_flush
 from shared.logging import get_logger
+from shared.env import extract_env, stamp as stamp_env
 from opentelemetry.trace import SpanKind
 
 # Import handlers
@@ -89,6 +90,14 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
             span.set_attribute("request.body_size", len(json.dumps(body)))
 
+            # Extract per-invocation env (from body, ClientContext, SNS, or HTTP header)
+            # and stamp on root span so gateway collector can route by env.
+            env_raw = extract_env(body if isinstance(body, dict) else {}, context)
+            if env_raw == "unknown":
+                # Fall back to the full event for non-body sources (ClientContext, SNS).
+                env_raw = extract_env(event, context)
+            env_tagged = stamp_env(span, env_raw)
+
             # Log request info
             headers = event.get("headers", {}) or {}
             logger.info(
@@ -136,7 +145,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
             # Call handler
             logger.info(f"Routing to handler: {handler.__module__}.{handler.__name__}")
-            response = handler(body, context, tracer)
+            response = handler(body, context, tracer, env_tagged)
 
             # Ensure response has required fields
             if not isinstance(response, dict):

--- a/planning-lambda/collector/env.template
+++ b/planning-lambda/collector/env.template
@@ -1,0 +1,37 @@
+# Splunk OpenTelemetry Collector - Gateway env vars (multi-env routing)
+#
+# Deploy to: /etc/otel/collector/splunk-otel-collector.conf.d/env
+# Then: sudo systemctl restart splunk-otel-collector
+#
+# Loaded by the systemd unit and substituted into gateway-config.yaml.
+# Replace every <...> placeholder with the real value before saving.
+
+SPLUNK_LISTEN_INTERFACE=0.0.0.0
+
+# --- dev-astronomy ---
+SPLUNK_REALM_DEV=<realm>
+SPLUNK_TOKEN_DEV=<o11y-access-token>
+SPLUNK_HEC_URL_DEV=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_DEV=<hec-token>
+SPLUNK_INDEX_DEV=main
+
+# --- astronomy-shop-eu ---
+SPLUNK_REALM_EU=<realm>
+SPLUNK_TOKEN_EU=<o11y-access-token>
+SPLUNK_HEC_URL_EU=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_EU=<hec-token>
+SPLUNK_INDEX_EU=main
+
+# --- astronomy-shop-us ---
+SPLUNK_REALM_US=<realm>
+SPLUNK_TOKEN_US=<o11y-access-token>
+SPLUNK_HEC_URL_US=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_US=<hec-token>
+SPLUNK_INDEX_US=main
+
+# --- default (catch-all for unmatched env) ---
+SPLUNK_REALM_DEFAULT=<realm>
+SPLUNK_TOKEN_DEFAULT=<o11y-access-token>
+SPLUNK_HEC_URL_DEFAULT=https://http-inputs-<instance>.splunkcloud.com:443/services/collector
+SPLUNK_HEC_TOKEN_DEFAULT=<hec-token>
+SPLUNK_INDEX_DEFAULT=main

--- a/planning-lambda/collector/gateway-config-cloudwatch.yaml
+++ b/planning-lambda/collector/gateway-config-cloudwatch.yaml
@@ -1,0 +1,137 @@
+# Splunk OpenTelemetry Collector - Gateway Mode (CloudWatch Logs variant)
+#
+# Same as gateway-config.yaml but adds an `awscloudwatchlogs` receiver that
+# polls Lambda CloudWatch log groups and ships them to Splunk Cloud via HEC.
+# OTLP traces/metrics/logs from Lambda runtime instrumentation still flow
+# through the existing pipelines.
+#
+# Environment variables required (set in /etc/otel/collector/splunk-otel-collector.conf):
+#   SPLUNK_ACCESS_TOKEN      - Splunk Observability Cloud access token
+#   SPLUNK_REALM             - Splunk Observability Cloud realm (e.g., us0, us1, eu0)
+#   SPLUNK_LISTEN_INTERFACE  - Listen interface (default: 0.0.0.0)
+#   SPLUNK_HEC_URL           - Splunk Cloud HEC endpoint (e.g., https://<host>:8088/services/collector)
+#   SPLUNK_HEC_TOKEN         - Splunk Cloud HEC token
+#   SPLUNK_INDEX             - Target Splunk index
+#   AWS_REGION               - AWS region for CloudWatch Logs polling (e.g., us-east-1)
+#   LAMBDA_LOG_GROUP         - CloudWatch log group for the Lambda function (e.g., /aws/lambda/planning)
+#
+# The collector host must have IAM permissions: logs:DescribeLogGroups,
+# logs:DescribeLogStreams, logs:GetLogEvents, logs:FilterLogEvents on the
+# target log group(s).
+
+extensions:
+  health_check:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
+  zpages:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
+  headers_setter:
+    headers:
+      - action: upsert
+        key: X-SF-TOKEN
+        from_context: X-SF-TOKEN
+        default_value: "${SPLUNK_ACCESS_TOKEN}"
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+  awscloudwatchlogs:
+    region: "${AWS_REGION}"
+    log_groups:
+      - "${LAMBDA_LOG_GROUP}"
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 3000
+    spike_limit_mib: 1000
+
+  resource/add_environment:
+    attributes:
+      - action: insert
+        value: "demo"
+        key: deployment.environment
+
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+  attributes/logs:
+    actions:
+      - key: source
+        value: "lambda"
+        action: insert
+      - key: sourcetype
+        value: "_json"
+        action: insert
+
+  attributes/cloudwatch_logs:
+    actions:
+      - key: source
+        value: "aws:lambda"
+        action: insert
+      - key: sourcetype
+        value: "aws:cloudwatchlogs"
+        action: insert
+
+exporters:
+  # Traces and metrics to Splunk Observability Cloud via OTLP HTTP
+  otlphttp:
+    auth:
+      authenticator: headers_setter
+    traces_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/trace/otlp"
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/datapoint/otlp"
+
+  # OTLP-derived app logs to Splunk Cloud HEC
+  splunk_hec:
+    endpoint: "${SPLUNK_HEC_URL}"
+    token: "${SPLUNK_HEC_TOKEN}"
+    source: otel
+    sourcetype: _json
+    index: "${SPLUNK_INDEX}"
+    timeout: 10s
+    tls:
+      insecure_skip_verify: false
+
+  # CloudWatch-sourced Lambda logs to Splunk Cloud HEC (separate exporter so
+  # source/sourcetype defaults reflect the CloudWatch origin)
+  splunk_hec/cloudwatch:
+    endpoint: "${SPLUNK_HEC_URL}"
+    token: "${SPLUNK_HEC_TOKEN}"
+    source: "aws:lambda"
+    sourcetype: "aws:cloudwatchlogs"
+    index: "${SPLUNK_INDEX}"
+    timeout: 10s
+    tls:
+      insecure_skip_verify: false
+
+  # Debug exporter for troubleshooting (remove from pipelines when not needed)
+  debug:
+    verbosity: basic
+
+service:
+  extensions: [health_check, zpages, headers_setter]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource/add_environment]
+      exporters: [otlphttp, debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource/add_environment]
+      exporters: [otlphttp, debug]
+
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource/add_environment, attributes/logs]
+      exporters: [splunk_hec, debug]
+
+    logs/cloudwatch:
+      receivers: [awscloudwatchlogs]
+      processors: [memory_limiter, batch, resource/add_environment, attributes/cloudwatch_logs]
+      exporters: [splunk_hec/cloudwatch, debug]

--- a/planning-lambda/collector/gateway-config-cloudwatch.yaml
+++ b/planning-lambda/collector/gateway-config-cloudwatch.yaml
@@ -5,6 +5,13 @@
 # OTLP traces/metrics/logs from Lambda runtime instrumentation still flow
 # through the existing pipelines.
 #
+# TODO (multi-env follow-up): This file remains single-org. The main
+# gateway-config.yaml now routes by env (deployment.environment) across three
+# Splunk Observability + HEC orgs plus a default. Rewriting this variant for
+# multi-env requires tagging CloudWatch logs by env -- either via log-group
+# naming convention (e.g. /aws/lambda/planning-<env>) or content parsing.
+# Design + implement after the main multi-env OTLP path is validated.
+#
 # Environment variables required (set in /etc/otel/collector/splunk-otel-collector.conf):
 #   SPLUNK_ACCESS_TOKEN      - Splunk Observability Cloud access token
 #   SPLUNK_REALM             - Splunk Observability Cloud realm (e.g., us0, us1, eu0)

--- a/planning-lambda/collector/gateway-config.yaml
+++ b/planning-lambda/collector/gateway-config.yaml
@@ -1,24 +1,43 @@
-# Splunk OpenTelemetry Collector - Gateway Mode
-# Receives OTLP from Lambda functions and forwards to Splunk
+# Splunk OpenTelemetry Collector - Gateway Mode (Multi-Env Routing)
 #
-# Environment variables required (set in /etc/otel/collector/splunk-otel-collector.conf):
-#   SPLUNK_ACCESS_TOKEN      - Splunk Observability Cloud access token
-#   SPLUNK_REALM             - Splunk Observability Cloud realm (e.g., us0, us1, eu0)
-#   SPLUNK_LISTEN_INTERFACE  - Listen interface (default: 0.0.0.0)
+# Receives OTLP from Lambda functions, promotes the per-invocation
+# `deployment.environment` span/datapoint/log attribute to a resource attribute,
+# and routes telemetry to one of four Splunk Observability + HEC orgs based on
+# the env value. Lambdas stamp `deployment.environment = "<env>-lambda"` per
+# invocation, where <env> is the source K8s cluster (dev-astronomy,
+# astronomy-shop-eu, astronomy-shop-us). Anything unmatched falls through to
+# the `default` pipelines.
 #
-# The splunk_hec exporter uses hardcoded values below — update for your environment.
+# Required env vars (set in /etc/otel/collector/splunk-otel-collector.conf.d/env):
+#
+#   SPLUNK_LISTEN_INTERFACE          - Listen interface (default: 0.0.0.0)
+#
+#   # --- dev-astronomy ---
+#   SPLUNK_REALM_DEV                 - Splunk O11y realm (e.g. us0, us1, eu0)
+#   SPLUNK_TOKEN_DEV                 - Splunk O11y access token
+#   SPLUNK_HEC_URL_DEV               - HEC endpoint (https://<host>:8088/services/collector)
+#   SPLUNK_HEC_TOKEN_DEV             - HEC token
+#   SPLUNK_INDEX_DEV                 - HEC target index
+#
+#   # --- astronomy-shop-eu ---     (same five vars, _EU suffix)
+#   SPLUNK_REALM_EU, SPLUNK_TOKEN_EU, SPLUNK_HEC_URL_EU, SPLUNK_HEC_TOKEN_EU, SPLUNK_INDEX_EU
+#
+#   # --- astronomy-shop-us ---     (same five vars, _US suffix)
+#   SPLUNK_REALM_US, SPLUNK_TOKEN_US, SPLUNK_HEC_URL_US, SPLUNK_HEC_TOKEN_US, SPLUNK_INDEX_US
+#
+#   # --- default fallback ---     (same five vars, _DEFAULT suffix)
+#   SPLUNK_REALM_DEFAULT, SPLUNK_TOKEN_DEFAULT, SPLUNK_HEC_URL_DEFAULT,
+#   SPLUNK_HEC_TOKEN_DEFAULT, SPLUNK_INDEX_DEFAULT
+#
+# DIAB note: DIAB deployments may require a parallel gateway-config-diab.yaml
+# with the same routing-connector shape plus DIAB-specific exporter/auth
+# settings. Tracked as a follow-up after multi-env OTLP path is validated.
 
 extensions:
   health_check:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
   zpages:
     endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
-  headers_setter:
-    headers:
-      - action: upsert
-        key: X-SF-TOKEN
-        from_context: X-SF-TOKEN
-        default_value: "${SPLUNK_ACCESS_TOKEN}"
 
 receivers:
   otlp:
@@ -34,15 +53,32 @@ processors:
     limit_mib: 3000
     spike_limit_mib: 1000
 
-  resource/add_environment:
-    attributes:
-      - action: insert
-        value: "demo"
-        key: deployment.environment
-
   batch:
     timeout: 5s
     send_batch_size: 1024
+
+  # Promote per-invocation env stamped by Lambda from signal attribute to
+  # resource attribute so the routing connector can match on it.
+  transform/promote_env_traces:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(resource.attributes["deployment.environment"], attributes["deployment.environment"]) where attributes["deployment.environment"] != nil
+
+  transform/promote_env_metrics:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(resource.attributes["deployment.environment"], attributes["deployment.environment"]) where attributes["deployment.environment"] != nil
+
+  transform/promote_env_logs:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - set(resource.attributes["deployment.environment"], attributes["deployment.environment"]) where attributes["deployment.environment"] != nil
 
   attributes/logs:
     actions:
@@ -53,41 +89,219 @@ processors:
         value: "_json"
         action: insert
 
-exporters:
-  # Traces and metrics to Splunk Observability Cloud via OTLP HTTP
-  otlphttp:
-    auth:
-      authenticator: headers_setter
-    traces_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/trace/otlp"
-    metrics_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/datapoint/otlp"
+connectors:
+  routing/traces:
+    default_pipelines: [traces/default]
+    error_mode: ignore
+    table:
+      - statement: route() where resource.attributes["deployment.environment"] == "dev-astronomy-lambda"
+        pipelines: [traces/dev]
+      - statement: route() where resource.attributes["deployment.environment"] == "astronomy-shop-eu-lambda"
+        pipelines: [traces/eu]
+      - statement: route() where resource.attributes["deployment.environment"] == "astronomy-shop-us-lambda"
+        pipelines: [traces/us]
 
-  # Logs to Splunk Cloud/Enterprise via HEC
-  splunk_hec:
-    endpoint: "${SPLUNK_HEC_URL}"
-    token: "${SPLUNK_HEC_TOKEN}"
+  routing/metrics:
+    default_pipelines: [metrics/default]
+    error_mode: ignore
+    table:
+      - statement: route() where resource.attributes["deployment.environment"] == "dev-astronomy-lambda"
+        pipelines: [metrics/dev]
+      - statement: route() where resource.attributes["deployment.environment"] == "astronomy-shop-eu-lambda"
+        pipelines: [metrics/eu]
+      - statement: route() where resource.attributes["deployment.environment"] == "astronomy-shop-us-lambda"
+        pipelines: [metrics/us]
+
+  routing/logs:
+    default_pipelines: [logs/default]
+    error_mode: ignore
+    table:
+      - statement: route() where resource.attributes["deployment.environment"] == "dev-astronomy-lambda"
+        pipelines: [logs/dev]
+      - statement: route() where resource.attributes["deployment.environment"] == "astronomy-shop-eu-lambda"
+        pipelines: [logs/eu]
+      - statement: route() where resource.attributes["deployment.environment"] == "astronomy-shop-us-lambda"
+        pipelines: [logs/us]
+
+exporters:
+  # ---------- dev-astronomy ----------
+  otlphttp/dev:
+    traces_endpoint: "https://ingest.${SPLUNK_REALM_DEV}.signalfx.com/v2/trace/otlp"
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM_DEV}.signalfx.com/v2/datapoint/otlp"
+    headers:
+      X-SF-TOKEN: "${SPLUNK_TOKEN_DEV}"
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+  splunk_hec/dev:
+    endpoint: "${SPLUNK_HEC_URL_DEV}"
+    token: "${SPLUNK_HEC_TOKEN_DEV}"
+    index: "${SPLUNK_INDEX_DEV}"
     source: otel
     sourcetype: _json
-    index: "${SPLUNK_INDEX}"
     timeout: 10s
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
 
-  # Debug exporter for troubleshooting (remove from pipelines when not needed)
+  # ---------- astronomy-shop-eu ----------
+  otlphttp/eu:
+    traces_endpoint: "https://ingest.${SPLUNK_REALM_EU}.signalfx.com/v2/trace/otlp"
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM_EU}.signalfx.com/v2/datapoint/otlp"
+    headers:
+      X-SF-TOKEN: "${SPLUNK_TOKEN_EU}"
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+  splunk_hec/eu:
+    endpoint: "${SPLUNK_HEC_URL_EU}"
+    token: "${SPLUNK_HEC_TOKEN_EU}"
+    index: "${SPLUNK_INDEX_EU}"
+    source: otel
+    sourcetype: _json
+    timeout: 10s
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+  # ---------- astronomy-shop-us ----------
+  otlphttp/us:
+    traces_endpoint: "https://ingest.${SPLUNK_REALM_US}.signalfx.com/v2/trace/otlp"
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM_US}.signalfx.com/v2/datapoint/otlp"
+    headers:
+      X-SF-TOKEN: "${SPLUNK_TOKEN_US}"
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+  splunk_hec/us:
+    endpoint: "${SPLUNK_HEC_URL_US}"
+    token: "${SPLUNK_HEC_TOKEN_US}"
+    index: "${SPLUNK_INDEX_US}"
+    source: otel
+    sourcetype: _json
+    timeout: 10s
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+  # ---------- default (fallback for unmatched env) ----------
+  otlphttp/default:
+    traces_endpoint: "https://ingest.${SPLUNK_REALM_DEFAULT}.signalfx.com/v2/trace/otlp"
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM_DEFAULT}.signalfx.com/v2/datapoint/otlp"
+    headers:
+      X-SF-TOKEN: "${SPLUNK_TOKEN_DEFAULT}"
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+  splunk_hec/default:
+    endpoint: "${SPLUNK_HEC_URL_DEFAULT}"
+    token: "${SPLUNK_HEC_TOKEN_DEFAULT}"
+    index: "${SPLUNK_INDEX_DEFAULT}"
+    source: otel
+    sourcetype: _json
+    timeout: 10s
+    sending_queue:
+      enabled: true
+      queue_size: 5000
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
   debug:
     verbosity: basic
 
 service:
-  extensions: [health_check, zpages, headers_setter]
+  extensions: [health_check, zpages]
   pipelines:
-    traces:
+    # ---------- ingress pipelines (one per signal): receive, promote env, route ----------
+    traces/in:
       receivers: [otlp]
-      processors: [memory_limiter, batch, resource/add_environment]
-      exporters: [otlphttp, debug]
+      processors: [memory_limiter, transform/promote_env_traces, batch]
+      exporters: [routing/traces]
 
-    metrics:
+    metrics/in:
       receivers: [otlp]
-      processors: [memory_limiter, batch, resource/add_environment]
-      exporters: [otlphttp, debug]
+      processors: [memory_limiter, transform/promote_env_metrics, batch]
+      exporters: [routing/metrics]
 
-    logs:
+    logs/in:
       receivers: [otlp]
-      processors: [memory_limiter, batch, attributes/logs]
-      exporters: [splunk_hec, debug]
+      processors: [memory_limiter, transform/promote_env_logs, batch, attributes/logs]
+      exporters: [routing/logs]
+
+    # ---------- per-env terminal pipelines ----------
+    traces/dev:
+      receivers: [routing/traces]
+      exporters: [otlphttp/dev, splunk_hec/dev]
+    traces/eu:
+      receivers: [routing/traces]
+      exporters: [otlphttp/eu, splunk_hec/eu]
+    traces/us:
+      receivers: [routing/traces]
+      exporters: [otlphttp/us, splunk_hec/us]
+    traces/default:
+      receivers: [routing/traces]
+      exporters: [otlphttp/default, splunk_hec/default, debug]
+
+    metrics/dev:
+      receivers: [routing/metrics]
+      exporters: [otlphttp/dev, splunk_hec/dev]
+    metrics/eu:
+      receivers: [routing/metrics]
+      exporters: [otlphttp/eu, splunk_hec/eu]
+    metrics/us:
+      receivers: [routing/metrics]
+      exporters: [otlphttp/us, splunk_hec/us]
+    metrics/default:
+      receivers: [routing/metrics]
+      exporters: [otlphttp/default, splunk_hec/default, debug]
+
+    logs/dev:
+      receivers: [routing/logs]
+      exporters: [otlphttp/dev, splunk_hec/dev]
+    logs/eu:
+      receivers: [routing/logs]
+      exporters: [otlphttp/eu, splunk_hec/eu]
+    logs/us:
+      receivers: [routing/logs]
+      exporters: [otlphttp/us, splunk_hec/us]
+    logs/default:
+      receivers: [routing/logs]
+      exporters: [otlphttp/default, splunk_hec/default, debug]

--- a/planning-lambda/collector/gateway-config.yaml
+++ b/planning-lambda/collector/gateway-config.yaml
@@ -293,15 +293,17 @@ service:
       receivers: [routing/metrics]
       exporters: [otlphttp/default, splunk_hec/default, debug]
 
+    # Logs go to Splunk Cloud HEC only (Splunk O11y log ingest path is HEC,
+    # not OTLP), so the otlphttp/* exporters are omitted from logs pipelines.
     logs/dev:
       receivers: [routing/logs]
-      exporters: [otlphttp/dev, splunk_hec/dev]
+      exporters: [splunk_hec/dev]
     logs/eu:
       receivers: [routing/logs]
-      exporters: [otlphttp/eu, splunk_hec/eu]
+      exporters: [splunk_hec/eu]
     logs/us:
       receivers: [routing/logs]
-      exporters: [otlphttp/us, splunk_hec/us]
+      exporters: [splunk_hec/us]
     logs/default:
       receivers: [routing/logs]
-      exporters: [otlphttp/default, splunk_hec/default, debug]
+      exporters: [splunk_hec/default, debug]

--- a/planning-lambda/collector/gateway-config.yaml.bak
+++ b/planning-lambda/collector/gateway-config.yaml.bak
@@ -1,0 +1,93 @@
+# Splunk OpenTelemetry Collector - Gateway Mode
+# Receives OTLP from Lambda functions and forwards to Splunk
+#
+# Environment variables required (set in /etc/otel/collector/splunk-otel-collector.conf):
+#   SPLUNK_ACCESS_TOKEN      - Splunk Observability Cloud access token
+#   SPLUNK_REALM             - Splunk Observability Cloud realm (e.g., us0, us1, eu0)
+#   SPLUNK_LISTEN_INTERFACE  - Listen interface (default: 0.0.0.0)
+#
+# The splunk_hec exporter uses hardcoded values below — update for your environment.
+
+extensions:
+  health_check:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:13133"
+  zpages:
+    endpoint: "${SPLUNK_LISTEN_INTERFACE}:55679"
+  headers_setter:
+    headers:
+      - action: upsert
+        key: X-SF-TOKEN
+        from_context: X-SF-TOKEN
+        default_value: "${SPLUNK_ACCESS_TOKEN}"
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 3000
+    spike_limit_mib: 1000
+
+  resource/add_environment:
+    attributes:
+      - action: insert
+        value: "demo"
+        key: deployment.environment
+
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+  attributes/logs:
+    actions:
+      - key: source
+        value: "lambda"
+        action: insert
+      - key: sourcetype
+        value: "_json"
+        action: insert
+
+exporters:
+  # Traces and metrics to Splunk Observability Cloud via OTLP HTTP
+  otlphttp:
+    auth:
+      authenticator: headers_setter
+    traces_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/trace/otlp"
+    metrics_endpoint: "https://ingest.${SPLUNK_REALM}.signalfx.com/v2/datapoint/otlp"
+
+  # Logs to Splunk Cloud/Enterprise via HEC
+  splunk_hec:
+    endpoint: "${SPLUNK_HEC_URL}"
+    token: "${SPLUNK_HEC_TOKEN}"
+    source: otel
+    sourcetype: _json
+    index: "${SPLUNK_INDEX}"
+    timeout: 10s
+
+  # Debug exporter for troubleshooting (remove from pipelines when not needed)
+  debug:
+    verbosity: basic
+
+service:
+  extensions: [health_check, zpages, headers_setter]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource/add_environment]
+      exporters: [otlphttp, debug]
+
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource/add_environment]
+      exporters: [otlphttp, debug]
+
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, attributes/logs]
+      exporters: [splunk_hec, debug]

--- a/planning-lambda/shared/env.py
+++ b/planning-lambda/shared/env.py
@@ -1,0 +1,166 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-invocation env extraction + stamping helpers for Lambda telemetry.
+
+The K8s planning service passes the source cluster name (e.g. "dev-astronomy")
+as a payload field. Every Lambda in the chain stamps
+`deployment.environment = "<env>-lambda"` on its root span so the gateway
+collector can route telemetry to the correct Splunk Observability + HEC org.
+
+This module centralises the contract across all communication channels:
+  - API Gateway HTTP request body field   ("env")
+  - lambda.invoke ClientContext.custom    (key "env")
+  - SNS MessageAttributes                 (key "env")
+  - Direct HTTP/JSON header               ("x-demo-env")
+"""
+
+import base64
+import json
+from typing import Any, Dict, Optional
+
+from opentelemetry.trace import Span
+
+# Field/header/attribute names — single source of truth.
+BARE_ENV_KEY = "env"
+HTTP_HEADER = "x-demo-env"
+STAMPED_ATTR = "deployment.environment"
+LAMBDA_SUFFIX = "-lambda"
+UNKNOWN_ENV = "unknown"
+
+
+def extract_env(event: Dict[str, Any], context: Any = None) -> str:
+    """
+    Extract the bare env name from a Lambda invocation.
+
+    Lookup order:
+      1. Parsed request body field "env" (set by Planning_Init handler).
+      2. Top-level event["env"] (Event-type invokes, manual payloads).
+      3. lambda.invoke ClientContext.custom["env"].
+      4. SNS record MessageAttributes "env".StringValue.
+      5. HTTP header "x-demo-env" (case-insensitive).
+      6. Default UNKNOWN_ENV.
+
+    Args:
+        event: The Lambda event dict OR a parsed request body dict.
+        context: Lambda context object (optional; used for ClientContext).
+
+    Returns:
+        Bare env string (no "-lambda" suffix). Caller applies stamp().
+    """
+    if not isinstance(event, dict):
+        return UNKNOWN_ENV
+
+    # 1 + 2: direct field on body or event
+    direct = event.get(BARE_ENV_KEY)
+    if isinstance(direct, str) and direct:
+        return direct
+
+    # API Gateway nested body (still a string at this layer for HTTP API v2)
+    body = event.get("body")
+    if isinstance(body, dict):
+        v = body.get(BARE_ENV_KEY)
+        if isinstance(v, str) and v:
+            return v
+
+    # 3: ClientContext from lambda.invoke
+    if context is not None:
+        client_ctx = getattr(context, "client_context", None)
+        if client_ctx is not None:
+            custom = getattr(client_ctx, "custom", None)
+            if isinstance(custom, dict):
+                v = custom.get(BARE_ENV_KEY)
+                if isinstance(v, str) and v:
+                    return v
+
+    # 4: SNS event shape
+    records = event.get("Records")
+    if isinstance(records, list) and records:
+        first = records[0]
+        if isinstance(first, dict):
+            sns = first.get("Sns") or first.get("sns")
+            if isinstance(sns, dict):
+                attrs = sns.get("MessageAttributes") or {}
+                entry = attrs.get(BARE_ENV_KEY) if isinstance(attrs, dict) else None
+                if isinstance(entry, dict):
+                    v = entry.get("Value") or entry.get("StringValue")
+                    if isinstance(v, str) and v:
+                        return v
+
+    # 5: HTTP header (case-insensitive)
+    headers = event.get("headers") or {}
+    if isinstance(headers, dict):
+        for k, v in headers.items():
+            if isinstance(k, str) and k.lower() == HTTP_HEADER and isinstance(v, str) and v:
+                return v
+
+    return UNKNOWN_ENV
+
+
+def stamp(span: Optional[Span], env_raw: str) -> str:
+    """
+    Stamp `deployment.environment = "<env>-lambda"` on the given span.
+
+    Args:
+        span: Active OTel span (may be None — function still returns tagged value).
+        env_raw: Bare env name from extract_env().
+
+    Returns:
+        The tagged env string (env_raw + "-lambda").
+    """
+    env_tagged = tag(env_raw)
+    if span is not None:
+        try:
+            span.set_attribute(STAMPED_ATTR, env_tagged)
+        except Exception:
+            # Span may be a no-op / NonRecordingSpan; ignore.
+            pass
+    return env_tagged
+
+
+def tag(env_raw: str) -> str:
+    """Return env_raw with the Lambda suffix applied. Pure function."""
+    base = env_raw if (isinstance(env_raw, str) and env_raw) else UNKNOWN_ENV
+    return f"{base}{LAMBDA_SUFFIX}"
+
+
+def for_invoke(env_raw: str, extra: Optional[Dict[str, str]] = None) -> str:
+    """
+    Build a base64-encoded ClientContext JSON for boto3 lambda.invoke.
+
+    AWS Lambda surfaces ClientContext.custom to the invoked function as a dict
+    of strings. We pack env (bare) plus any extra custom values (e.g. trace
+    headers) into the `custom` block.
+
+    Args:
+        env_raw: Bare env name. Will be stored under BARE_ENV_KEY.
+        extra: Additional custom key/value pairs to merge (e.g. traceparent).
+
+    Returns:
+        Base64-encoded JSON string suitable for boto3 `ClientContext` parameter.
+    """
+    custom: Dict[str, str] = {BARE_ENV_KEY: env_raw or UNKNOWN_ENV}
+    if extra:
+        custom.update({k: v for k, v in extra.items() if isinstance(v, str)})
+    payload = {"custom": custom}
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+
+
+def for_sns(env_raw: str) -> Dict[str, Dict[str, str]]:
+    """
+    Build SNS MessageAttribute entry for env propagation.
+
+    Merge into the `MessageAttributes` kwarg of boto3 SNS publish().
+    """
+    return {
+        BARE_ENV_KEY: {
+            "DataType": "String",
+            "StringValue": env_raw or UNKNOWN_ENV,
+        }
+    }
+
+
+def for_http(env_raw: str) -> Dict[str, str]:
+    """Build HTTP header dict for env propagation on direct HTTP/JSON calls."""
+    return {HTTP_HEADER: env_raw or UNKNOWN_ENV}

--- a/planning-lambda/shared/lambda_client.py
+++ b/planning-lambda/shared/lambda_client.py
@@ -14,6 +14,7 @@ from opentelemetry.trace import SpanKind
 
 from .tracing import create_span, inject_context
 from .logging import get_logger
+from .env import for_invoke, STAMPED_ATTR, tag as tag_env
 
 logger = get_logger(__name__)
 
@@ -41,16 +42,20 @@ def invoke_lambda(
     function_name: str,
     payload: Dict[str, Any],
     invocation_type: str = "RequestResponse",
-    propagate_context: bool = True
+    propagate_context: bool = True,
+    env_raw: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """
-    Invoke another Lambda function with trace context propagation.
+    Invoke another Lambda function with trace context + env propagation.
 
     Args:
         function_name: Lambda function name or ARN.
         payload: Request payload to send.
         invocation_type: 'RequestResponse' (sync) or 'Event' (async).
         propagate_context: Whether to propagate trace context.
+        env_raw: Bare source env (e.g. "dev-astronomy"). When set, packed into
+            ClientContext.custom["env"] so the invoked Lambda can stamp its own
+            telemetry with the same env for gateway-collector routing.
 
     Returns:
         Response payload for sync invocations, None for async.
@@ -66,6 +71,8 @@ def invoke_lambda(
         "faas.invoked_provider": "aws",
         "faas.invocation_type": invocation_type.lower(),
     }
+    if env_raw:
+        span_attributes[STAMPED_ATTR] = tag_env(env_raw)
 
     with create_span(
         f"Lambda.Invoke.{function_name.split(':')[-1]}",
@@ -80,21 +87,30 @@ def invoke_lambda(
                 "_trace_context": headers
             }
 
+        # Build ClientContext carrying env + trace headers (custom values must be strings).
+        invoke_kwargs: Dict[str, Any] = {
+            "FunctionName": function_name,
+            "InvocationType": invocation_type,
+            "Payload": json.dumps(payload).encode('utf-8'),
+        }
+        if env_raw:
+            invoke_kwargs["ClientContext"] = for_invoke(
+                env_raw,
+                extra=headers if propagate_context else None,
+            )
+
         logger.info(
             f"Invoking Lambda: {function_name}",
             extra={
                 "function_name": function_name,
                 "invocation_type": invocation_type,
-                "payload_size": len(json.dumps(payload))
+                "payload_size": len(json.dumps(payload)),
+                "env": env_raw or "unset",
             }
         )
 
         try:
-            response = client.invoke(
-                FunctionName=function_name,
-                InvocationType=invocation_type,
-                Payload=json.dumps(payload).encode('utf-8')
-            )
+            response = client.invoke(**invoke_kwargs)
 
             status_code = response.get('StatusCode', 0)
             span.set_attribute("http.status_code", status_code)
@@ -152,7 +168,8 @@ def invoke_lambda(
 def invoke_lambda_async(
     function_name: str,
     payload: Dict[str, Any],
-    propagate_context: bool = True
+    propagate_context: bool = True,
+    env_raw: Optional[str] = None,
 ) -> None:
     """
     Invoke Lambda function asynchronously.
@@ -161,10 +178,12 @@ def invoke_lambda_async(
         function_name: Lambda function name or ARN.
         payload: Request payload to send.
         propagate_context: Whether to propagate trace context.
+        env_raw: Bare source env (see invoke_lambda).
     """
     invoke_lambda(
         function_name=function_name,
         payload=payload,
         invocation_type="Event",
-        propagate_context=propagate_context
+        propagate_context=propagate_context,
+        env_raw=env_raw,
     )

--- a/planning-lambda/shared/tracing.py
+++ b/planning-lambda/shared/tracing.py
@@ -1,7 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""OpenTelemetry tracing utilities for AWS Lambda."""
+"""
+OpenTelemetry tracing utilities for AWS Lambda.
+
+Resource attributes (service.name, cloud.provider, ...) are set once at
+cold-start in init_tracer(). The per-invocation `deployment.environment`
+attribute used for gateway-collector routing is NOT a resource attribute —
+it varies per request and is stamped on each root span by the handler via
+shared.env.stamp(). The gateway then promotes the span attribute to a
+resource attribute (transform/promote_env_traces) before routing.
+"""
 
 import os
 from contextlib import contextmanager

--- a/planning-lambda/tests/conftest.py
+++ b/planning-lambda/tests/conftest.py
@@ -102,6 +102,7 @@ def sample_orders_payload():
     """Sample orders payload from K8s planning service."""
     return {
         "service": "planning",
+        "env": "dev-astronomy",
         "timestamp": "2024-01-15T10:30:00Z",
         "orders_count": 2,
         "orders": [

--- a/planning-lambda/tests/unit/test_env.py
+++ b/planning-lambda/tests/unit/test_env.py
@@ -1,0 +1,153 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for shared/env.py."""
+
+import base64
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from shared.env import (
+    BARE_ENV_KEY,
+    HTTP_HEADER,
+    LAMBDA_SUFFIX,
+    STAMPED_ATTR,
+    UNKNOWN_ENV,
+    extract_env,
+    for_http,
+    for_invoke,
+    for_sns,
+    stamp,
+    tag,
+)
+
+
+class TestTag:
+    def test_appends_suffix(self):
+        assert tag("dev-astronomy") == "dev-astronomy-lambda"
+
+    def test_empty_falls_back_to_unknown(self):
+        assert tag("") == "unknown-lambda"
+
+    def test_none_falls_back_to_unknown(self):
+        assert tag(None) == "unknown-lambda"
+
+
+class TestStamp:
+    def test_sets_attribute(self):
+        span = MagicMock()
+        result = stamp(span, "astronomy-shop-eu")
+        span.set_attribute.assert_called_once_with(STAMPED_ATTR, "astronomy-shop-eu-lambda")
+        assert result == "astronomy-shop-eu-lambda"
+
+    def test_none_span_returns_tagged(self):
+        result = stamp(None, "dev-astronomy")
+        assert result == "dev-astronomy-lambda"
+
+    def test_span_set_attribute_error_swallowed(self):
+        span = MagicMock()
+        span.set_attribute.side_effect = RuntimeError("non-recording")
+        result = stamp(span, "dev-astronomy")
+        assert result == "dev-astronomy-lambda"
+
+
+class TestExtractEnv:
+    def test_direct_body_field(self):
+        assert extract_env({"env": "dev-astronomy"}) == "dev-astronomy"
+
+    def test_top_level_event_field(self):
+        assert extract_env({"env": "astronomy-shop-us"}, context=None) == "astronomy-shop-us"
+
+    def test_client_context_custom(self):
+        ctx = MagicMock()
+        ctx.client_context.custom = {"env": "astronomy-shop-eu"}
+        assert extract_env({}, context=ctx) == "astronomy-shop-eu"
+
+    def test_sns_message_attributes(self):
+        event = {
+            "Records": [
+                {"Sns": {"MessageAttributes": {"env": {"Type": "String", "Value": "dev-astronomy"}}}}
+            ]
+        }
+        assert extract_env(event) == "dev-astronomy"
+
+    def test_sns_string_value_variant(self):
+        event = {
+            "Records": [
+                {"Sns": {"MessageAttributes": {"env": {"DataType": "String", "StringValue": "dev-astronomy"}}}}
+            ]
+        }
+        assert extract_env(event) == "dev-astronomy"
+
+    def test_http_header_lowercase(self):
+        assert extract_env({"headers": {"x-demo-env": "astronomy-shop-us"}}) == "astronomy-shop-us"
+
+    def test_http_header_case_insensitive(self):
+        assert extract_env({"headers": {"X-DEMO-ENV": "astronomy-shop-eu"}}) == "astronomy-shop-eu"
+
+    def test_default_unknown(self):
+        assert extract_env({}) == UNKNOWN_ENV
+
+    def test_non_dict_event_safe(self):
+        assert extract_env(None) == UNKNOWN_ENV
+        assert extract_env("string") == UNKNOWN_ENV
+
+    def test_empty_string_falls_through(self):
+        assert extract_env({"env": ""}) == UNKNOWN_ENV
+
+    def test_precedence_body_over_header(self):
+        event = {"env": "dev-astronomy", "headers": {"x-demo-env": "astronomy-shop-eu"}}
+        assert extract_env(event) == "dev-astronomy"
+
+
+class TestForInvoke:
+    def test_base64_encodes_custom_env(self):
+        encoded = for_invoke("dev-astronomy")
+        decoded = json.loads(base64.b64decode(encoded).decode("utf-8"))
+        assert decoded == {"custom": {"env": "dev-astronomy"}}
+
+    def test_merges_extra(self):
+        encoded = for_invoke("astronomy-shop-eu", extra={"traceparent": "00-abc-def-01"})
+        decoded = json.loads(base64.b64decode(encoded).decode("utf-8"))
+        assert decoded["custom"]["env"] == "astronomy-shop-eu"
+        assert decoded["custom"]["traceparent"] == "00-abc-def-01"
+
+    def test_extra_non_string_values_dropped(self):
+        encoded = for_invoke("dev-astronomy", extra={"good": "ok", "bad": 123})
+        decoded = json.loads(base64.b64decode(encoded).decode("utf-8"))
+        assert "good" in decoded["custom"]
+        assert "bad" not in decoded["custom"]
+
+    def test_empty_env_uses_unknown(self):
+        encoded = for_invoke("")
+        decoded = json.loads(base64.b64decode(encoded).decode("utf-8"))
+        assert decoded["custom"]["env"] == UNKNOWN_ENV
+
+
+class TestForSns:
+    def test_returns_message_attribute_entry(self):
+        result = for_sns("dev-astronomy")
+        assert result == {"env": {"DataType": "String", "StringValue": "dev-astronomy"}}
+
+
+class TestForHttp:
+    def test_returns_header_dict(self):
+        assert for_http("astronomy-shop-us") == {"x-demo-env": "astronomy-shop-us"}
+
+    def test_empty_uses_unknown(self):
+        assert for_http("") == {"x-demo-env": UNKNOWN_ENV}
+
+
+class TestConstants:
+    def test_keys_match_contract(self):
+        assert BARE_ENV_KEY == "env"
+        assert HTTP_HEADER == "x-demo-env"
+        assert STAMPED_ATTR == "deployment.environment"
+        assert LAMBDA_SUFFIX == "-lambda"
+        assert UNKNOWN_ENV == "unknown"

--- a/planning-lambda/tests/unit/test_lambda_client.py
+++ b/planning-lambda/tests/unit/test_lambda_client.py
@@ -123,6 +123,45 @@ class TestInvokeLambda:
 
             assert "Lambda function error" in str(exc_info.value)
 
+    def test_invoke_lambda_attaches_client_context_when_env_set(self):
+        """env_raw → ClientContext base64 JSON with custom.env."""
+        import base64
+
+        init_tracer("test-service")
+
+        with patch('shared.lambda_client.get_lambda_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_response = {'StatusCode': 200, 'Payload': MagicMock()}
+            mock_response['Payload'].read.return_value = json.dumps({}).encode('utf-8')
+            mock_client.invoke.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            invoke_lambda("test-function", {"k": "v"}, env_raw="dev-astronomy")
+
+            call_args = mock_client.invoke.call_args
+            client_ctx_b64 = call_args.kwargs.get("ClientContext")
+            assert client_ctx_b64 is not None
+            decoded = json.loads(base64.b64decode(client_ctx_b64).decode("utf-8"))
+            assert decoded["custom"]["env"] == "dev-astronomy"
+            # Trace headers also propagated when propagate_context default True
+            assert "traceparent" in decoded["custom"]
+
+    def test_invoke_lambda_no_client_context_when_env_unset(self):
+        """No ClientContext when env_raw not supplied (backward-compat)."""
+        init_tracer("test-service")
+
+        with patch('shared.lambda_client.get_lambda_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_response = {'StatusCode': 200, 'Payload': MagicMock()}
+            mock_response['Payload'].read.return_value = json.dumps({}).encode('utf-8')
+            mock_client.invoke.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            invoke_lambda("test-function", {"k": "v"})
+
+            call_args = mock_client.invoke.call_args
+            assert "ClientContext" not in call_args.kwargs
+
     def test_invoke_lambda_async_invocation(self):
         """Async invocation returns None."""
         init_tracer("test-service")

--- a/planning-lambda/tests/unit/test_lambda_handler.py
+++ b/planning-lambda/tests/unit/test_lambda_handler.py
@@ -182,3 +182,30 @@ class TestLambdaHandler:
         response = lambda_handler(api_event_with_orders, None)
 
         assert response["statusCode"] == 200
+
+    def test_handler_propagates_env_to_handler(self, api_event_with_orders, mock_lambda_context):
+        """Env from body lands in orders.handle response (verifies end-to-end propagation)."""
+        from Planning_Init.lambda_function import lambda_handler
+
+        response = lambda_handler(api_event_with_orders, mock_lambda_context)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        # sample_orders_payload sets env=dev-astronomy
+        assert body["env"] == "dev-astronomy"
+        assert body["lambda"]["deployment.environment"] == "dev-astronomy-lambda"
+
+    def test_handler_env_default_when_missing(self, sample_api_gateway_event, mock_lambda_context):
+        """Missing env in body falls back to unknown."""
+        from Planning_Init.lambda_function import lambda_handler
+
+        event = sample_api_gateway_event.copy()
+        event["requestContext"]["http"]["path"] = "/orders"
+        event["body"] = json.dumps({"service": "planning", "orders_count": 0, "orders": []})
+
+        response = lambda_handler(event, mock_lambda_context)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["env"] == "unknown"
+        assert body["lambda"]["deployment.environment"] == "unknown-lambda"

--- a/planning-lambda/tests/unit/test_orders_handler.py
+++ b/planning-lambda/tests/unit/test_orders_handler.py
@@ -40,7 +40,7 @@ class TestOrdersHandle:
             "orders": []
         }
 
-        response = handle(body, mock_lambda_context, self.tracer)
+        response = handle(body, mock_lambda_context, self.tracer, "dev-astronomy-lambda")
 
         assert response["statusCode"] == 200
         response_body = json.loads(response["body"])
@@ -63,7 +63,7 @@ class TestOrdersHandle:
             ]
         }
 
-        response = handle(body, mock_lambda_context, self.tracer)
+        response = handle(body, mock_lambda_context, self.tracer, "dev-astronomy-lambda")
 
         assert response["statusCode"] == 200
         response_body = json.loads(response["body"])
@@ -97,7 +97,7 @@ class TestOrdersHandle:
             ]
         }
 
-        response = handle(body, mock_lambda_context, self.tracer)
+        response = handle(body, mock_lambda_context, self.tracer, "dev-astronomy-lambda")
 
         response_body = json.loads(response["body"])
         assert response_body["processed_count"] == 15
@@ -122,6 +122,33 @@ class TestOrdersHandle:
         assert response_body["downstream_forwarded"] is True
         mock_invoke.assert_called_once()
 
+    def test_handle_env_in_response(self, mock_lambda_context, sample_orders_payload):
+        """Response carries bare env + tagged env in lambda block."""
+        response = handle(sample_orders_payload, mock_lambda_context, self.tracer, "astronomy-shop-eu-lambda")
+        response_body = json.loads(response["body"])
+        assert response_body["env"] == "astronomy-shop-eu"
+        assert response_body["lambda"]["deployment.environment"] == "astronomy-shop-eu-lambda"
+
+    def test_handle_env_default_when_missing(self, mock_lambda_context, sample_orders_payload):
+        """Handler defaults to unknown-lambda when env_tagged not passed."""
+        response = handle(sample_orders_payload, mock_lambda_context, self.tracer)
+        response_body = json.loads(response["body"])
+        assert response_body["env"] == "unknown"
+        assert response_body["lambda"]["deployment.environment"] == "unknown-lambda"
+
+    def test_downstream_invoke_receives_env(self, mock_lambda_context, sample_orders_payload):
+        """invoke_lambda called with env_raw + downstream payload includes env field."""
+        # DOWNSTREAM_LAMBDA_ARN is captured at module import; patch the module attr directly.
+        with patch('handlers.orders.DOWNSTREAM_LAMBDA_ARN', 'arn:aws:lambda:us-east-1:123456789012:function:Downstream'):
+            with patch('handlers.orders.invoke_lambda') as mock_invoke:
+                mock_invoke.return_value = {"statusCode": 200}
+                handle(sample_orders_payload, mock_lambda_context, self.tracer, "dev-astronomy-lambda")
+        assert mock_invoke.call_args is not None, "invoke_lambda was never called"
+        args, kwargs = mock_invoke.call_args
+        assert kwargs.get("env_raw") == "dev-astronomy"
+        downstream_payload = args[1]
+        assert downstream_payload["env"] == "dev-astronomy"
+
 
 class TestProcessOrder:
     """Tests for process_order function."""
@@ -143,7 +170,7 @@ class TestProcessOrder:
             "shipping_cost": {"units": 30, "currency_code": "USD"}
         }
 
-        result = process_order(order, self.tracer)
+        result = process_order(order, self.tracer, "dev-astronomy-lambda")
 
         assert result["order_id"] == "ORD-123"
         assert result["items_count"] == 5
@@ -156,7 +183,7 @@ class TestProcessOrder:
         """Handles order with missing optional fields."""
         order = {"order_id": "ORD-MINIMAL"}
 
-        result = process_order(order, self.tracer)
+        result = process_order(order, self.tracer, "dev-astronomy-lambda")
 
         assert result["order_id"] == "ORD-MINIMAL"
         assert result["items_count"] == 0
@@ -166,7 +193,7 @@ class TestProcessOrder:
         """Handles order without order_id."""
         order = {"items_count": 3}
 
-        result = process_order(order, self.tracer)
+        result = process_order(order, self.tracer, "dev-astronomy-lambda")
 
         assert result["order_id"] == "unknown"
 

--- a/src/planning/planning_server.py
+++ b/src/planning/planning_server.py
@@ -36,6 +36,7 @@ KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "orders")
 KAFKA_GROUP_ID = os.getenv("KAFKA_GROUP_ID", "planning")
 LAMBDA_ENDPOINT = os.getenv("LAMBDA_ENDPOINT", "")
 LAMBDA_CALL_INTERVAL_MINUTES = int(os.getenv("LAMBDA_CALL_INTERVAL_MINUTES", "5"))
+WORKSHOP_ENV = os.getenv("WORKSHOP_ENV", "unknown")
 
 # Initialize logger
 logger = getJSONLogger(SERVICE_NAME)
@@ -187,6 +188,7 @@ def call_lambda():
             # Prepare payload
             payload = {
                 "service": SERVICE_NAME,
+                "env": WORKSHOP_ENV,
                 "timestamp": datetime.utcnow().isoformat(),
                 "orders_count": len(orders_to_send),
                 "orders": orders_to_send
@@ -303,6 +305,7 @@ def main():
     logger.info(f"Kafka: {KAFKA_ADDR}, Topic: {KAFKA_TOPIC}")
     logger.info(f"Lambda endpoint: {LAMBDA_ENDPOINT or 'NOT CONFIGURED'}")
     logger.info(f"Lambda call interval: {LAMBDA_CALL_INTERVAL_MINUTES} minutes")
+    logger.info(f"Workshop env: {WORKSHOP_ENV}")
 
     # Setup signal handlers
     signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
## Summary

- Planning service now includes `WORKSHOP_ENV` as `env` in the Lambda payload, so a single Lambda fronting all three demo clusters (dev-astronomy, astronomy-shop-eu, astronomy-shop-us) can tag its telemetry per-invocation
- Lambda extracts env from the payload (with ClientContext / SNS / HTTP-header fallbacks via a new `shared/env.py` helper) and stamps `deployment.environment = "<env>-lambda"` on every span
- Gateway collector config rewritten to promote that span attribute to a resource attribute (OTTL transform) and fan out via three `routing` connectors (traces, metrics, logs) to four exporter sets — one per env plus a `default` fallback — each pairing `otlphttp` to Splunk O11y with `splunk_hec` to Splunk Cloud
- Original single-org gateway config preserved at `gateway-config.yaml.bak` for rollback during validation. CloudWatch-variant config left untouched with TODO note for a follow-up multi-env rewrite
- Includes 25 new unit tests for the shared env helper plus coverage for env-on-handler + downstream-invoke propagation

## Test plan

- [x] `splunk-otel-collector validate` passes against the new `gateway-config.yaml` (caught one real bug — `otlphttp` exporters needed to be dropped from logs pipelines, fixed in `bea2d881`)
- [x] `sam build` succeeds for `Planning_Init`
- [x] `sam deploy` to `splunk-astronomy-planning` stack (Stage=demo, in-place update, no resource replacement) — Lambda live as of 2026-06-15
- [x] Smoke test against deployed Lambda: `env=dev-astronomy` in body → response carries `env` + `lambda.deployment.environment=dev-astronomy-lambda`; missing env → falls back to `unknown-lambda`; injected `traceparent` round-trips as expected
- [x] Local pytest: 115 passing (4 pre-existing failures unrelated to this work — Python 3.14 incompatibility with MagicMock-as-exception pattern and module-load-time `os.getenv` capture)
- [ ] Deploy gateway config to EC2 host + populate `/etc/otel/collector/splunk-otel-collector.conf.d/env` with the 20 vars (template at `planning-lambda/collector/env.template`) + `systemctl restart splunk-otel-collector`
- [ ] Set `OtelCollectorEndpoint` on the Lambda + verify routing per env reaches the correct Splunk O11y / HEC org
- [ ] Confirm planning service image build by the CI pipeline picks up the new payload field
- [ ] Once validated, delete `gateway-config.yaml.bak` and follow up on the CloudWatch-variant multi-env rewrite + DIAB config + Secrets Manager migration for tokens