### PR TITLE
sync 2.0.5-values.yaml with deployed prod (+ kafka receiver)

### DIFF
--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -13,6 +13,19 @@ clusterReceiver:
   # Disabled eventsEnabled and k8s_objects - these generate non-HEC data
   # that gets refused by Splunk Platform endpoints
   eventsEnabled: true
+  # Bump from 500Mi/200m — pod was OOM-restarting under export back-pressure
+  # (memorylimiter soft=450Mi vs pod limit=500Mi had only 50Mi headroom).
+  # 149 restarts in 14d on dev-astronomy traced to signalfx/HEC exporter
+  # timeouts back-pressuring the pipeline. Chart does not expose liveness/
+  # readiness probe tuning — if restarts persist post-upgrade, patch
+  # deployment probes via kubectl after helm install.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 500Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
 
 agent:
   extraEnvs:

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -198,6 +198,18 @@ agent:
                   enabled: true
                 postgresql.connection.max:
                   enabled: true
+      receiver_creator/kafka:
+        watch_observers: [k8s_observer]
+        receivers:
+          kafka_metrics:
+            rule: type == "pod" && labels["app.kubernetes.io/component"] == "kafka"
+            config:
+              cluster_alias: kafka-${WORKSHOP_ENVIRONMENT}
+              brokers: ["`endpoint`:9092"]
+              scrapers:
+                - brokers
+                - topics
+                - consumers
     exporters:
       # Exports dbmon events as logs
       otlp_http/dbmon:
@@ -313,7 +325,7 @@ agent:
         metrics:
           exporters: [signalfx]
           processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
-          receivers: [host_metrics, kubeletstats, otlp, receiver_creator]
+          receivers: [host_metrics, kubeletstats, otlp, receiver_creator, receiver_creator/kafka]
         traces:
           # signalfx exporter removed from traces — chart 0.153.1 align.
           # OTLP alone is sufficient for trace correlation; dropping signalfx

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -315,7 +315,11 @@ agent:
           processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
           receivers: [host_metrics, kubeletstats, otlp, receiver_creator]
         traces:
-          exporters: [signalfx, otlp_http]
+          # signalfx exporter removed from traces — chart 0.153.1 align.
+          # OTLP alone is sufficient for trace correlation; dropping signalfx
+          # here reduces load on the exporter currently timing out under
+          # back-pressure on the cluster-receiver.
+          exporters: [otlp_http]
           processors: [memory_limiter, filter/drop_flagd, transform/dc_not_error, k8s_attributes, batch, resourcedetection, resource, resource/add_environment]
           receivers: [otlp, jaeger, zipkin]
         # DBMon logs pipeline - sends query samples and top queries to Splunk O11y

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -214,9 +214,14 @@ agent:
       # Inject environment as a resource attribute for traces
       resource/add_environment:
         attributes:
+          # `insert` (not `upsert`): only inject WORKSHOP_ENVIRONMENT when the
+          # service hasn't set deployment.environment itself. Services like
+          # planning and report-generator set their own variant suffix
+          # (e.g. ${WORKSHOP_ENV}-lambda, ${WORKSHOP_ENV}-throttle-demo) and
+          # were getting clobbered by upsert.
           - key: deployment.environment
             value: ${WORKSHOP_ENVIRONMENT}
-            action: upsert
+            action: insert
       filter/drop_flagd:
         traces:
           span:


### PR DESCRIPTION
## Summary

`kubernetes/splunk-astronomy-shop-2.0.5-values.yaml` in upstream has drifted behind the file actually deployed on the demo clusters (`dev-astronomy`, `astronomy-shop-eu`). Three pre-existing prod hot-patches were never propagated back to upstream, plus a new kafkametrics receiver. This PR brings upstream in line with deployed prod.

Branch HEAD is verified byte-identical to the values file currently in use on `astronomy-shop-eu`.

## Commits (in order)

1. **bump clusterReceiver resources** — OOM-restart fix (149 restarts in 14d on dev-astronomy traced to signalfx/HEC exporter back-pressure; memorylimiter soft=450Mi vs pod limit=500Mi had only 50Mi headroom). Bumps requests to 200m/500Mi and limits to 500m/1Gi.
2. **`add_environment` action `insert`** — was `upsert`, clobbering services that set their own `deployment.environment` variant suffix (planning → `${WORKSHOP_ENV}-lambda`, order-validation → `${WORKSHOP_ENV}-throttle-demo`, etc). `insert` only fires when service hasn't set it.
3. **drop signalfx from traces exporters** — OTLP alone is sufficient for trace correlation. signalfx exporter on traces was timing out under cluster-receiver back-pressure, amplifying the OOM loop. Aligns with chart 0.153.1 convention.
4. **kafkametrics receiver** — new `receiver_creator/kafka` discovers kafka pods via label `app.kubernetes.io/component=kafka` and scrapes broker / topic / consumer-group metrics on :9092. `cluster_alias` parameterized via `${WORKSHOP_ENVIRONMENT}` so multi-env clusters don't collide. Wired into metrics pipeline only.

## Test plan

- [ ] Helm renders cleanly with new values
- [ ] Deploy on non-prod cluster, verify `kafka.*` metrics flow to Splunk O11y
- [ ] Confirm planning / throttle-demo `deployment.environment` retains its variant suffix (no upsert regression)
- [ ] Watch clusterReceiver pod for OOM restarts post-deploy (expect zero)