### PR TITLE
feat(flagd): default rumBlueGreen + recommendationCartesianQuery to on (2.0.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ test/fraud-standalone/fraud-standalone-manifest.yaml
 test/fraud-standalone/fraud-standalone-values.yaml
 test/dc-shim-standalone/dc-shim-standalone-values.yaml
 
+planning-lambda/Planning_Init_Lambda/.aws-sam/build.toml

--- a/kubernetes/BETA/splunk-astronomy-shop-multienv-test-dc-shim.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-multienv-test-dc-shim.yaml
@@ -1,0 +1,292 @@
+# Splunk Astronomy Shop Kubernetes Manifest - dc-shim
+# Version: multienv-test
+# Generated on: 2026-06-15T13:38:46Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === shop-dc-shim ===
+### Expects a deployment of Astronomy Shop Demo in the same cluster
+### Uses checkout service from that demo
+### Or add this at config at the end of an astronomy shop demo deployment yaml
+---
+# Shop DC Shim Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: shop-dc-shim
+  labels:
+    opentelemetry.io/name: shop-dc-shim
+    app.kubernetes.io/component: shop-dc-shim
+    app.kubernetes.io/name: shop-dc-shim
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8070
+      name: tcp-service
+      targetPort: 8070
+  selector:
+    opentelemetry.io/name: shop-dc-shim
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shop-dc-shim
+  labels:
+    opentelemetry.io/name: shop-dc-shim
+    app.kubernetes.io/component: shop-dc-shim
+    app.kubernetes.io/name: shop-dc-shim
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shop-dc-shim
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shop-dc-shim
+        app.kubernetes.io/component: shop-dc-shim
+        app.kubernetes.io/name: shop-dc-shim
+        app.kubernetes.io/version: "2.1.3"
+        app.kubernetes.io/part-of: opentelemetry-demo
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+        - name: shop-dc-shim
+          image: ghcr.io/splunk/opentelemetry-demo/otel-shop-dc-shim:2.0.5
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8070
+              name: http
+          command: ["/usr/bin/dumb-init"]
+          args:
+          - --
+          - /bin/bash
+          - -c
+          - |
+            export OTEL_RESOURCE_ATTRIBUTES="service.name=shop-dc-shim-service,deployment.environment=${ENV_VALUE}-datacenter-b01,service.version=multienv-test,service.namespace=shop-dc-shim"
+            sed -i "s|http://splunk-otel-collector-agent:4318|http://${NODE_IP}:4318|g" /app/start-app-dual.sh
+            exec /app/start-app-dual.sh
+          env:
+            - name: WORKSHOP_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: workshop-secret
+                  key: env
+            - name: TPM
+              value: "10"  # Transactions Per Minute - scales both request frequency and processing load
+            # Memory optimization - uncomment to reduce memory usage
+            # - name: AUDIT_LOG_ENABLED
+            #   value: "false"  # Disable audit log generation
+            - name: TRANSACTION_RETENTION_MINUTES
+              value: "30"  # Clean up transactions after 30 minutes (default: 120)
+            - name: TRANSACTION_CLEANUP_INTERVAL_MS
+              value: "1800000"  # Run cleanup every 30 minutes (default: 7200000)
+            - name: SHOP_DC_SHIM_PORT
+              value: "8070"
+            - name: DB_CONNECTION_STRING
+              value: "jdbc:sqlserver://shop-dc-shim-db:1433;databaseName=master;encrypt=false;trustServerCertificate=true"
+            - name: DB_USERNAME
+              value: "sa"
+            - name: DB_PASSWORD
+              value: "ShopPass123!"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkout:8080"
+            - name: EMAIL_SERVICE_URL
+              value: "http://email:8080"
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_COLLECTOR_NAME
+              value: $(NODE_IP)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://$(OTEL_COLLECTOR_NAME):4318"
+            - name: OTEL_SERVICE_NAME
+              value: "shop-dc-shim"
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: "true"
+            - name: APPDYNAMICS_AGENT_ACCOUNT_NAME
+              value: "se-lab"
+            - name: APPDYNAMICS_JAVAAGENT_ENABLED
+              value: "true"
+            - name: APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: workshop-secret
+                  key: appd_token
+                  optional: true
+            - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+              value: "true"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8070
+            initialDelaySeconds: 240
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8070
+            initialDelaySeconds: 420
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+
+---
+
+# === shop-dc-shim-db ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+### Expects a deployment of Astronomy Shop Demo in the same cluster
+### Uses checkout service from that demo
+### Or add this at config at the end of an astronomy shop demo deployment yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shop-dc-shim-db
+
+  labels:
+    opentelemetry.io/name: shop-dc-shim-db
+    app.kubernetes.io/component: shop-dc-shim-db
+    app.kubernetes.io/name: shop-dc-shim-db
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1433
+      name: sqlserver
+      targetPort: 1433
+  selector:
+    opentelemetry.io/name: shop-dc-shim-db
+---
+apiVersion: apps/v1
+kind: Deployment 
+metadata:
+  name: shop-dc-shim-db
+  labels:
+    opentelemetry.io/name: shop-dc-shim-db
+    app.kubernetes.io/component: shop-dc-shim-db
+    app.kubernetes.io/name: shop-dc-shim-db
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shop-dc-shim-db
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: sqlserver
+        splunk.com/sqlserver.database: shopshim
+      labels:
+        opentelemetry.io/name: shop-dc-shim-db
+        app.kubernetes.io/component: shop-dc-shim-db
+        app.kubernetes.io/name: shop-dc-shim-db
+        app.kubernetes.io/version: "2.1.3"
+        app.kubernetes.io/part-of: opentelemetry-demo
+    spec:
+      containers:
+        - name: sqlserver
+          image: mcr.microsoft.com/mssql/server:2022-latest
+          ports:
+            - containerPort: 1433
+          env:
+            - name: ACCEPT_EULA
+              value: "Y"
+            - name: MSSQL_SA_PASSWORD
+              value: "ShopPass123!"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "3Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: sqlserver-storage
+              mountPath: /var/opt/mssql/data
+      volumes:
+        - name: sqlserver-storage
+          emptyDir: {}
+---
+
+# === shop-dc-loadgenerator ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+### Expects a deployment of Astronomy Shop Demo in the same cluster
+### Uses checkout service from that demo
+### Or add this at config at the end of an astronomy shop demo deployment yaml
+---
+# Shop DC Load Generator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shop-dc-load-generator
+  labels:
+    opentelemetry.io/name: shop-dc-load-generator
+    app.kubernetes.io/component: shop-dc-load-generator
+    app.kubernetes.io/name: shop-dc-load-generator
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shop-dc-load-generator
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shop-dc-load-generator
+        app.kubernetes.io/component: shop-dc-load-generator
+        app.kubernetes.io/name: shop-dc-load-generator
+        app.kubernetes.io/version: "2.1.3"
+        app.kubernetes.io/part-of: opentelemetry-demo
+    spec:
+      serviceAccountName: opentelemetry-demo
+      initContainers:
+        - name: wait-for-shop-dc-shim
+          image: curlimages/curl:8.1.2
+          command: ['sh', '-c']
+          args:
+            - |
+              echo "Waiting for shop-dc-shim service to be ready..."
+              until curl -f --connect-timeout 5 --max-time 20 http://shop-dc-shim:8070/actuator/health; do
+                echo "Shop DC Shim not ready, waiting 20 seconds..."
+                sleep 20
+              done
+              echo "Shop DC Shim is ready, starting load generator..."
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "50m"
+      containers:
+        - name: load-generator
+          image: ghcr.io/splunk/opentelemetry-demo/otel-shop-dc-loadgenerator:2.0.5
+          env:
+            - name: TPM
+              value: "10"  # Transactions Per Minute - adjust to control load (e.g., 5, 10, 25, 50)
+          args: ["--url", "http://shop-dc-shim:8070", "--mode", "continuous", "--duration", "0"]
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-multienv-test-diab.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-multienv-test-diab.yaml
@@ -1,0 +1,3815 @@
+# Splunk Astronomy Shop Kubernetes Manifest
+# Version: multienv-test
+# Generated on: 2026-06-15T13:38:46Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === accounting ===
+# Kubernetes manifest for accounting
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accounting
+  labels:
+    opentelemetry.io/name: accounting
+    app.kubernetes.io/component: accounting
+    app.kubernetes.io/name: accounting
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: accounting
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: accounting
+        app.kubernetes.io/component: accounting
+        app.kubernetes.io/name: accounting
+    spec:
+      serviceAccountName: opentelemetry-demo
+      # DNS Configuration to prevent stale DNS caching
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          # Reduce DNS TTL to 10 seconds for faster updates
+          - name: ndots
+            value: "2"
+          # Number of DNS queries before giving up
+          - name: timeout
+            value: "2"
+          # Number of retries for DNS queries
+          - name: attempts
+            value: "3"
+      containers:
+      - name: accounting
+        image: ghcr.io/splunk/opentelemetry-demo/otel-accounting:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        # Kafka connection retry configuration
+        - name: KAFKA_RECONNECT_BACKOFF_MS
+          value: "1000"
+        - name: KAFKA_RECONNECT_BACKOFF_MAX_MS
+          value: "10000"
+        - name: KAFKA_CONNECTIONS_MAX_IDLE_MS
+          value: "300000"
+        - name: KAFKA_METADATA_MAX_AGE_MS
+          value: "10000"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: DB_CONNECTION_STRING
+          value: Host=postgresql;Username=otelu;Password=otelp;Database=otel
+        - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
+          value: 'false'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=spanlink
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === ad ===
+# Kubernetes manifest for ad
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: ad
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: ad
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: ad
+        app.kubernetes.io/component: ad
+        app.kubernetes.io/name: ad
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: ad
+        image: ghcr.io/splunk/opentelemetry-demo/otel-ad:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./build/install/opentelemetry-demo-ad/bin/Ad
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: AD_PORT
+          value: '8080'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_TRACES_SAMPLER
+          value: rules
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '100'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/usr/src/app/splunk-otel-javaagent-csa.jar -Dsplunk.snapshot.profiler.enabled=true
+            -Dsplunk.snapshot.profiler.sampling.interval=1 -Dsplunk.snapshot.selection.probability=0.1
+            -Xmx440m
+        resources:
+          limits:
+            memory: 600Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === astronomy-loadgen ===
+# Kubernetes manifest for astronomy-loadgen
+# Includes scriptfile ConfigMap used by the deployment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scriptfile
+data:
+  local-file: |
+    /* eslint-disable no-console */
+    const { Console } = require('console');
+    const puppeteer = require('puppeteer');
+    const customUserAgent = 'Mozilla/5.0 (X11; Linux x86_64; Splunk RUM_LoadGen) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36';
+
+    // Debug logging flag (set via DEBUG_LOGGING env var)
+    const debugEnabled = process.env.DEBUG_LOGGING === 'true';
+    if (debugEnabled) console.log('DEBUG: Using User Agent:', customUserAgent);
+
+    // Global browser instance for reuse across cycles
+    let globalBrowser = null;
+
+
+    async function launchBrowser() {
+      console.log('🔹 Starting headless browser...');
+      const browser = await puppeteer.launch({
+        headless: true,
+        defaultViewport: null,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--disable-web-security',
+          '--disable-features=VizDisplayCompositor',
+          '--max-old-space-size=256',
+          '--disable-extensions',
+          '--disable-plugins',
+          '--disable-background-networking',
+          '--disable-background-timer-throttling',
+          '--disable-backgrounding-occluded-windows',
+          '--disable-renderer-backgrounding',
+          '--memory-pressure-off',
+          '--aggressive-cache-discard',
+          '--ignore-certificate-errors',
+          '--allow-insecure-localhost',
+          `--user-agent=${customUserAgent}`
+        ]
+      });
+      console.log('✅ Browser started.');
+      return browser;
+    }
+
+    async function ensureBrowser() {
+      if (!globalBrowser || !globalBrowser.isConnected()) {
+        console.log('🔄 Launching new global browser instance...');
+        globalBrowser = await launchBrowser();
+      }
+      return globalBrowser;
+    }
+
+    function buildBaseUrl() {
+      const raw = (process.env.RUM_FRONTEND_IP || '').trim();
+
+      // If it's empty, default to localhost
+      if (!raw) return 'https://localhost/';
+
+      // If it already starts with http:// or https://, keep it exactly as-is
+      if (/^https?:\/\//i.test(raw)) {
+        return raw.replace(/\/+$/, '') + '/';
+      }
+
+      // Otherwise, prepend https://
+      return `https://${raw.replace(/\/+$/, '')}/`;
+    }
+
+    function getProductIds() {
+      const envProductIds = (process.env.PRODUCT_IDS || '').trim();
+      if (envProductIds) {
+        return envProductIds.split(',').map(id => id.trim()).filter(id => id);
+      }
+      // Hardcoded product IDs if env variable is not set or empty
+      return [
+        'OLJCESPC7Z', // National Park Foundation Explorascope
+        '66VCHSJNUP', // Starsense Explorer Refractor Telescope
+        '1YMWWN1N4O', // Eclipsmart Travel Refractor Telescope
+        'L9ECAV7KIM', // Lens Cleaning Kit
+        '2ZYFJ3GM2N', // Roof Binoculars
+        '0PUK6V6EV0', // Solar System Color Imager
+        'LS4PSXUNUM', // Red Flashlight
+        '9SIQT8TOJO', // Optical Tube Assembly
+        '6E92ZMYYFZ', // Solar Filter
+        'HQTGWGPNH4'  // The Comet Book
+      ];
+    }
+
+    function getRandomProducts() {
+      const allProducts = getProductIds();
+      const numProducts = Math.floor(Math.random() * 3) + 1; // Random number between 1 and 3
+      const shuffled = allProducts.sort(() => Math.random() - 0.5);
+      return shuffled.slice(0, numProducts);
+    }
+
+    // Throttle quick prompts — parsed from env, default 5 min
+    const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
+    let lastQuickPromptTime = 0;
+
+    // Shipping API — random interval between 34s and 1m45s
+    const SHIPPING_MIN_MS = parseInt(process.env.SHIPPING_MIN_MS || '34000', 10);
+    const SHIPPING_MAX_MS = parseInt(process.env.SHIPPING_MAX_MS || '105000', 10);
+    let nextShippingTime = 0;
+    const SHIPPING_API_ENABLED = (process.env.SHIPPING_API || '').toLowerCase() === 'true';
+
+    function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
+
+    /** Generate a random shipping tracking number */
+    function randomTrackingNumber() {
+      const num = Math.floor(Math.random() * 99999) + 10000;
+      return `SHIP-${num}`;
+    }
+
+    /** Schedule next shipping call at a random interval */
+    function scheduleNextShipping() {
+      const interval = SHIPPING_MIN_MS + Math.floor(Math.random() * (SHIPPING_MAX_MS - SHIPPING_MIN_MS));
+      nextShippingTime = Date.now() + interval;
+      if (debugEnabled) console.log(`[DEBUG] Next shipping call in ${Math.round(interval/1000)}s`);
+    }
+
+    /** Fetch shipping info via the frontend-proxy /shipping/ route */
+    async function fetchShippingInfo(page) {
+      if (!SHIPPING_API_ENABLED) return;
+      if (Date.now() < nextShippingTime) return;
+      scheduleNextShipping();
+
+      const tracking = randomTrackingNumber();
+      const base = buildBaseUrl();
+      const url = `${base}shipping/?tracking=${tracking}`;
+      console.log(`📦 Fetching shipping info for ${tracking}...`);
+      try {
+        const result = await page.evaluate(async (fetchUrl) => {
+          const resp = await fetch(fetchUrl);
+          return { status: resp.status, body: await resp.text() };
+        }, url);
+        console.log(`📦 Shipping info: HTTP ${result.status}`);
+        if (debugEnabled) console.log(`[DEBUG] Shipping response: ${result.body}`);
+      } catch (e) {
+        console.log(`⚠️ Shipping info fetch failed: ${e.message}`);
+      }
+    }
+
+    /** Wait until innerText of the page contains a substring */
+    async function waitForText(page, text, timeoutMs = 30000, pollMs = 200) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const found = await page.evaluate(t =>
+          document && document.body && document.body.innerText.includes(t),
+          text
+        );
+        if (found) return true;
+        await delay(pollMs);
+      }
+      throw new Error(`Timed out waiting for text: "${text}"`);
+    }
+
+    async function runOnce() {
+      const browser = await ensureBrowser();
+      let page;
+      let ctx;
+      try {
+        // Fresh browser context per cycle so localStorage / cookies / session
+        // ID reset between cycles. Otherwise every cycle reuses the same RUM
+        // session ID and the funnel sees a single user looping forever.
+        ctx = await browser.createBrowserContext();
+        page = await ctx.newPage();
+        page.setDefaultNavigationTimeout(45000);
+        page.setDefaultTimeout && page.setDefaultTimeout(30000);
+
+        // Log all responses for debugging (when DEBUG_LOGGING=true)
+        if (debugEnabled) {
+          page.on('response', response => {
+            const url = response.url();
+            if (url.includes('api')) {
+              console.log(`[DEBUG] API Response: ${url} (${response.status()})`);
+            }
+          });
+        }
+
+        const base = buildBaseUrl();
+        const productsToOrder = getRandomProducts();
+        console.log(`🛒 Ordering ${productsToOrder.length} product(s): ${productsToOrder.join(', ')}`);
+
+        // Visit homepage first so the user enters the sequential RUM funnel
+        // at step 1. Without this the loadgen lands on /product/<id> and the
+        // funnel records 0 conversions because step 1 is never satisfied.
+        const homeUrl = base.replace(/\/+$/, '/');
+        console.log(`🏠 Visiting homepage ${homeUrl}`);
+        await page.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+        await delay(1500);
+
+        // Loop through each product and add to cart
+        for (const productId of productsToOrder) {
+          const url = new URL(`product/${productId}`, base).toString();
+          console.log(`🌐 Navigating to ${url}`);
+
+          // Set up /api/data response listener BEFORE navigation
+          const apiDataPromise = page.waitForResponse(
+            response => {
+              const url = response.url();
+              const status = response.status();
+              const matches = url.includes('/api/data') && (status === 200 || status === 304);
+              if (matches) {
+                console.log(`✅ /api/data response received: ${status}`);
+              }
+              return matches;
+            },
+            { timeout: 15000 }
+          );
+
+          // Navigate to page
+          await page.goto(url, {
+            waitUntil: 'networkidle2',  // Wait until no more than 2 connections for 500ms
+            timeout: 60000               // 60 second timeout for page load
+          });
+
+          // Now wait for /api/data to complete (may have already completed during goto)
+          console.log('⏳ Ensuring ad service (/api/data) completed...');
+          await apiDataPromise.catch(() => {
+            console.log('⚠️ /api/data did not complete in 15s, continuing anyway...');
+          });
+
+          // Small delay to ensure any follow-up requests finish
+          await delay(500);
+          console.log('✅ Page fully loaded with all API calls complete');
+
+          // Quick prompts - throttled to once every 5 minutes
+          const now = Date.now();
+          if (now - lastQuickPromptTime >= QUICK_PROMPT_INTERVAL_MS) {
+          lastQuickPromptTime = now;
+
+          const quickPrompts = [
+            {
+              label: 'Can you summarize the product reviews?',
+              dataCy: 'QuickPromptSummarize',
+              ariaSelector: '::-p-aria(Can you summarize the product reviews?)',
+              textSelector: '::-p-text(Can you summarize)',
+              offset: { x: 129, y: 15 },
+            },
+            {
+              label: 'Were there any negative reviews?',
+              dataCy: 'QuickPromptNegative',
+              ariaSelector: '::-p-aria(Were there any negative reviews?)',
+              textSelector: '::-p-text(Were there any)',
+              offset: { x: 171.6640625, y: 25 },
+            },
+            {
+              label: 'What age(s) is this recommended for?',
+              dataCy: 'QuickPromptAges',
+              ariaSelector: '::-p-aria(What age\\(s\\) is this recommended for?)',
+              textSelector: '::-p-text(What age\\(s\\) is)',
+              offset: { x: 148.0390625, y: 19 },
+            },
+          ];
+
+          const prompt = quickPrompts[Math.floor(Math.random() * quickPrompts.length)];
+          console.log(`🖱️ Clicking quick prompt: "${prompt.label}"`);
+
+          {
+              const targetPage = page;
+              const timeout = 5000;
+              await puppeteer.Locator.race([
+                  targetPage.locator(prompt.ariaSelector),
+                  targetPage.locator(`[data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(`::-p-xpath(//*[@data-cy=\\"${prompt.dataCy}\\"])`),
+                  targetPage.locator(`:scope >>> [data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(prompt.textSelector)
+              ])
+                  .setTimeout(timeout)
+                  .click({ offset: prompt.offset });
+              console.log('⏳ Waiting for AI response...');
+              await delay(500); // Let request start
+              await page.waitForSelector("[data-cy='AIAnswer']", { timeout: 15000, visible: true }).catch(() => {
+                console.log('⚠️ AI response timeout, continuing...');
+              });
+              await delay(1500); // Allow response to fully render
+          }
+
+          } else {
+            console.log('⏭️ Skipping quick prompts (next run in ' + Math.round((QUICK_PROMPT_INTERVAL_MS - (now - lastQuickPromptTime)) / 1000) + 's)');
+          }
+
+          const addSel = "[data-cy='product-add-to-cart']";
+          await page.waitForSelector(addSel);
+          console.log(`🖱️ Clicking "Add To Cart" for product ${productId}`);
+          await page.click(addSel);
+        }
+
+        // Place order after all products are added to cart
+        const placeSel = "[data-cy='checkout-place-order']";
+        await page.waitForSelector(placeSel);
+        console.log('🖱️ Clicking "Place Order"');
+        await page.click(placeSel);
+
+        // Wait for either success message or error modal
+        console.log('⏳ Waiting for order result...');
+        const orderResult = await Promise.race([
+          waitForText(page, 'Your order is complete!').then(() => 'success'),
+          page.waitForSelector('#modal-close-btn', { timeout: 30000, visible: true }).then(() => 'error-modal')
+        ]);
+
+        if (orderResult === 'success') {
+          console.log('🎉 Order completed successfully!');
+          // Confirmation page useEffect fires the `order.confirmed` RUM span
+          // asynchronously. Wait so the RUM batcher can flush the beacon
+          // before the page / context is torn down.
+          await delay(5000);
+        } else if (orderResult === 'error-modal') {
+          console.log('⚠️ Error modal detected - closing it to continue...');
+          await page.click('#modal-close-btn');
+          await delay(500);
+          console.log('✅ Error modal closed.');
+        }
+
+        // Periodic shipping info fetch (every 2 minutes, gated by SHIPPING_API)
+        await fetchShippingInfo(page);
+      } finally {
+        console.log('🧹 Cleaning up page resources...');
+        try {
+          if (page) {
+            page.removeAllListeners();
+            await page.close({ runBeforeUnload: true }).catch(()=>{});
+          }
+          if (ctx) {
+            await ctx.close().catch(()=>{});
+          }
+        } catch (e) {
+          console.error('⚠️ Error closing page:', e.message);
+        }
+        console.log('✅ Page + context closed cleanly. Browser will be reused for next cycle.');
+      }
+    }
+
+    (async function mainLoop() {
+      const cycleDelayMs = parseInt(process.env.CYCLE_DELAY_MS || '5000', 10);
+      console.log(`⚙️ Cycle delay: ${cycleDelayMs}ms`);
+
+      let cycle = 1;
+      while (true) {
+        console.log(`=== Starting load generation cycle #${cycle} ===`);
+        try {
+          await runOnce();
+          console.log(`✅ Cycle #${cycle} finished OK`);
+        } catch (e) {
+          console.error(`❌ Cycle #${cycle} failed:`, e && e.stack ? e.stack : e);
+        }
+        cycle += 1;
+        await delay(cycleDelayMs);
+      }
+    })();
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astronomy-loadgen-deployment
+  labels:
+    app: astronomy-loadgen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: astronomy-loadgen
+  template:
+    metadata:
+      labels:
+        app: astronomy-loadgen
+    spec:
+      initContainers:
+      - name: wait-for-frontend
+        image: curlimages/curl:8.1.2
+        command: ['sh', '-c']
+        args:
+        - |
+          echo "Waiting for frontend-proxy to be ready..."
+          until curl -f --connect-timeout 5 --max-time 10 http://frontend-proxy:8080; do
+            echo "Frontend not ready, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Frontend is ready, starting loadgen..."
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "50m"
+      containers:
+      - name: astronomy-loadgen
+        image: ghcr.io/splunk/online-boutique/rumloadgen:5.6
+        imagePullPolicy: Always
+        env:
+        # NOTE: For RUM funnels that filter on the public ingress URL (e.g.
+        # `https://astronomy-shop.example.com`), override this value per
+        # deployment so the loadgen browser navigates to the same origin as
+        # real users. The in-cluster default below works for traffic-only
+        # generation but produces RUM events tagged with the internal URL.
+        - name: RUM_FRONTEND_IP
+          value: "http://frontend-proxy:8080"
+        - name: CYCLE_DELAY_MS
+          value: "1000"
+        - name: DEBUG_LOGGING
+          value: ""  # Set to "true" to enable debug logging
+        - name: QUICK_PROMPT_INTERVAL_MS
+          value: "300000"  # How often AI quick prompts run (ms). Default 300000 (5min). Set "0" for every cycle.
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "500m"
+          limits:
+            memory: "1536Mi"
+            cpu: "1000m"
+        volumeMounts:
+        - name: puppeteer
+          subPath: local-file
+          mountPath: /puppeteer/touchwebsite.js
+      volumes:
+      - name: puppeteer
+        configMap:
+          name: scriptfile
+
+---
+
+# === cart ===
+# Kubernetes manifest for cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: cart
+        app.kubernetes.io/component: cart
+        app.kubernetes.io/name: cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: cart
+        image: ghcr.io/splunk/opentelemetry-demo/otel-cart:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CART_PORT
+          value: '8080'
+        - name: ASPNETCORE_URLS
+          value: http://*:$(CART_PORT)
+        - name: VALKEY_ADDR
+          value: valkey-cart:6379
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          limits:
+            memory: 320Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep
+          2; done;
+        image: busybox:latest
+        name: wait-for-valkey-cart
+      volumes: null
+
+---
+
+# === checkout ===
+# Kubernetes manifest for checkout
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: checkout
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: checkout
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: checkout
+        app.kubernetes.io/component: checkout
+        app.kubernetes.io/name: checkout
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: checkout
+        image: ghcr.io/splunk/opentelemetry-demo/otel-checkout:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CHECKOUT_PORT
+          value: '8080'
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: EMAIL_ADDR
+          value: http://email:8080
+        - name: PAYMENT_ADDR
+          value: payment:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 16MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === currency ===
+# Kubernetes manifest for currency
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: currency
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: currency
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: currency
+        app.kubernetes.io/component: currency
+        app.kubernetes.io/name: currency
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: currency
+        image: ghcr.io/open-telemetry/demo:2.2.0-currency
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CURRENCY_PORT
+          value: '8080'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: VERSION
+          value: 2.1.3
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === email ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for email
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: email
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: email
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: email
+        app.kubernetes.io/component: email
+        app.kubernetes.io/name: email
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: email
+        image: ghcr.io/open-telemetry/demo:2.2.0-email
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: EMAIL_PORT
+          value: '8080'
+        - name: APP_ENV
+          value: production
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === flagd ===
+# Kubernetes manifest for flagd
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8013
+    name: rpc
+    targetPort: 8013
+  - port: 8016
+    name: ofrep
+    targetPort: 8016
+  selector:
+    opentelemetry.io/name: flagd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd
+        app.kubernetes.io/component: flagd
+        app.kubernetes.io/name: flagd
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: flagd
+        image: ghcr.io/open-feature/flagd:v0.14.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /flagd-build
+        - start
+        - --port
+        - '8013'
+        - --ofrep-port
+        - '8016'
+        - --uri
+        - file:./etc/flagd/demo.flagd.json
+        ports:
+        - containerPort: 8013
+          name: rpc
+        - containerPort: 8016
+          name: ofrep
+        env:
+        - name: GOMEMLIMIT
+          value: 60MiB
+        resources:
+          limits:
+            memory: 75Mi
+        volumeMounts:
+        - name: config-rw
+          mountPath: /etc/flagd
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === flagd-config ===
+# Kubernetes manifest for flagd-config
+# NOTE: The ConfigMap is generated at stitch time from src/flagd/demo.flagd.json
+# This file only contains the PVC definition
+---
+# PersistentVolumeClaim for shared flagd configuration
+# This PVC is shared between flagd and flagd-ui to enable dynamic flag updates
+# Using ReadWriteOnce with podAffinity to ensure both pods on same node
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flagd-shared-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/component: flagd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flagd-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  demo.flagd.json: |
+    {
+      "$schema": "https://flagd.dev/schema/v0/flags.json",
+      "flags": {
+        "llmInaccurateResponse": {
+          "defaultVariant": "off",
+          "description": "LLM returns an inaccurate product summary for product ID L9ECAV7KIM",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "llmRateLimitError": {
+          "defaultVariant": "off",
+          "description": "LLM intermittently returns a rate limit error",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "productCatalogFailure": {
+          "description": "Fail product catalog service on a specific product",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCacheFailure": {
+          "description": "Fail recommendation service cache",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adManualGc": {
+          "description": "Triggers full manual garbage collections in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adHighCpu": {
+          "description": "Triggers high cpu load in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adFailure": {
+          "description": "Fail ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "kafkaQueueProblems": {
+          "description": "Overloads Kafka queue while simultaneously introducing a consumer side delay leading to a lag spike",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "cartFailure": {
+          "description": "Fail cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentFailure": {
+          "description": "Fail payment service charge requests n%",
+          "state": "ENABLED",
+          "variants": {
+            "100%": 1,
+            "90%": 0.95,
+            "75%": 0.75,
+            "50%": 0.5,
+            "25%": 0.25,
+            "10%": 0.1,
+            "off": 0
+          },
+          "defaultVariant": "50%"
+        },
+        "rumBlueGreen": {
+          "description": "Enable RUM-based payment path (A/B) tracking in user.deployment_type attribute",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentUnreachable": {
+          "description": "Payment service is unavailable",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "loadGeneratorFloodHomepage": {
+          "description": "Flood the frontend with a large amount of requests.",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "imageSlowLoad": {
+          "description": "slow loading images in the frontend",
+          "state": "ENABLED",
+          "variants": {
+            "10sec": 10000,
+            "5sec": 5000,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "failedReadinessProbe": {
+          "description": "readiness probe failure for cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+    
+        },
+        "emailMemoryLeak": {
+          "description": "Memory leak in the email service.",
+          "state": "ENABLED",
+          "variants": {
+            "off": 0,
+            "1x": 1,
+            "10x": 10,
+            "100x": 100,
+            "1000x": 1000,
+            "10000x": 10000
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCartesianQuery": {
+          "description": "DBMon Demo: Triggers a Cartesian join query (500M rows) in recommendation service PostgreSQL calls. Query returns correct results but processes 500M intermediate rows, taking 12+ seconds.",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "secureappAttack": {
+          "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",
+          "state": "ENABLED",
+          "variants": {
+            "minimal": "minimal",
+            "targeted": "targeted",
+            "max": "max"
+          },
+          "defaultVariant": "minimal"
+        }
+      }
+    }
+
+---
+
+# === flagd-ui ===
+# Kubernetes manifest for flagd-ui
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4000
+    name: tcp-service
+    targetPort: 4000
+  selector:
+    opentelemetry.io/name: flagd-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd-ui
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd-ui
+        app.kubernetes.io/component: flagd-ui
+        app.kubernetes.io/name: flagd-ui
+    spec:
+      serviceAccountName: opentelemetry-demo
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: opentelemetry.io/name
+                operator: In
+                values:
+                - flagd
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: flagd-ui
+        image: ghcr.io/open-telemetry/demo:2.2.0-flagd-ui
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 4000
+          name: service
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: SECRET_KEY_BASE
+          value: yYrECL4qbNwleYInGJYvVnSkwJuSQJ4ijPTx5tirGUXrbznFIBFVJdPl5t6O9ASw
+        - name: PHX_HOST
+          value: localhost
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        resources:
+          limits:
+            memory: 250Mi
+        volumeMounts:
+        - mountPath: /app/data
+          name: config-rw
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === fraud-detection ===
+# Kubernetes manifest for fraud-detection
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fraud-detection
+  labels:
+    opentelemetry.io/name: fraud-detection
+    app.kubernetes.io/component: fraud-detection
+    app.kubernetes.io/name: fraud-detection
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: fraud-detection
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: fraud-detection
+        app.kubernetes.io/component: fraud-detection
+        app.kubernetes.io/name: fraud-detection
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: fraud-detection
+        image: ghcr.io/splunk/opentelemetry-demo/otel-fraud-detection:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_INSTRUMENTATION_KAFKA_CLIENTS_ENABLED
+          value: 'false'
+        - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+          value: 'true'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=propagation
+        - name: SQL_SERVER_HOST
+          value: sql-server-fraud.default.svc.cluster.local
+        - name: SQL_SERVER_PORT
+          value: '1433'
+        - name: SQL_SERVER_DATABASE
+          value: FraudDetection
+        - name: SQL_SERVER_USER
+          value: sa
+        - name: SQL_SERVER_PASSWORD
+          value: ChangeMe_SuperStrong123!
+        - name: FRAUD_DETECTION_RATE
+          value: '80'
+        - name: CLEANUP_RETENTION_DAYS
+          value: '4'
+        - name: CLEANUP_INTERVAL_HOURS
+          value: '6'
+        - name: FRAUD_MUTATION_PERCENTAGE
+          value: '25'
+        - name: BAD_QUERY_PERCENTAGE
+          value: '0'
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 512Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 sql-server-fraud.default.svc.cluster.local 1433; do echo
+          waiting for sql-server-fraud; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-sqlserver
+      volumes: null
+
+---
+
+# === frontend ===
+# Kubernetes manifest for frontend
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: frontend
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: PORT
+          value: $(FRONTEND_PORT)
+        - name: FRONTEND_ADDR
+          value: :8080
+        - name: AD_ADDR
+          value: ad:8080
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CHECKOUT_ADDR
+          value: checkout:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: PRODUCT_REVIEWS_ADDR
+          value: product-reviews:3551
+        - name: RECOMMENDATION_ADDR
+          value: recommendation:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: ENV_PLATFORM
+          value: kubernetes
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+        - name: OTEL_LOG_LEVEL
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: api_token
+              optional: true
+        - name: SPLUNK_RUM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: rum_token
+        - name: SPLUNK_APP_NAME
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: app
+        - name: SPLUNK_RUM_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: SPLUNK_RUM_REALM
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: realm
+        resources:
+          limits:
+            memory: 250Mi
+        securityContext:
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === frontend-proxy ===
+# Kubernetes manifest for frontend-proxy
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend-proxy
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend-proxy
+        app.kubernetes.io/component: frontend-proxy
+        app.kubernetes.io/name: frontend-proxy
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend-proxy
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend-proxy:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: ENVOY_ADDR
+          value: 0.0.0.0
+        - name: ENVOY_PORT
+          value: '8080'
+        - name: ENVOY_ADMIN_PORT
+          value: '10000'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8016'
+        - name: FLAGD_UI_HOST
+          value: flagd-ui
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: FRONTEND_HOST
+          value: frontend
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: IMAGE_PROVIDER_HOST
+          value: image-provider
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: LOCUST_WEB_HOST
+          value: load-generator
+        - name: LOCUST_WEB_PORT
+          value: '8089'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_PORT_HTTP
+          value: '4318'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: SECUREAPP_HOST
+          value: secureapp-loadgen
+        - name: SECUREAPP_PORT
+          value: '8080'
+        - name: FEATURE_AUTH_ENABLED
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_auth
+              optional: true
+        - name: FEATURE_USER
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_user
+              optional: true
+        - name: FEATURE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_pw
+              optional: true
+        resources:
+          limits:
+            memory: 65Mi
+        securityContext:
+          runAsGroup: 101
+          runAsNonRoot: true
+          runAsUser: 101
+        volumeMounts: null
+      volumes: null
+---
+
+
+---
+
+# === image-provider ===
+# Kubernetes manifest for image-provider
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8081
+    name: tcp-service
+    targetPort: 8081
+  selector:
+    opentelemetry.io/name: image-provider
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: image-provider
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: image-provider
+        app.kubernetes.io/component: image-provider
+        app.kubernetes.io/name: image-provider
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: image-provider
+        image: ghcr.io/splunk/opentelemetry-demo/otel-image-provider:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 50Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === kafka ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for kafka
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9092
+    name: plaintext
+    targetPort: 9092
+  - port: 9093
+    name: controller
+    targetPort: 9093
+  selector:
+    opentelemetry.io/name: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: kafka
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: kafka
+        app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: kafka
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: kafka
+        image: ghcr.io/open-telemetry/demo:2.2.0-kafka
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+          name: plaintext
+        - containerPort: 9093
+          name: controller
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka:9092
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx400M -Xms400M
+        - name: KAFKA_LISTENERS
+          value: PLAINTEXT://:9092,CONTROLLER://:9093
+        - name: KAFKA_CONTROLLER_LISTENER_NAMES
+          value: CONTROLLER
+        - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+          value: 1@kafka:9093
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 800Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === llm ===
+# Kubernetes manifest for llm
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    name: tcp-service
+    targetPort: 8000
+  selector:
+    opentelemetry.io/name: llm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: llm
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: llm
+        app.kubernetes.io/component: llm
+        app.kubernetes.io/name: llm
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: llm
+        image: ghcr.io/splunk/opentelemetry-demo/otel-llm:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === demo-service-account ===
+# Kubernetes manifest for demo-service-account
+# ServiceAccount used by all Astronomy Shop application pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-demo
+  labels:
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+
+---
+
+# === payment-vA ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version A - Stable/Conservative Version
+# This manifest deploys payment service v1.7.0-a with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-payment-secret
+type: Opaque
+stringData:
+  api-token: "prod-a8cf28f9-1a1a-4994-bafa-cd4b143c3291"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-va
+    app.kubernetes.io/version: "1.7.0-a"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vA
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vA
+        opentelemetry.io/name: payment-va
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-va
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version A
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vA"]
+
+        # Anti-affinity - never on same node as version B
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vB
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.9"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-a"
+
+        # Token from dedicated secret for version A
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: prod-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=multienv-test,payment.variant=A"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging
+        - name: OTEL_LOG_LEVEL
+          value: info
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vA
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === payment-vB ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version B - Optimized/Next-gen Version
+# This manifest deploys payment service v1.7.0-b with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-payment-secret
+type: Opaque
+stringData:
+  api-token: "test-20e26e90-356b-432e-a2c6-956fc03f5609"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-vb
+    app.kubernetes.io/version: "1.7.0-b"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vB
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vB
+        opentelemetry.io/name: payment-vb
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-vb
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version B
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vB"]
+
+        # Anti-affinity - never on same node as version A
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vA
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.10"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-b"
+
+        # Token from dedicated secret for version B
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: test-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=multienv-test,payment.variant=B"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging (more verbose for version B)
+        - name: OTEL_LOG_LEVEL
+          value: debug
+        - name: LOG_LEVEL
+          value: debug
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vB
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === postgresql-setup ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# PostgreSQL Database Initialization ConfigMap
+# This ConfigMap contains scripts that create schemas, tables, and extensions
+# for the accounting, product-catalog, product-reviews, and recommendation services
+#
+# The postgres deployment mounts these as /docker-entrypoint-initdb.d/
+# which PostgreSQL automatically executes on first startup (alphabetical order)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-sql
+  labels:
+    app.kubernetes.io/name: postgres-init
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # Shell script runs first (alphabetically) to create extension in postgres database
+  00-pg-stat-statements.sh: |
+    #!/bin/bash
+    # Create pg_stat_statements extension in the postgres database
+    # This is required for PostgreSQL receiver top query monitoring
+    set -e
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<-EOSQL
+        CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    EOSQL
+    echo "pg_stat_statements extension created in postgres database"
+  init.sql: |
+    -- Copyright The OpenTelemetry Authors
+    -- SPDX-License-Identifier: Apache-2.0
+
+    -- Enable pg_stat_statements for database monitoring (top query tracking)
+    -- Note: This runs in the 'otel' database. The extension is also created
+    -- in the 'postgres' database by 00-pg-stat-statements.sh for top query monitoring.
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+    CREATE USER otelu WITH PASSWORD 'otelp';
+
+    -- Accounting Service: create a schema
+    CREATE SCHEMA accounting;
+    GRANT USAGE ON SCHEMA accounting TO otelu;
+
+    -- Accounting Service: create tables
+    CREATE TABLE accounting."order" (
+        order_id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE accounting.shipping (
+        shipping_tracking_id TEXT PRIMARY KEY,
+        shipping_cost_currency_code TEXT NOT NULL,
+        shipping_cost_units BIGINT NOT NULL,
+        shipping_cost_nanos INT NOT NULL,
+        street_address TEXT,
+        city TEXT,
+        state TEXT,
+        country TEXT,
+        zip_code TEXT,
+        order_id TEXT NOT NULL,
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE accounting.orderitem (
+        item_cost_currency_code TEXT NOT NULL,
+        item_cost_units BIGINT NOT NULL,
+        item_cost_nanos INT NOT NULL,
+        product_id TEXT NOT NULL,
+        quantity INT NOT NULL,
+        order_id TEXT NOT NULL,
+        PRIMARY KEY (order_id, product_id),
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    -- Accounting Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA accounting TO otelu;
+
+    -- Product Catalog Service: create a schema
+    CREATE SCHEMA catalog;
+    GRANT USAGE ON SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: create tables
+    CREATE TABLE catalog.products (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        picture TEXT,
+        price_currency_code TEXT NOT NULL,
+        price_units BIGINT NOT NULL,
+        price_nanos INT NOT NULL,
+        categories TEXT
+    );
+
+    -- Product Catalog Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: add product data
+    INSERT INTO catalog.products (id, name, description, picture, price_currency_code, price_units, price_nanos, categories)
+    VALUES
+        ('OLJCESPC7Z', 'National Park Foundation Explorascope', 'The National Park Foundation''s (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.', 'NationalParkFoundationExplorascope.jpg', 'USD', 101, 960000000, 'telescopes'),
+        ('66VCHSJNUP', 'Starsense Explorer Refractor Telescope', 'The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app''s user-friendly interface and detailed tutorials. It''s like having your own personal tour guide of the night sky', 'StarsenseExplorer.jpg', 'USD', 349, 950000000, 'telescopes'),
+        ('1YMWWN1N4O', 'Eclipsmart Travel Refractor Telescope', 'Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.', 'EclipsmartTravelRefractorTelescope.jpg', 'USD', 129, 950000000, 'telescopes,travel'),
+        ('L9ECAV7KIM', 'Lens Cleaning Kit', 'Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.', 'LensCleaningKit.jpg', 'USD', 21, 950000000, 'accessories'),
+        ('2ZYFJ3GM2N', 'Roof Binoculars', 'This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It''s an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.', 'RoofBinoculars.jpg', 'USD', 209, 950000000, 'binoculars'),
+        ('0PUK6V6EV0', 'Solar System Color Imager', 'You have your new telescope and have observed Saturn and Jupiter. Now you''re ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.', 'SolarSystemColorImager.jpg', 'USD', 175, 0, 'accessories,telescopes'),
+        ('LS4PSXUNUM', 'Red Flashlight', 'This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red''s rugged, IPX4-rated design will withstand your everyday activities.', 'RedFlashlight.jpg', 'USD', 57, 80000000, 'accessories,flashlights'),
+        ('9SIQT8TOJO', 'Optical Tube Assembly', 'Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today''s top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won''t need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.', 'OpticalTubeAssembly.jpg', 'USD', 3599, 0, 'accessories,telescopes,assembly'),
+        ('6E92ZMYYFZ', 'Solar Filter', 'Enhance your viewing experience with EclipSmart Solar Filter for 8" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.', 'SolarFilter.jpg', 'USD', 69, 950000000, 'accessories,telescopes'),
+        ('HQTGWGPNH4', 'The Comet Book', 'A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as "Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)', 'TheCometBook.jpg', 'USD', 0, 990000000, 'books');
+
+    -- Product Review Service: create a schema
+    CREATE SCHEMA reviews;
+    GRANT USAGE ON SCHEMA reviews TO otelu;
+
+    -- Product Review Service: create tables
+    CREATE TABLE reviews.productreviews (
+        id INTEGER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+        product_id VARCHAR(16) NOT NULL,
+        username VARCHAR(64) NOT NULL,
+        description VARCHAR(1024),
+        score NUMERIC(2,1) NOT NULL
+    );
+
+    -- Product Review Service: create index for product_id lookups
+    CREATE INDEX product_id_index ON reviews.productreviews (product_id);
+
+    -- Product Review Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA reviews TO otelu;
+
+    -- Product Review Service:  add product review data
+    INSERT INTO reviews.productreviews (product_id, username, description, score)
+    VALUES
+        ('OLJCESPC7Z', 'stargazer_mike', 'Great entry-level telescope! Easy to set up and provides clear views of the moon and brighter planets. Highly recommend for new astronomers.', '4.5'),
+        ('OLJCESPC7Z', 'nightskylover', 'For the price, this Explorascope delivers excellent performance. I was able to see Jupiter''s moons clearly. A fantastic purchase for casual viewing.', '4.0'),
+        ('OLJCESPC7Z', 'beginner_astro', 'A bit tricky to get used to the manual controls, but once you do, it''s very rewarding. Saw the Orion Nebula for the first time! Good value.', '3.5'),
+        ('OLJCESPC7Z', 'celestial_explorer', 'Perfect for camping trips. It''s lightweight and portable, making it easy to take anywhere. The views are surprisingly good for its size.', '4.0'),
+        ('OLJCESPC7Z', 'telescope_fan', 'Not the most powerful scope, but it''s great for kids and beginners. My children love looking at the moon with it. A solid choice for family fun.', '3.0'),
+
+        ('66VCHSJNUP', 'tech_astro', 'The StarSense app is revolutionary! It made finding celestial objects incredibly easy. This telescope is a game-changer for beginners.', '5.0'),
+        ('66VCHSJNUP', 'app_user', 'Amazing technology, the smartphone integration works flawlessly. I''ve never had so much fun exploring the night sky. Worth every penny.', '4.5'),
+        ('66VCHSJNUP', 'innovator_john', 'Setup was a breeze, and the tutorials in the app are very helpful. The views are crisp and clear. My only minor gripe is battery drain on the phone.', '4.0'),
+        ('66VCHSJNUP', 'clear_skies', 'Finally, a telescope that takes the guesswork out of stargazing. The real-time positioning is incredibly accurate. Highly recommended for anyone new to astronomy.', '5.0'),
+        ('66VCHSJNUP', 'gadget_geek', 'Fantastic product, the app truly guides you. It''s like having a personal astronomer with you. The optical quality is also very good.', '4.5'),
+
+        ('1YMWWN1N4O', 'solar_viewer', 'Perfect for solar observations! The Solar Safe filter gives peace of mind. I used it for the last partial eclipse and it was fantastic.', '5.0'),
+        ('1YMWWN1N4O', 'eclipse_chaser', 'Compact and easy to carry, this telescope is ideal for eclipse events. The included backpack is a nice touch. Views of the sun are incredibly clear and safe.', '4.5'),
+        ('1YMWWN1N4O', 'travel_astro', 'Excellent travel scope for solar viewing. The magnification is much better than binoculars for the sun. A must-have for any solar enthusiast.', '4.0'),
+        ('1YMWWN1N4O', 'sun_gazer', 'Very impressed with the safety features and clarity. Sharing the sun with family has never been easier or safer. Great value for a dedicated solar scope.', '5.0'),
+        ('1YMWWN1N4O', 'safe_viewer', 'The ISO compliant filter is reassuring. It''s a well-designed product for safe solar observation. Highly recommend for educational purposes too.', '4.5'),
+
+        ('L9ECAV7KIM', 'clean_optics', 'This kit is a lifesaver for all my optics. The brush and wipes work perfectly without leaving any residue. My lenses have never been cleaner.', '5.0'),
+        ('L9ECAV7KIM', 'photog_pro', 'Essential for any photographer or telescope owner. It safely removes dust and fingerprints. A high-quality cleaning solution.', '4.5'),
+        ('L9ECAV7KIM', 'daily_cleaner', 'I use this on my binoculars, camera lenses, and even my phone screen. It''s very effective and gentle. A versatile cleaning kit.', '4.0'),
+        ('L9ECAV7KIM', 'tech_maintenance', 'Great value for money. The different cleaning options cover all needs. Keeps my expensive equipment in pristine condition.', '5.0'),
+        ('L9ECAV7KIM', 'sharp_view', 'Works as advertised, my telescope views are much clearer after using this. The fluid and cloth are excellent. Definitely recommend.', '4.5'),
+
+        ('2ZYFJ3GM2N', 'bird_watcher', 'Incredible clarity and brightness, perfect for bird watching. The ED glass really makes a difference. I can spot the subtlest markings.', '5.0'),
+        ('2ZYFJ3GM2N', 'nature_lover', 'These binoculars are fantastic for nature observation. The close focus is a huge advantage for viewing nearby wildlife. Very comfortable to hold.', '4.5'),
+        ('2ZYFJ3GM2N', 'hiker_guy', 'Lightweight and durable, these are my go-to binoculars for hiking. The wide field of view is excellent. Highly recommend for outdoor enthusiasts.', '4.0'),
+        ('2ZYFJ3GM2N', 'stadium_fan', 'Took these to a game and had an amazing view of the action. They perform great in various lighting conditions. A solid all-around binocular.', '4.0'),
+        ('2ZYFJ3GM2N', 'outdoor_adventurer', 'Excellent build quality and optical performance. They feel robust and provide sharp images. A great investment for any outdoor activity.', '4.5'),
+
+        ('0PUK6V6EV0', 'astro_photog', 'This imager is a fantastic step up for planetary photography. The color quality is superb. Easy to use with my existing telescope setup.', '5.0'),
+        ('0PUK6V6EV0', 'planet_shooter', 'Finally capturing stunning images of Saturn and Jupiter! The NexImage 10 makes it so accessible. Great for beginners in astrophotography.', '4.5'),
+        ('0PUK6V6EV0', 'imager_pro', 'Excellent resolution and color rendition for its price point. It''s a perfect solution for those looking to start imaging planets. Highly satisfied.', '4.0'),
+        ('0PUK6V6EV0', 'space_artist', 'The detail I can capture with this imager is incredible. It integrates well with various software. A must-have for serious planetary observers.', '5.0'),
+        ('0PUK6V6EV0', 'digital_sky', 'A solid choice for getting into solar system imaging. The setup was straightforward. Produces beautiful, vibrant planetary images.', '4.5'),
+
+        ('LS4PSXUNUM', 'night_walker', 'The red light is perfect for preserving night vision during astronomy sessions. The hand warmer is an unexpected bonus. Very practical device.', '5.0'),
+        ('LS4PSXUNUM', 'star_party_goer', 'This flashlight is indispensable for star parties. The red mode is gentle on the eyes, and the power bank feature is super handy. Love it!', '4.5'),
+        ('LS4PSXUNUM', 'camper_chris', 'Rugged and versatile, this flashlight is great for camping and night walks. The hand warmer function is a game-changer on cold nights. Highly recommend.', '4.5'),
+        ('LS4PSXUNUM', 'emergency_kit', 'A fantastic multi-tool for my emergency kit. The red light is useful, and the power bank means I can charge my phone. Great design.', '4.0'),
+        ('LS4PSXUNUM', 'astro_accessory', 'Every astronomer needs one of these. The red light is essential, and the hand warmer and power bank make it incredibly useful. A top-tier accessory.', '5.0'),
+
+        ('9SIQT8TOJO', 'deep_sky_master', 'The RASA V2 is a dream come true for deep-sky imaging. The f/2.2 speed drastically cuts down exposure times. My best astrophotography investment yet.', '5.0'),
+        ('9SIQT8TOJO', 'pro_astro', 'Unbelievable performance for wide-field astrophotography. The short focal length makes guiding less critical. Produces stunning, detailed images.', '5.0'),
+        ('9SIQT8TOJO', 'imaging_guru', 'This OTA is a beast! The fast optics mean more data in less time. If you''re serious about deep-sky imaging, this is the one.', '4.5'),
+        ('9SIQT8TOJO', 'advanced_scope', 'Worth every penny for the quality and speed it offers. My images have never been sharper or more vibrant. A truly professional piece of equipment.', '5.0'),
+        ('9SIQT8TOJO', 'precision_optics', 'The engineering behind this RASA is exceptional. It''s incredibly efficient for capturing faint objects. A high-end choice for dedicated imagers.', '4.5'),
+
+        ('6E92ZMYYFZ', 'solar_safety', 'Essential for safe solar viewing with my 8-inch telescope. The Velcro straps ensure it stays securely in place. Peace of mind during solar observations.', '5.0'),
+        ('6E92ZMYYFZ', 'telescope_upgrade', 'This EclipSmart filter is a perfect addition to my setup. The ISO compliance is crucial. Highly recommend for anyone looking to view the sun safely.', '4.5'),
+        ('6E92ZMYYFZ', 'safe_sun_gazer', 'Easy to attach and provides crystal clear, safe views of the sun. The build quality is excellent. A must-have accessory for solar enthusiasts.', '5.0'),
+        ('6E92ZMYYFZ', 'filter_fan', 'Works perfectly with my 8-inch scope. No more worries about accidental dislodgement. Great product for protecting your eyes and equipment.', '4.5'),
+        ('6E92ZMYYFZ', 'eclipse_ready', 'Bought this for the upcoming eclipse, and it fits perfectly. Tested it out, and the views are fantastic and safe. Very happy with this purchase.', '5.0'),
+
+        ('HQTGWGPNH4', 'history_buff', 'A fascinating glimpse into historical astronomical thought. The content is incredibly insightful. A must-read for anyone interested in the history of science.', '5.0'),
+        ('HQTGWGPNH4', 'bookworm_astro', 'Beautifully presented historical document. It''s amazing to see how comets were understood centuries ago. A valuable addition to any astronomy library.', '4.5'),
+        ('HQTGWGPNH4', 'ancient_texts', 'Such a unique and intriguing read. The historical context is captivating. It offers a different perspective on celestial events.', '4.0'),
+        ('HQTGWGPNH4', 'celestial_history', 'I love historical astronomy, and this book delivers. It''s well-researched and provides a window into past beliefs. Highly recommended for scholars.', '5.0'),
+        ('HQTGWGPNH4', 'rare_find', 'A truly special book for enthusiasts of astronomical history. The details about ancient astrologers are very interesting. Great for a deeper understanding.', '4.5');
+
+    -- ============================================================
+    -- Recommendation Service: DBMon Cartesian Join Demo
+    -- ============================================================
+
+    -- Recommendation Service: create tables (public schema)
+    CREATE TABLE IF NOT EXISTS products (
+        id           SERIAL PRIMARY KEY,
+        product_id   VARCHAR(64) UNIQUE NOT NULL,
+        name         VARCHAR(255),
+        category     VARCHAR(64),
+        price        DECIMAL(10,2),
+        created_at   TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS product_tags (
+        id              SERIAL PRIMARY KEY,
+        product_id      VARCHAR(64) NOT NULL,
+        tag             VARCHAR(64),
+        relevance_score DECIMAL(4,3)
+    );
+
+    -- Recommendation Service: seed 5,000 products
+    INSERT INTO products (product_id, name, category, price)
+    SELECT 'prod_' || gs, 'Product ' || gs,
+           (ARRAY['telescope','eyepiece','mount','camera','filter'])[floor(random()*5+1)],
+           (random() * 2000 + 50)::DECIMAL
+    FROM generate_series(1, 5000) gs
+    ON CONFLICT (product_id) DO NOTHING;
+
+    -- Recommendation Service: seed 100,000 tags (~20 per product)
+    INSERT INTO product_tags (product_id, tag, relevance_score)
+    SELECT 'prod_' || gs,
+           (ARRAY['beginner','advanced','astrophotography','visual','planetary',
+                  'deepsky','portable','goto','wifi','budget'])[floor(random()*10+1)],
+           (random())::DECIMAL
+    FROM generate_series(1, 5000) gs, generate_series(1, 20);
+
+    -- DO NOT create indexes or run ANALYZE - we want worst-case execution plan
+
+    -- Recommendation Service: create application user with settings that force Nested Loop Cartesian
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'demo_app_user') THEN
+            CREATE ROLE demo_app_user WITH LOGIN PASSWORD 'demo_password';
+        END IF;
+    END
+    $$;
+
+    GRANT SELECT ON products TO demo_app_user;
+    GRANT SELECT ON product_tags TO demo_app_user;
+
+    -- Force worst-case execution plan for demo_app_user
+    ALTER ROLE demo_app_user SET work_mem = '64kB';
+    ALTER ROLE demo_app_user SET enable_hashjoin  = OFF;
+    ALTER ROLE demo_app_user SET enable_mergejoin = OFF;
+
+---
+
+# === postgresql ===
+# Kubernetes manifest for postgres (PostgreSQL database)
+# Extracted from opentelemetry-demo.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    name: tcp-service
+    targetPort: 5432
+  selector:
+    opentelemetry.io/name: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: postgresql
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: postgresql
+        splunk.com/postgresql.database: otel
+      labels:
+        opentelemetry.io/name: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/name: postgresql
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: postgresql
+        image: postgres:17.8
+        imagePullPolicy: IfNotPresent
+        args:
+          - "-c"
+          - "shared_preload_libraries=pg_stat_statements"
+          - "-c"
+          - "pg_stat_statements.track=all"
+        ports:
+        - containerPort: 5432
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: POSTGRES_USER
+          value: root
+        - name: POSTGRES_PASSWORD
+          value: otel
+        - name: POSTGRES_DB
+          value: otel
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 256Mi
+        volumeMounts:
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/00-pg-stat-statements.sh
+          subPath: 00-pg-stat-statements.sh
+          readOnly: true
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/init.sql
+          subPath: init.sql
+          readOnly: true
+      volumes:
+      - name: postgres-init
+        configMap:
+          name: postgres-init-sql
+          defaultMode: 0755
+
+---
+
+# === product-catalog ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for product-catalog
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s): Service, Deployment, and ConfigMap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: product-catalog
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-catalog
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-catalog
+        app.kubernetes.io/component: product-catalog
+        app.kubernetes.io/name: product-catalog
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-catalog
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-catalog:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_CATALOG_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_RELOAD_INTERVAL
+          value: '10'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: "host=postgresql user=otelu password=otelp dbname=otel sslmode=disable"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 200MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            memory: 200Mi
+        volumeMounts:
+        - name: product-catalog-products
+          mountPath: /usr/src/app/products
+      volumes:
+      - name: product-catalog-products
+        configMap:
+          name: product-catalog-products
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-products
+  labels:
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # yamllint disable rule:line-length
+  products.json: |
+    {
+      "products": [
+        {
+          "id": "OLJCESPC7Z",
+          "name": "National Park Foundation Explorascope",
+          "description": "The National Park Foundation's (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.",
+          "picture": "NationalParkFoundationExplorascope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 101,
+            "nanos": 960000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "66VCHSJNUP",
+          "name": "Starsense Explorer Refractor Telescope",
+          "description": "The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app's user-friendly interface and detailed tutorials. It's like having your own personal tour guide of the night sky",
+          "picture": "StarsenseExplorer.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 349,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "1YMWWN1N4O",
+          "name": "Eclipsmart Travel Refractor Telescope",
+          "description": "Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.",
+          "picture": "EclipsmartTravelRefractorTelescope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 129,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes",
+            "travel"
+          ]
+        },
+        {
+          "id": "L9ECAV7KIM",
+          "name": "Lens Cleaning Kit",
+          "description": "Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.",
+          "picture": "LensCleaningKit.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 21,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories"
+          ]
+        },
+        {
+          "id": "2ZYFJ3GM2N",
+          "name": "Roof Binoculars",
+          "description": "This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It's an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.",
+          "picture": "RoofBinoculars.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 209,
+            "nanos": 950000000
+          },
+          "categories": [
+            "binoculars"
+          ]
+        },
+        {
+          "id": "0PUK6V6EV0",
+          "name": "Solar System Color Imager",
+          "description": "You have your new telescope and have observed Saturn and Jupiter. Now you're ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.",
+          "picture": "SolarSystemColorImager.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 175,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "LS4PSXUNUM",
+          "name": "Red Flashlight",
+          "description": "This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red's rugged, IPX4-rated design will withstand your everyday activities.",
+          "picture": "RedFlashlight.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 57,
+            "nanos": 80000000
+          },
+          "categories": [
+            "accessories",
+            "flashlights"
+          ]
+        },
+        {
+          "id": "9SIQT8TOJO",
+          "name": "Optical Tube Assembly",
+          "description": "Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today's top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won't need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.",
+          "picture": "OpticalTubeAssembly.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 3599,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes",
+            "assembly"
+          ]
+        },
+        {
+          "id": "6E92ZMYYFZ",
+          "name": "Solar Filter",
+          "description": "Enhance your viewing experience with EclipSmart Solar Filter for 8\" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.",
+          "picture": "SolarFilter.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 69,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "HQTGWGPNH4",
+          "name": "The Comet Book",
+          "description": "A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as \"Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers\". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)",
+          "picture": "TheCometBook.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 0,
+            "nanos": 990000000
+          },
+          "categories": [
+            "books"
+          ]
+        }
+      ]
+    }
+
+---
+
+# === product-reviews ===
+# Kubernetes manifest for product-reviews
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3551
+    name: tcp-service
+    targetPort: 3551
+  selector:
+    opentelemetry.io/name: product-reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-reviews
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-reviews
+        app.kubernetes.io/component: product-reviews
+        app.kubernetes.io/name: product-reviews
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-reviews
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-reviews:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3551
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_REVIEWS_PORT
+          value: '3551'
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
+          value: 'span_only'
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: 'gen_ai_latest_experimental'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: host=postgresql user=otelu password=otelp dbname=otel
+        - name: LLM_HOST
+          value: llm
+        - name: LLM_PORT
+          value: '8000'
+        - name: LLM_BASE_URL
+          value: http://llm:8000/v1
+        - name: LLM_MODEL
+          value: astronomy-llm
+        - name: OPENAI_API_KEY
+          value: dummy
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === quote ===
+# Kubernetes manifest for quote
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: quote
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: quote
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: quote
+        app.kubernetes.io/component: quote
+        app.kubernetes.io/name: quote
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: quote
+        image: ghcr.io/open-telemetry/demo:2.2.0-quote
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: QUOTE_PORT
+          value: '8080'
+        - name: OTEL_PHP_AUTOLOAD_ENABLED
+          value: 'true'
+        - name: OTEL_PHP_INTERNAL_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 40Mi
+        securityContext:
+          runAsGroup: 33
+          runAsNonRoot: true
+          runAsUser: 33
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === recommendation ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for recommendation
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: recommendation
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: recommendation
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: recommendation
+        app.kubernetes.io/component: recommendation
+        app.kubernetes.io/name: recommendation
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: recommendation
+        image: ghcr.io/splunk/opentelemetry-demo/otel-recommendation:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: RECOMMENDATION_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '750'
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        # PostgreSQL connection for DBMon Cartesian demo
+        - name: POSTGRES_HOST
+          value: "postgresql"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          value: "otel"
+        - name: POSTGRES_USER
+          value: "demo_app_user"
+        - name: POSTGRES_PASSWORD
+          value: "demo_password"
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === shipping ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for shipping
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: shipping
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shipping
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shipping
+        app.kubernetes.io/component: shipping
+        app.kubernetes.io/name: shipping
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: shipping
+        image: ghcr.io/open-telemetry/demo:2.2.0-shipping
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SHIPPING_PORT
+          value: '8080'
+        - name: QUOTE_ADDR
+          value: http://quote:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === sql-server-fraud-setup ===
+# Kubernetes manifest for SQL Server setup
+# Includes secrets and initialization script for MSSQL
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secrets
+type: Opaque
+stringData:
+  SA_PASSWORD: ChangeMe_SuperStrong123!
+  DB_CONNECTION_STRING: Server=tcp:sql-server-fraud.astronomy-shop.svc.cluster.local,1433;Database=FraudDetection;User
+    Id=sa;Password=ChangeMe_SuperStrong123!;Encrypt=True;TrustServerCertificate=True
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mssql-init-script
+data:
+  init-db.sql: |
+    IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'FraudDetection')
+    BEGIN
+      CREATE DATABASE FraudDetection;
+    END
+    GO
+
+---
+
+# === sql-server-fraud ===
+# Kubernetes manifest for sql-server-fraud
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sql-server-fraud
+spec:
+  type: ClusterIP
+  ports:
+  - port: 1433
+    targetPort: 1433
+    protocol: TCP
+    name: tds
+  selector:
+    app: sql-server-fraud
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sql-server-fraud
+spec:
+  serviceName: sql-server-fraud
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  selector:
+    matchLabels:
+      app: sql-server-fraud
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: sqlserver
+        splunk.com/sqlserver.database: fraud
+      labels:
+        app: sql-server-fraud
+    spec:
+      containers:
+      - name: mssql
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 1433
+          name: tds
+        env:
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: MSSQL_PID
+          value: Express
+        - name: SA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mssql-secrets
+              key: SA_PASSWORD
+        volumeMounts:
+        - name: data
+          mountPath: /var/opt/mssql
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'sleep 30
+
+                /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}"
+                -C -i /docker-entrypoint-initdb.d/init-db.sql
+
+                '
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+        readinessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 30
+          periodSeconds: 20
+      volumes:
+      - name: init-script
+        configMap:
+          name: mssql-init-script
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+
+---
+
+# === valkey-cart ===
+# Kubernetes manifest for valkey-cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    name: valkey-cart
+    targetPort: 6379
+  selector:
+    opentelemetry.io/name: valkey-cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: valkey-cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: valkey-cart
+        app.kubernetes.io/component: valkey-cart
+        app.kubernetes.io/name: valkey-cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: valkey-cart
+        image: valkey/valkey:9.0.2-alpine3.23
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: valkey-cart
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === ingress ===
+# === ingress for DIAB  ===
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+spec:
+  ingressClassName: traefik
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-proxy
+            port:
+              number: 8080
+              
+---
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-multienv-test-lambda.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-multienv-test-lambda.yaml
@@ -1,0 +1,97 @@
+# Splunk Astronomy Shop Kubernetes Manifest - lambda
+# Version: multienv-test
+# Generated on: 2026-06-15T13:38:45Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === planning ===
+# Kubernetes manifest for planning
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planning
+  labels:
+    opentelemetry.io/name: planning
+    app.kubernetes.io/component: planning
+    app.kubernetes.io/name: planning
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: planning
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: planning
+        app.kubernetes.io/component: planning
+        app.kubernetes.io/name: planning
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: planning
+        image: ghcr.io/splunk/opentelemetry-demo/otel-planning:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: KAFKA_TOPIC
+          value: orders
+        - name: KAFKA_GROUP_ID
+          value: planning
+        # Lambda configuration
+        - name: LAMBDA_ENDPOINT
+          value: "https://61d4vss237.execute-api.eu-west-1.amazonaws.com/demo/orders"
+        - name: LAMBDA_CALL_INTERVAL_MINUTES
+          value: "5"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=spanlink,deployment.environment=$(WORKSHOP_ENV)-lambda
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-multienv-test-secureapp.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-multienv-test-secureapp.yaml
@@ -1,0 +1,123 @@
+# Splunk Astronomy Shop Kubernetes Manifest - secureapp
+# Version: multienv-test
+# Generated on: 2026-06-15T13:38:46Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === secureapp-loadgen ===
+# SecureApp loadgen — Java vulnerability test app.
+# Reports as whatever OTEL_SERVICE_NAME is set to (currently "shipping-api").
+# Exercises 5 vulnerability classes for Splunk SecureApp agent detection.
+# Deployed via separate manifest group (secureapp).
+# See usage.md for configuration details.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: secureapp-loadgen
+  labels:
+    opentelemetry.io/name: secureapp-loadgen
+    app.kubernetes.io/component: secureapp-loadgen
+    app.kubernetes.io/name: secureapp-loadgen
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: secureapp-loadgen
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secureapp-loadgen
+  labels:
+    opentelemetry.io/name: secureapp-loadgen
+    app.kubernetes.io/component: secureapp-loadgen
+    app.kubernetes.io/name: secureapp-loadgen
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: secureapp-loadgen
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: secureapp-loadgen
+        app.kubernetes.io/component: secureapp-loadgen
+        app.kubernetes.io/name: secureapp-loadgen
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: secureapp-loadgen
+        image: ghcr.io/splunk/opentelemetry-demo/otel-secureapp-loadgen:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./entrypoint.sh
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
+        - name: OTEL_SERVICE_NAME
+          value: "shipping-api"
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/app/splunk-otel-javaagent.jar
+            -Dargento.allow.security.events=true
+            -Dargento.wait.events.for.first.transaction=false
+            -Dotel.instrumentation.common.peer-service-mapping=shipping:8080=shipping
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      volumes: null
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-multienv-test.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-multienv-test.yaml
@@ -1,0 +1,3792 @@
+# Splunk Astronomy Shop Kubernetes Manifest
+# Version: multienv-test
+# Generated on: 2026-06-15T13:38:43Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === accounting ===
+# Kubernetes manifest for accounting
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accounting
+  labels:
+    opentelemetry.io/name: accounting
+    app.kubernetes.io/component: accounting
+    app.kubernetes.io/name: accounting
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: accounting
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: accounting
+        app.kubernetes.io/component: accounting
+        app.kubernetes.io/name: accounting
+    spec:
+      serviceAccountName: opentelemetry-demo
+      # DNS Configuration to prevent stale DNS caching
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          # Reduce DNS TTL to 10 seconds for faster updates
+          - name: ndots
+            value: "2"
+          # Number of DNS queries before giving up
+          - name: timeout
+            value: "2"
+          # Number of retries for DNS queries
+          - name: attempts
+            value: "3"
+      containers:
+      - name: accounting
+        image: ghcr.io/splunk/opentelemetry-demo/otel-accounting:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        # Kafka connection retry configuration
+        - name: KAFKA_RECONNECT_BACKOFF_MS
+          value: "1000"
+        - name: KAFKA_RECONNECT_BACKOFF_MAX_MS
+          value: "10000"
+        - name: KAFKA_CONNECTIONS_MAX_IDLE_MS
+          value: "300000"
+        - name: KAFKA_METADATA_MAX_AGE_MS
+          value: "10000"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: DB_CONNECTION_STRING
+          value: Host=postgresql;Username=otelu;Password=otelp;Database=otel
+        - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
+          value: 'false'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=spanlink
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === ad ===
+# Kubernetes manifest for ad
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: ad
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: ad
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: ad
+        app.kubernetes.io/component: ad
+        app.kubernetes.io/name: ad
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: ad
+        image: ghcr.io/splunk/opentelemetry-demo/otel-ad:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./build/install/opentelemetry-demo-ad/bin/Ad
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: AD_PORT
+          value: '8080'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_TRACES_SAMPLER
+          value: rules
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '100'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/usr/src/app/splunk-otel-javaagent-csa.jar -Dsplunk.snapshot.profiler.enabled=true
+            -Dsplunk.snapshot.profiler.sampling.interval=1 -Dsplunk.snapshot.selection.probability=0.1
+            -Xmx440m
+        resources:
+          limits:
+            memory: 600Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === astronomy-loadgen ===
+# Kubernetes manifest for astronomy-loadgen
+# Includes scriptfile ConfigMap used by the deployment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scriptfile
+data:
+  local-file: |
+    /* eslint-disable no-console */
+    const { Console } = require('console');
+    const puppeteer = require('puppeteer');
+    const customUserAgent = 'Mozilla/5.0 (X11; Linux x86_64; Splunk RUM_LoadGen) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36';
+
+    // Debug logging flag (set via DEBUG_LOGGING env var)
+    const debugEnabled = process.env.DEBUG_LOGGING === 'true';
+    if (debugEnabled) console.log('DEBUG: Using User Agent:', customUserAgent);
+
+    // Global browser instance for reuse across cycles
+    let globalBrowser = null;
+
+
+    async function launchBrowser() {
+      console.log('🔹 Starting headless browser...');
+      const browser = await puppeteer.launch({
+        headless: true,
+        defaultViewport: null,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--disable-web-security',
+          '--disable-features=VizDisplayCompositor',
+          '--max-old-space-size=256',
+          '--disable-extensions',
+          '--disable-plugins',
+          '--disable-background-networking',
+          '--disable-background-timer-throttling',
+          '--disable-backgrounding-occluded-windows',
+          '--disable-renderer-backgrounding',
+          '--memory-pressure-off',
+          '--aggressive-cache-discard',
+          '--ignore-certificate-errors',
+          '--allow-insecure-localhost',
+          `--user-agent=${customUserAgent}`
+        ]
+      });
+      console.log('✅ Browser started.');
+      return browser;
+    }
+
+    async function ensureBrowser() {
+      if (!globalBrowser || !globalBrowser.isConnected()) {
+        console.log('🔄 Launching new global browser instance...');
+        globalBrowser = await launchBrowser();
+      }
+      return globalBrowser;
+    }
+
+    function buildBaseUrl() {
+      const raw = (process.env.RUM_FRONTEND_IP || '').trim();
+
+      // If it's empty, default to localhost
+      if (!raw) return 'https://localhost/';
+
+      // If it already starts with http:// or https://, keep it exactly as-is
+      if (/^https?:\/\//i.test(raw)) {
+        return raw.replace(/\/+$/, '') + '/';
+      }
+
+      // Otherwise, prepend https://
+      return `https://${raw.replace(/\/+$/, '')}/`;
+    }
+
+    function getProductIds() {
+      const envProductIds = (process.env.PRODUCT_IDS || '').trim();
+      if (envProductIds) {
+        return envProductIds.split(',').map(id => id.trim()).filter(id => id);
+      }
+      // Hardcoded product IDs if env variable is not set or empty
+      return [
+        'OLJCESPC7Z', // National Park Foundation Explorascope
+        '66VCHSJNUP', // Starsense Explorer Refractor Telescope
+        '1YMWWN1N4O', // Eclipsmart Travel Refractor Telescope
+        'L9ECAV7KIM', // Lens Cleaning Kit
+        '2ZYFJ3GM2N', // Roof Binoculars
+        '0PUK6V6EV0', // Solar System Color Imager
+        'LS4PSXUNUM', // Red Flashlight
+        '9SIQT8TOJO', // Optical Tube Assembly
+        '6E92ZMYYFZ', // Solar Filter
+        'HQTGWGPNH4'  // The Comet Book
+      ];
+    }
+
+    function getRandomProducts() {
+      const allProducts = getProductIds();
+      const numProducts = Math.floor(Math.random() * 3) + 1; // Random number between 1 and 3
+      const shuffled = allProducts.sort(() => Math.random() - 0.5);
+      return shuffled.slice(0, numProducts);
+    }
+
+    // Throttle quick prompts — parsed from env, default 5 min
+    const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
+    let lastQuickPromptTime = 0;
+
+    // Shipping API — random interval between 34s and 1m45s
+    const SHIPPING_MIN_MS = parseInt(process.env.SHIPPING_MIN_MS || '34000', 10);
+    const SHIPPING_MAX_MS = parseInt(process.env.SHIPPING_MAX_MS || '105000', 10);
+    let nextShippingTime = 0;
+    const SHIPPING_API_ENABLED = (process.env.SHIPPING_API || '').toLowerCase() === 'true';
+
+    function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
+
+    /** Generate a random shipping tracking number */
+    function randomTrackingNumber() {
+      const num = Math.floor(Math.random() * 99999) + 10000;
+      return `SHIP-${num}`;
+    }
+
+    /** Schedule next shipping call at a random interval */
+    function scheduleNextShipping() {
+      const interval = SHIPPING_MIN_MS + Math.floor(Math.random() * (SHIPPING_MAX_MS - SHIPPING_MIN_MS));
+      nextShippingTime = Date.now() + interval;
+      if (debugEnabled) console.log(`[DEBUG] Next shipping call in ${Math.round(interval/1000)}s`);
+    }
+
+    /** Fetch shipping info via the frontend-proxy /shipping/ route */
+    async function fetchShippingInfo(page) {
+      if (!SHIPPING_API_ENABLED) return;
+      if (Date.now() < nextShippingTime) return;
+      scheduleNextShipping();
+
+      const tracking = randomTrackingNumber();
+      const base = buildBaseUrl();
+      const url = `${base}shipping/?tracking=${tracking}`;
+      console.log(`📦 Fetching shipping info for ${tracking}...`);
+      try {
+        const result = await page.evaluate(async (fetchUrl) => {
+          const resp = await fetch(fetchUrl);
+          return { status: resp.status, body: await resp.text() };
+        }, url);
+        console.log(`📦 Shipping info: HTTP ${result.status}`);
+        if (debugEnabled) console.log(`[DEBUG] Shipping response: ${result.body}`);
+      } catch (e) {
+        console.log(`⚠️ Shipping info fetch failed: ${e.message}`);
+      }
+    }
+
+    /** Wait until innerText of the page contains a substring */
+    async function waitForText(page, text, timeoutMs = 30000, pollMs = 200) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const found = await page.evaluate(t =>
+          document && document.body && document.body.innerText.includes(t),
+          text
+        );
+        if (found) return true;
+        await delay(pollMs);
+      }
+      throw new Error(`Timed out waiting for text: "${text}"`);
+    }
+
+    async function runOnce() {
+      const browser = await ensureBrowser();
+      let page;
+      let ctx;
+      try {
+        // Fresh browser context per cycle so localStorage / cookies / session
+        // ID reset between cycles. Otherwise every cycle reuses the same RUM
+        // session ID and the funnel sees a single user looping forever.
+        ctx = await browser.createBrowserContext();
+        page = await ctx.newPage();
+        page.setDefaultNavigationTimeout(45000);
+        page.setDefaultTimeout && page.setDefaultTimeout(30000);
+
+        // Log all responses for debugging (when DEBUG_LOGGING=true)
+        if (debugEnabled) {
+          page.on('response', response => {
+            const url = response.url();
+            if (url.includes('api')) {
+              console.log(`[DEBUG] API Response: ${url} (${response.status()})`);
+            }
+          });
+        }
+
+        const base = buildBaseUrl();
+        const productsToOrder = getRandomProducts();
+        console.log(`🛒 Ordering ${productsToOrder.length} product(s): ${productsToOrder.join(', ')}`);
+
+        // Visit homepage first so the user enters the sequential RUM funnel
+        // at step 1. Without this the loadgen lands on /product/<id> and the
+        // funnel records 0 conversions because step 1 is never satisfied.
+        const homeUrl = base.replace(/\/+$/, '/');
+        console.log(`🏠 Visiting homepage ${homeUrl}`);
+        await page.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+        await delay(1500);
+
+        // Loop through each product and add to cart
+        for (const productId of productsToOrder) {
+          const url = new URL(`product/${productId}`, base).toString();
+          console.log(`🌐 Navigating to ${url}`);
+
+          // Set up /api/data response listener BEFORE navigation
+          const apiDataPromise = page.waitForResponse(
+            response => {
+              const url = response.url();
+              const status = response.status();
+              const matches = url.includes('/api/data') && (status === 200 || status === 304);
+              if (matches) {
+                console.log(`✅ /api/data response received: ${status}`);
+              }
+              return matches;
+            },
+            { timeout: 15000 }
+          );
+
+          // Navigate to page
+          await page.goto(url, {
+            waitUntil: 'networkidle2',  // Wait until no more than 2 connections for 500ms
+            timeout: 60000               // 60 second timeout for page load
+          });
+
+          // Now wait for /api/data to complete (may have already completed during goto)
+          console.log('⏳ Ensuring ad service (/api/data) completed...');
+          await apiDataPromise.catch(() => {
+            console.log('⚠️ /api/data did not complete in 15s, continuing anyway...');
+          });
+
+          // Small delay to ensure any follow-up requests finish
+          await delay(500);
+          console.log('✅ Page fully loaded with all API calls complete');
+
+          // Quick prompts - throttled to once every 5 minutes
+          const now = Date.now();
+          if (now - lastQuickPromptTime >= QUICK_PROMPT_INTERVAL_MS) {
+          lastQuickPromptTime = now;
+
+          const quickPrompts = [
+            {
+              label: 'Can you summarize the product reviews?',
+              dataCy: 'QuickPromptSummarize',
+              ariaSelector: '::-p-aria(Can you summarize the product reviews?)',
+              textSelector: '::-p-text(Can you summarize)',
+              offset: { x: 129, y: 15 },
+            },
+            {
+              label: 'Were there any negative reviews?',
+              dataCy: 'QuickPromptNegative',
+              ariaSelector: '::-p-aria(Were there any negative reviews?)',
+              textSelector: '::-p-text(Were there any)',
+              offset: { x: 171.6640625, y: 25 },
+            },
+            {
+              label: 'What age(s) is this recommended for?',
+              dataCy: 'QuickPromptAges',
+              ariaSelector: '::-p-aria(What age\\(s\\) is this recommended for?)',
+              textSelector: '::-p-text(What age\\(s\\) is)',
+              offset: { x: 148.0390625, y: 19 },
+            },
+          ];
+
+          const prompt = quickPrompts[Math.floor(Math.random() * quickPrompts.length)];
+          console.log(`🖱️ Clicking quick prompt: "${prompt.label}"`);
+
+          {
+              const targetPage = page;
+              const timeout = 5000;
+              await puppeteer.Locator.race([
+                  targetPage.locator(prompt.ariaSelector),
+                  targetPage.locator(`[data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(`::-p-xpath(//*[@data-cy=\\"${prompt.dataCy}\\"])`),
+                  targetPage.locator(`:scope >>> [data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(prompt.textSelector)
+              ])
+                  .setTimeout(timeout)
+                  .click({ offset: prompt.offset });
+              console.log('⏳ Waiting for AI response...');
+              await delay(500); // Let request start
+              await page.waitForSelector("[data-cy='AIAnswer']", { timeout: 15000, visible: true }).catch(() => {
+                console.log('⚠️ AI response timeout, continuing...');
+              });
+              await delay(1500); // Allow response to fully render
+          }
+
+          } else {
+            console.log('⏭️ Skipping quick prompts (next run in ' + Math.round((QUICK_PROMPT_INTERVAL_MS - (now - lastQuickPromptTime)) / 1000) + 's)');
+          }
+
+          const addSel = "[data-cy='product-add-to-cart']";
+          await page.waitForSelector(addSel);
+          console.log(`🖱️ Clicking "Add To Cart" for product ${productId}`);
+          await page.click(addSel);
+        }
+
+        // Place order after all products are added to cart
+        const placeSel = "[data-cy='checkout-place-order']";
+        await page.waitForSelector(placeSel);
+        console.log('🖱️ Clicking "Place Order"');
+        await page.click(placeSel);
+
+        // Wait for either success message or error modal
+        console.log('⏳ Waiting for order result...');
+        const orderResult = await Promise.race([
+          waitForText(page, 'Your order is complete!').then(() => 'success'),
+          page.waitForSelector('#modal-close-btn', { timeout: 30000, visible: true }).then(() => 'error-modal')
+        ]);
+
+        if (orderResult === 'success') {
+          console.log('🎉 Order completed successfully!');
+          // Confirmation page useEffect fires the `order.confirmed` RUM span
+          // asynchronously. Wait so the RUM batcher can flush the beacon
+          // before the page / context is torn down.
+          await delay(5000);
+        } else if (orderResult === 'error-modal') {
+          console.log('⚠️ Error modal detected - closing it to continue...');
+          await page.click('#modal-close-btn');
+          await delay(500);
+          console.log('✅ Error modal closed.');
+        }
+
+        // Periodic shipping info fetch (every 2 minutes, gated by SHIPPING_API)
+        await fetchShippingInfo(page);
+      } finally {
+        console.log('🧹 Cleaning up page resources...');
+        try {
+          if (page) {
+            page.removeAllListeners();
+            await page.close({ runBeforeUnload: true }).catch(()=>{});
+          }
+          if (ctx) {
+            await ctx.close().catch(()=>{});
+          }
+        } catch (e) {
+          console.error('⚠️ Error closing page:', e.message);
+        }
+        console.log('✅ Page + context closed cleanly. Browser will be reused for next cycle.');
+      }
+    }
+
+    (async function mainLoop() {
+      const cycleDelayMs = parseInt(process.env.CYCLE_DELAY_MS || '5000', 10);
+      console.log(`⚙️ Cycle delay: ${cycleDelayMs}ms`);
+
+      let cycle = 1;
+      while (true) {
+        console.log(`=== Starting load generation cycle #${cycle} ===`);
+        try {
+          await runOnce();
+          console.log(`✅ Cycle #${cycle} finished OK`);
+        } catch (e) {
+          console.error(`❌ Cycle #${cycle} failed:`, e && e.stack ? e.stack : e);
+        }
+        cycle += 1;
+        await delay(cycleDelayMs);
+      }
+    })();
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astronomy-loadgen-deployment
+  labels:
+    app: astronomy-loadgen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: astronomy-loadgen
+  template:
+    metadata:
+      labels:
+        app: astronomy-loadgen
+    spec:
+      initContainers:
+      - name: wait-for-frontend
+        image: curlimages/curl:8.1.2
+        command: ['sh', '-c']
+        args:
+        - |
+          echo "Waiting for frontend-proxy to be ready..."
+          until curl -f --connect-timeout 5 --max-time 10 http://frontend-proxy:8080; do
+            echo "Frontend not ready, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Frontend is ready, starting loadgen..."
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "50m"
+      containers:
+      - name: astronomy-loadgen
+        image: ghcr.io/splunk/online-boutique/rumloadgen:5.6
+        imagePullPolicy: Always
+        env:
+        # NOTE: For RUM funnels that filter on the public ingress URL (e.g.
+        # `https://astronomy-shop.example.com`), override this value per
+        # deployment so the loadgen browser navigates to the same origin as
+        # real users. The in-cluster default below works for traffic-only
+        # generation but produces RUM events tagged with the internal URL.
+        - name: RUM_FRONTEND_IP
+          value: "http://frontend-proxy:8080"
+        - name: CYCLE_DELAY_MS
+          value: "1000"
+        - name: DEBUG_LOGGING
+          value: ""  # Set to "true" to enable debug logging
+        - name: QUICK_PROMPT_INTERVAL_MS
+          value: "300000"  # How often AI quick prompts run (ms). Default 300000 (5min). Set "0" for every cycle.
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "500m"
+          limits:
+            memory: "1536Mi"
+            cpu: "1000m"
+        volumeMounts:
+        - name: puppeteer
+          subPath: local-file
+          mountPath: /puppeteer/touchwebsite.js
+      volumes:
+      - name: puppeteer
+        configMap:
+          name: scriptfile
+
+---
+
+# === cart ===
+# Kubernetes manifest for cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: cart
+        app.kubernetes.io/component: cart
+        app.kubernetes.io/name: cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: cart
+        image: ghcr.io/splunk/opentelemetry-demo/otel-cart:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CART_PORT
+          value: '8080'
+        - name: ASPNETCORE_URLS
+          value: http://*:$(CART_PORT)
+        - name: VALKEY_ADDR
+          value: valkey-cart:6379
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          limits:
+            memory: 320Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep
+          2; done;
+        image: busybox:latest
+        name: wait-for-valkey-cart
+      volumes: null
+
+---
+
+# === checkout ===
+# Kubernetes manifest for checkout
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: checkout
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: checkout
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: checkout
+        app.kubernetes.io/component: checkout
+        app.kubernetes.io/name: checkout
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: checkout
+        image: ghcr.io/splunk/opentelemetry-demo/otel-checkout:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CHECKOUT_PORT
+          value: '8080'
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: EMAIL_ADDR
+          value: http://email:8080
+        - name: PAYMENT_ADDR
+          value: payment:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 16MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === currency ===
+# Kubernetes manifest for currency
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: currency
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: currency
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: currency
+        app.kubernetes.io/component: currency
+        app.kubernetes.io/name: currency
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: currency
+        image: ghcr.io/open-telemetry/demo:2.2.0-currency
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CURRENCY_PORT
+          value: '8080'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: VERSION
+          value: 2.1.3
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === email ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for email
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: email
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: email
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: email
+        app.kubernetes.io/component: email
+        app.kubernetes.io/name: email
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: email
+        image: ghcr.io/open-telemetry/demo:2.2.0-email
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: EMAIL_PORT
+          value: '8080'
+        - name: APP_ENV
+          value: production
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === flagd ===
+# Kubernetes manifest for flagd
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8013
+    name: rpc
+    targetPort: 8013
+  - port: 8016
+    name: ofrep
+    targetPort: 8016
+  selector:
+    opentelemetry.io/name: flagd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd
+        app.kubernetes.io/component: flagd
+        app.kubernetes.io/name: flagd
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: flagd
+        image: ghcr.io/open-feature/flagd:v0.14.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /flagd-build
+        - start
+        - --port
+        - '8013'
+        - --ofrep-port
+        - '8016'
+        - --uri
+        - file:./etc/flagd/demo.flagd.json
+        ports:
+        - containerPort: 8013
+          name: rpc
+        - containerPort: 8016
+          name: ofrep
+        env:
+        - name: GOMEMLIMIT
+          value: 60MiB
+        resources:
+          limits:
+            memory: 75Mi
+        volumeMounts:
+        - name: config-rw
+          mountPath: /etc/flagd
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === flagd-config ===
+# Kubernetes manifest for flagd-config
+# NOTE: The ConfigMap is generated at stitch time from src/flagd/demo.flagd.json
+# This file only contains the PVC definition
+---
+# PersistentVolumeClaim for shared flagd configuration
+# This PVC is shared between flagd and flagd-ui to enable dynamic flag updates
+# Using ReadWriteOnce with podAffinity to ensure both pods on same node
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flagd-shared-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/component: flagd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flagd-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  demo.flagd.json: |
+    {
+      "$schema": "https://flagd.dev/schema/v0/flags.json",
+      "flags": {
+        "llmInaccurateResponse": {
+          "defaultVariant": "off",
+          "description": "LLM returns an inaccurate product summary for product ID L9ECAV7KIM",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "llmRateLimitError": {
+          "defaultVariant": "off",
+          "description": "LLM intermittently returns a rate limit error",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "productCatalogFailure": {
+          "description": "Fail product catalog service on a specific product",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCacheFailure": {
+          "description": "Fail recommendation service cache",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adManualGc": {
+          "description": "Triggers full manual garbage collections in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adHighCpu": {
+          "description": "Triggers high cpu load in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adFailure": {
+          "description": "Fail ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "kafkaQueueProblems": {
+          "description": "Overloads Kafka queue while simultaneously introducing a consumer side delay leading to a lag spike",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "cartFailure": {
+          "description": "Fail cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentFailure": {
+          "description": "Fail payment service charge requests n%",
+          "state": "ENABLED",
+          "variants": {
+            "100%": 1,
+            "90%": 0.95,
+            "75%": 0.75,
+            "50%": 0.5,
+            "25%": 0.25,
+            "10%": 0.1,
+            "off": 0
+          },
+          "defaultVariant": "50%"
+        },
+        "rumBlueGreen": {
+          "description": "Enable RUM-based payment path (A/B) tracking in user.deployment_type attribute",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentUnreachable": {
+          "description": "Payment service is unavailable",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "loadGeneratorFloodHomepage": {
+          "description": "Flood the frontend with a large amount of requests.",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "imageSlowLoad": {
+          "description": "slow loading images in the frontend",
+          "state": "ENABLED",
+          "variants": {
+            "10sec": 10000,
+            "5sec": 5000,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "failedReadinessProbe": {
+          "description": "readiness probe failure for cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+    
+        },
+        "emailMemoryLeak": {
+          "description": "Memory leak in the email service.",
+          "state": "ENABLED",
+          "variants": {
+            "off": 0,
+            "1x": 1,
+            "10x": 10,
+            "100x": 100,
+            "1000x": 1000,
+            "10000x": 10000
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCartesianQuery": {
+          "description": "DBMon Demo: Triggers a Cartesian join query (500M rows) in recommendation service PostgreSQL calls. Query returns correct results but processes 500M intermediate rows, taking 12+ seconds.",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "secureappAttack": {
+          "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",
+          "state": "ENABLED",
+          "variants": {
+            "minimal": "minimal",
+            "targeted": "targeted",
+            "max": "max"
+          },
+          "defaultVariant": "minimal"
+        }
+      }
+    }
+
+---
+
+# === flagd-ui ===
+# Kubernetes manifest for flagd-ui
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4000
+    name: tcp-service
+    targetPort: 4000
+  selector:
+    opentelemetry.io/name: flagd-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd-ui
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd-ui
+        app.kubernetes.io/component: flagd-ui
+        app.kubernetes.io/name: flagd-ui
+    spec:
+      serviceAccountName: opentelemetry-demo
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: opentelemetry.io/name
+                operator: In
+                values:
+                - flagd
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: flagd-ui
+        image: ghcr.io/open-telemetry/demo:2.2.0-flagd-ui
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 4000
+          name: service
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: SECRET_KEY_BASE
+          value: yYrECL4qbNwleYInGJYvVnSkwJuSQJ4ijPTx5tirGUXrbznFIBFVJdPl5t6O9ASw
+        - name: PHX_HOST
+          value: localhost
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        resources:
+          limits:
+            memory: 250Mi
+        volumeMounts:
+        - mountPath: /app/data
+          name: config-rw
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === fraud-detection ===
+# Kubernetes manifest for fraud-detection
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fraud-detection
+  labels:
+    opentelemetry.io/name: fraud-detection
+    app.kubernetes.io/component: fraud-detection
+    app.kubernetes.io/name: fraud-detection
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: fraud-detection
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: fraud-detection
+        app.kubernetes.io/component: fraud-detection
+        app.kubernetes.io/name: fraud-detection
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: fraud-detection
+        image: ghcr.io/splunk/opentelemetry-demo/otel-fraud-detection:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_INSTRUMENTATION_KAFKA_CLIENTS_ENABLED
+          value: 'false'
+        - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+          value: 'true'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=propagation
+        - name: SQL_SERVER_HOST
+          value: sql-server-fraud.default.svc.cluster.local
+        - name: SQL_SERVER_PORT
+          value: '1433'
+        - name: SQL_SERVER_DATABASE
+          value: FraudDetection
+        - name: SQL_SERVER_USER
+          value: sa
+        - name: SQL_SERVER_PASSWORD
+          value: ChangeMe_SuperStrong123!
+        - name: FRAUD_DETECTION_RATE
+          value: '80'
+        - name: CLEANUP_RETENTION_DAYS
+          value: '4'
+        - name: CLEANUP_INTERVAL_HOURS
+          value: '6'
+        - name: FRAUD_MUTATION_PERCENTAGE
+          value: '25'
+        - name: BAD_QUERY_PERCENTAGE
+          value: '0'
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 512Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 sql-server-fraud.default.svc.cluster.local 1433; do echo
+          waiting for sql-server-fraud; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-sqlserver
+      volumes: null
+
+---
+
+# === frontend ===
+# Kubernetes manifest for frontend
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: frontend
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: PORT
+          value: $(FRONTEND_PORT)
+        - name: FRONTEND_ADDR
+          value: :8080
+        - name: AD_ADDR
+          value: ad:8080
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CHECKOUT_ADDR
+          value: checkout:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: PRODUCT_REVIEWS_ADDR
+          value: product-reviews:3551
+        - name: RECOMMENDATION_ADDR
+          value: recommendation:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: ENV_PLATFORM
+          value: kubernetes
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+        - name: OTEL_LOG_LEVEL
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: api_token
+              optional: true
+        - name: SPLUNK_RUM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: rum_token
+        - name: SPLUNK_APP_NAME
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: app
+        - name: SPLUNK_RUM_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: SPLUNK_RUM_REALM
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: realm
+        resources:
+          limits:
+            memory: 250Mi
+        securityContext:
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === frontend-proxy ===
+# Kubernetes manifest for frontend-proxy
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend-proxy
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend-proxy
+        app.kubernetes.io/component: frontend-proxy
+        app.kubernetes.io/name: frontend-proxy
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend-proxy
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend-proxy:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: ENVOY_ADDR
+          value: 0.0.0.0
+        - name: ENVOY_PORT
+          value: '8080'
+        - name: ENVOY_ADMIN_PORT
+          value: '10000'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8016'
+        - name: FLAGD_UI_HOST
+          value: flagd-ui
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: FRONTEND_HOST
+          value: frontend
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: IMAGE_PROVIDER_HOST
+          value: image-provider
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: LOCUST_WEB_HOST
+          value: load-generator
+        - name: LOCUST_WEB_PORT
+          value: '8089'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_PORT_HTTP
+          value: '4318'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: SECUREAPP_HOST
+          value: secureapp-loadgen
+        - name: SECUREAPP_PORT
+          value: '8080'
+        - name: FEATURE_AUTH_ENABLED
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_auth
+              optional: true
+        - name: FEATURE_USER
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_user
+              optional: true
+        - name: FEATURE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_pw
+              optional: true
+        resources:
+          limits:
+            memory: 65Mi
+        securityContext:
+          runAsGroup: 101
+          runAsNonRoot: true
+          runAsUser: 101
+        volumeMounts: null
+      volumes: null
+---
+
+
+---
+
+# === image-provider ===
+# Kubernetes manifest for image-provider
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8081
+    name: tcp-service
+    targetPort: 8081
+  selector:
+    opentelemetry.io/name: image-provider
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: image-provider
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: image-provider
+        app.kubernetes.io/component: image-provider
+        app.kubernetes.io/name: image-provider
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: image-provider
+        image: ghcr.io/splunk/opentelemetry-demo/otel-image-provider:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 50Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === kafka ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for kafka
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9092
+    name: plaintext
+    targetPort: 9092
+  - port: 9093
+    name: controller
+    targetPort: 9093
+  selector:
+    opentelemetry.io/name: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: kafka
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: kafka
+        app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: kafka
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: kafka
+        image: ghcr.io/open-telemetry/demo:2.2.0-kafka
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+          name: plaintext
+        - containerPort: 9093
+          name: controller
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka:9092
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx400M -Xms400M
+        - name: KAFKA_LISTENERS
+          value: PLAINTEXT://:9092,CONTROLLER://:9093
+        - name: KAFKA_CONTROLLER_LISTENER_NAMES
+          value: CONTROLLER
+        - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+          value: 1@kafka:9093
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 800Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === llm ===
+# Kubernetes manifest for llm
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    name: tcp-service
+    targetPort: 8000
+  selector:
+    opentelemetry.io/name: llm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: llm
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: llm
+        app.kubernetes.io/component: llm
+        app.kubernetes.io/name: llm
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: llm
+        image: ghcr.io/splunk/opentelemetry-demo/otel-llm:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === demo-service-account ===
+# Kubernetes manifest for demo-service-account
+# ServiceAccount used by all Astronomy Shop application pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-demo
+  labels:
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+
+---
+
+# === payment-vA ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version A - Stable/Conservative Version
+# This manifest deploys payment service v1.7.0-a with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-payment-secret
+type: Opaque
+stringData:
+  api-token: "prod-a8cf28f9-1a1a-4994-bafa-cd4b143c3291"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-va
+    app.kubernetes.io/version: "1.7.0-a"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vA
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vA
+        opentelemetry.io/name: payment-va
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-va
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version A
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vA"]
+
+        # Anti-affinity - never on same node as version B
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vB
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.9"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-a"
+
+        # Token from dedicated secret for version A
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: prod-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=multienv-test,payment.variant=A"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging
+        - name: OTEL_LOG_LEVEL
+          value: info
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vA
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === payment-vB ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version B - Optimized/Next-gen Version
+# This manifest deploys payment service v1.7.0-b with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-payment-secret
+type: Opaque
+stringData:
+  api-token: "test-20e26e90-356b-432e-a2c6-956fc03f5609"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-vb
+    app.kubernetes.io/version: "1.7.0-b"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vB
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vB
+        opentelemetry.io/name: payment-vb
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-vb
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version B
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vB"]
+
+        # Anti-affinity - never on same node as version A
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vA
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.10"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-b"
+
+        # Token from dedicated secret for version B
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: test-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=multienv-test,payment.variant=B"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging (more verbose for version B)
+        - name: OTEL_LOG_LEVEL
+          value: debug
+        - name: LOG_LEVEL
+          value: debug
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vB
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === postgresql-setup ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# PostgreSQL Database Initialization ConfigMap
+# This ConfigMap contains scripts that create schemas, tables, and extensions
+# for the accounting, product-catalog, product-reviews, and recommendation services
+#
+# The postgres deployment mounts these as /docker-entrypoint-initdb.d/
+# which PostgreSQL automatically executes on first startup (alphabetical order)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-sql
+  labels:
+    app.kubernetes.io/name: postgres-init
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # Shell script runs first (alphabetically) to create extension in postgres database
+  00-pg-stat-statements.sh: |
+    #!/bin/bash
+    # Create pg_stat_statements extension in the postgres database
+    # This is required for PostgreSQL receiver top query monitoring
+    set -e
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<-EOSQL
+        CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    EOSQL
+    echo "pg_stat_statements extension created in postgres database"
+  init.sql: |
+    -- Copyright The OpenTelemetry Authors
+    -- SPDX-License-Identifier: Apache-2.0
+
+    -- Enable pg_stat_statements for database monitoring (top query tracking)
+    -- Note: This runs in the 'otel' database. The extension is also created
+    -- in the 'postgres' database by 00-pg-stat-statements.sh for top query monitoring.
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+    CREATE USER otelu WITH PASSWORD 'otelp';
+
+    -- Accounting Service: create a schema
+    CREATE SCHEMA accounting;
+    GRANT USAGE ON SCHEMA accounting TO otelu;
+
+    -- Accounting Service: create tables
+    CREATE TABLE accounting."order" (
+        order_id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE accounting.shipping (
+        shipping_tracking_id TEXT PRIMARY KEY,
+        shipping_cost_currency_code TEXT NOT NULL,
+        shipping_cost_units BIGINT NOT NULL,
+        shipping_cost_nanos INT NOT NULL,
+        street_address TEXT,
+        city TEXT,
+        state TEXT,
+        country TEXT,
+        zip_code TEXT,
+        order_id TEXT NOT NULL,
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE accounting.orderitem (
+        item_cost_currency_code TEXT NOT NULL,
+        item_cost_units BIGINT NOT NULL,
+        item_cost_nanos INT NOT NULL,
+        product_id TEXT NOT NULL,
+        quantity INT NOT NULL,
+        order_id TEXT NOT NULL,
+        PRIMARY KEY (order_id, product_id),
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    -- Accounting Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA accounting TO otelu;
+
+    -- Product Catalog Service: create a schema
+    CREATE SCHEMA catalog;
+    GRANT USAGE ON SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: create tables
+    CREATE TABLE catalog.products (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        picture TEXT,
+        price_currency_code TEXT NOT NULL,
+        price_units BIGINT NOT NULL,
+        price_nanos INT NOT NULL,
+        categories TEXT
+    );
+
+    -- Product Catalog Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: add product data
+    INSERT INTO catalog.products (id, name, description, picture, price_currency_code, price_units, price_nanos, categories)
+    VALUES
+        ('OLJCESPC7Z', 'National Park Foundation Explorascope', 'The National Park Foundation''s (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.', 'NationalParkFoundationExplorascope.jpg', 'USD', 101, 960000000, 'telescopes'),
+        ('66VCHSJNUP', 'Starsense Explorer Refractor Telescope', 'The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app''s user-friendly interface and detailed tutorials. It''s like having your own personal tour guide of the night sky', 'StarsenseExplorer.jpg', 'USD', 349, 950000000, 'telescopes'),
+        ('1YMWWN1N4O', 'Eclipsmart Travel Refractor Telescope', 'Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.', 'EclipsmartTravelRefractorTelescope.jpg', 'USD', 129, 950000000, 'telescopes,travel'),
+        ('L9ECAV7KIM', 'Lens Cleaning Kit', 'Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.', 'LensCleaningKit.jpg', 'USD', 21, 950000000, 'accessories'),
+        ('2ZYFJ3GM2N', 'Roof Binoculars', 'This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It''s an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.', 'RoofBinoculars.jpg', 'USD', 209, 950000000, 'binoculars'),
+        ('0PUK6V6EV0', 'Solar System Color Imager', 'You have your new telescope and have observed Saturn and Jupiter. Now you''re ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.', 'SolarSystemColorImager.jpg', 'USD', 175, 0, 'accessories,telescopes'),
+        ('LS4PSXUNUM', 'Red Flashlight', 'This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red''s rugged, IPX4-rated design will withstand your everyday activities.', 'RedFlashlight.jpg', 'USD', 57, 80000000, 'accessories,flashlights'),
+        ('9SIQT8TOJO', 'Optical Tube Assembly', 'Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today''s top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won''t need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.', 'OpticalTubeAssembly.jpg', 'USD', 3599, 0, 'accessories,telescopes,assembly'),
+        ('6E92ZMYYFZ', 'Solar Filter', 'Enhance your viewing experience with EclipSmart Solar Filter for 8" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.', 'SolarFilter.jpg', 'USD', 69, 950000000, 'accessories,telescopes'),
+        ('HQTGWGPNH4', 'The Comet Book', 'A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as "Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)', 'TheCometBook.jpg', 'USD', 0, 990000000, 'books');
+
+    -- Product Review Service: create a schema
+    CREATE SCHEMA reviews;
+    GRANT USAGE ON SCHEMA reviews TO otelu;
+
+    -- Product Review Service: create tables
+    CREATE TABLE reviews.productreviews (
+        id INTEGER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+        product_id VARCHAR(16) NOT NULL,
+        username VARCHAR(64) NOT NULL,
+        description VARCHAR(1024),
+        score NUMERIC(2,1) NOT NULL
+    );
+
+    -- Product Review Service: create index for product_id lookups
+    CREATE INDEX product_id_index ON reviews.productreviews (product_id);
+
+    -- Product Review Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA reviews TO otelu;
+
+    -- Product Review Service:  add product review data
+    INSERT INTO reviews.productreviews (product_id, username, description, score)
+    VALUES
+        ('OLJCESPC7Z', 'stargazer_mike', 'Great entry-level telescope! Easy to set up and provides clear views of the moon and brighter planets. Highly recommend for new astronomers.', '4.5'),
+        ('OLJCESPC7Z', 'nightskylover', 'For the price, this Explorascope delivers excellent performance. I was able to see Jupiter''s moons clearly. A fantastic purchase for casual viewing.', '4.0'),
+        ('OLJCESPC7Z', 'beginner_astro', 'A bit tricky to get used to the manual controls, but once you do, it''s very rewarding. Saw the Orion Nebula for the first time! Good value.', '3.5'),
+        ('OLJCESPC7Z', 'celestial_explorer', 'Perfect for camping trips. It''s lightweight and portable, making it easy to take anywhere. The views are surprisingly good for its size.', '4.0'),
+        ('OLJCESPC7Z', 'telescope_fan', 'Not the most powerful scope, but it''s great for kids and beginners. My children love looking at the moon with it. A solid choice for family fun.', '3.0'),
+
+        ('66VCHSJNUP', 'tech_astro', 'The StarSense app is revolutionary! It made finding celestial objects incredibly easy. This telescope is a game-changer for beginners.', '5.0'),
+        ('66VCHSJNUP', 'app_user', 'Amazing technology, the smartphone integration works flawlessly. I''ve never had so much fun exploring the night sky. Worth every penny.', '4.5'),
+        ('66VCHSJNUP', 'innovator_john', 'Setup was a breeze, and the tutorials in the app are very helpful. The views are crisp and clear. My only minor gripe is battery drain on the phone.', '4.0'),
+        ('66VCHSJNUP', 'clear_skies', 'Finally, a telescope that takes the guesswork out of stargazing. The real-time positioning is incredibly accurate. Highly recommended for anyone new to astronomy.', '5.0'),
+        ('66VCHSJNUP', 'gadget_geek', 'Fantastic product, the app truly guides you. It''s like having a personal astronomer with you. The optical quality is also very good.', '4.5'),
+
+        ('1YMWWN1N4O', 'solar_viewer', 'Perfect for solar observations! The Solar Safe filter gives peace of mind. I used it for the last partial eclipse and it was fantastic.', '5.0'),
+        ('1YMWWN1N4O', 'eclipse_chaser', 'Compact and easy to carry, this telescope is ideal for eclipse events. The included backpack is a nice touch. Views of the sun are incredibly clear and safe.', '4.5'),
+        ('1YMWWN1N4O', 'travel_astro', 'Excellent travel scope for solar viewing. The magnification is much better than binoculars for the sun. A must-have for any solar enthusiast.', '4.0'),
+        ('1YMWWN1N4O', 'sun_gazer', 'Very impressed with the safety features and clarity. Sharing the sun with family has never been easier or safer. Great value for a dedicated solar scope.', '5.0'),
+        ('1YMWWN1N4O', 'safe_viewer', 'The ISO compliant filter is reassuring. It''s a well-designed product for safe solar observation. Highly recommend for educational purposes too.', '4.5'),
+
+        ('L9ECAV7KIM', 'clean_optics', 'This kit is a lifesaver for all my optics. The brush and wipes work perfectly without leaving any residue. My lenses have never been cleaner.', '5.0'),
+        ('L9ECAV7KIM', 'photog_pro', 'Essential for any photographer or telescope owner. It safely removes dust and fingerprints. A high-quality cleaning solution.', '4.5'),
+        ('L9ECAV7KIM', 'daily_cleaner', 'I use this on my binoculars, camera lenses, and even my phone screen. It''s very effective and gentle. A versatile cleaning kit.', '4.0'),
+        ('L9ECAV7KIM', 'tech_maintenance', 'Great value for money. The different cleaning options cover all needs. Keeps my expensive equipment in pristine condition.', '5.0'),
+        ('L9ECAV7KIM', 'sharp_view', 'Works as advertised, my telescope views are much clearer after using this. The fluid and cloth are excellent. Definitely recommend.', '4.5'),
+
+        ('2ZYFJ3GM2N', 'bird_watcher', 'Incredible clarity and brightness, perfect for bird watching. The ED glass really makes a difference. I can spot the subtlest markings.', '5.0'),
+        ('2ZYFJ3GM2N', 'nature_lover', 'These binoculars are fantastic for nature observation. The close focus is a huge advantage for viewing nearby wildlife. Very comfortable to hold.', '4.5'),
+        ('2ZYFJ3GM2N', 'hiker_guy', 'Lightweight and durable, these are my go-to binoculars for hiking. The wide field of view is excellent. Highly recommend for outdoor enthusiasts.', '4.0'),
+        ('2ZYFJ3GM2N', 'stadium_fan', 'Took these to a game and had an amazing view of the action. They perform great in various lighting conditions. A solid all-around binocular.', '4.0'),
+        ('2ZYFJ3GM2N', 'outdoor_adventurer', 'Excellent build quality and optical performance. They feel robust and provide sharp images. A great investment for any outdoor activity.', '4.5'),
+
+        ('0PUK6V6EV0', 'astro_photog', 'This imager is a fantastic step up for planetary photography. The color quality is superb. Easy to use with my existing telescope setup.', '5.0'),
+        ('0PUK6V6EV0', 'planet_shooter', 'Finally capturing stunning images of Saturn and Jupiter! The NexImage 10 makes it so accessible. Great for beginners in astrophotography.', '4.5'),
+        ('0PUK6V6EV0', 'imager_pro', 'Excellent resolution and color rendition for its price point. It''s a perfect solution for those looking to start imaging planets. Highly satisfied.', '4.0'),
+        ('0PUK6V6EV0', 'space_artist', 'The detail I can capture with this imager is incredible. It integrates well with various software. A must-have for serious planetary observers.', '5.0'),
+        ('0PUK6V6EV0', 'digital_sky', 'A solid choice for getting into solar system imaging. The setup was straightforward. Produces beautiful, vibrant planetary images.', '4.5'),
+
+        ('LS4PSXUNUM', 'night_walker', 'The red light is perfect for preserving night vision during astronomy sessions. The hand warmer is an unexpected bonus. Very practical device.', '5.0'),
+        ('LS4PSXUNUM', 'star_party_goer', 'This flashlight is indispensable for star parties. The red mode is gentle on the eyes, and the power bank feature is super handy. Love it!', '4.5'),
+        ('LS4PSXUNUM', 'camper_chris', 'Rugged and versatile, this flashlight is great for camping and night walks. The hand warmer function is a game-changer on cold nights. Highly recommend.', '4.5'),
+        ('LS4PSXUNUM', 'emergency_kit', 'A fantastic multi-tool for my emergency kit. The red light is useful, and the power bank means I can charge my phone. Great design.', '4.0'),
+        ('LS4PSXUNUM', 'astro_accessory', 'Every astronomer needs one of these. The red light is essential, and the hand warmer and power bank make it incredibly useful. A top-tier accessory.', '5.0'),
+
+        ('9SIQT8TOJO', 'deep_sky_master', 'The RASA V2 is a dream come true for deep-sky imaging. The f/2.2 speed drastically cuts down exposure times. My best astrophotography investment yet.', '5.0'),
+        ('9SIQT8TOJO', 'pro_astro', 'Unbelievable performance for wide-field astrophotography. The short focal length makes guiding less critical. Produces stunning, detailed images.', '5.0'),
+        ('9SIQT8TOJO', 'imaging_guru', 'This OTA is a beast! The fast optics mean more data in less time. If you''re serious about deep-sky imaging, this is the one.', '4.5'),
+        ('9SIQT8TOJO', 'advanced_scope', 'Worth every penny for the quality and speed it offers. My images have never been sharper or more vibrant. A truly professional piece of equipment.', '5.0'),
+        ('9SIQT8TOJO', 'precision_optics', 'The engineering behind this RASA is exceptional. It''s incredibly efficient for capturing faint objects. A high-end choice for dedicated imagers.', '4.5'),
+
+        ('6E92ZMYYFZ', 'solar_safety', 'Essential for safe solar viewing with my 8-inch telescope. The Velcro straps ensure it stays securely in place. Peace of mind during solar observations.', '5.0'),
+        ('6E92ZMYYFZ', 'telescope_upgrade', 'This EclipSmart filter is a perfect addition to my setup. The ISO compliance is crucial. Highly recommend for anyone looking to view the sun safely.', '4.5'),
+        ('6E92ZMYYFZ', 'safe_sun_gazer', 'Easy to attach and provides crystal clear, safe views of the sun. The build quality is excellent. A must-have accessory for solar enthusiasts.', '5.0'),
+        ('6E92ZMYYFZ', 'filter_fan', 'Works perfectly with my 8-inch scope. No more worries about accidental dislodgement. Great product for protecting your eyes and equipment.', '4.5'),
+        ('6E92ZMYYFZ', 'eclipse_ready', 'Bought this for the upcoming eclipse, and it fits perfectly. Tested it out, and the views are fantastic and safe. Very happy with this purchase.', '5.0'),
+
+        ('HQTGWGPNH4', 'history_buff', 'A fascinating glimpse into historical astronomical thought. The content is incredibly insightful. A must-read for anyone interested in the history of science.', '5.0'),
+        ('HQTGWGPNH4', 'bookworm_astro', 'Beautifully presented historical document. It''s amazing to see how comets were understood centuries ago. A valuable addition to any astronomy library.', '4.5'),
+        ('HQTGWGPNH4', 'ancient_texts', 'Such a unique and intriguing read. The historical context is captivating. It offers a different perspective on celestial events.', '4.0'),
+        ('HQTGWGPNH4', 'celestial_history', 'I love historical astronomy, and this book delivers. It''s well-researched and provides a window into past beliefs. Highly recommended for scholars.', '5.0'),
+        ('HQTGWGPNH4', 'rare_find', 'A truly special book for enthusiasts of astronomical history. The details about ancient astrologers are very interesting. Great for a deeper understanding.', '4.5');
+
+    -- ============================================================
+    -- Recommendation Service: DBMon Cartesian Join Demo
+    -- ============================================================
+
+    -- Recommendation Service: create tables (public schema)
+    CREATE TABLE IF NOT EXISTS products (
+        id           SERIAL PRIMARY KEY,
+        product_id   VARCHAR(64) UNIQUE NOT NULL,
+        name         VARCHAR(255),
+        category     VARCHAR(64),
+        price        DECIMAL(10,2),
+        created_at   TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS product_tags (
+        id              SERIAL PRIMARY KEY,
+        product_id      VARCHAR(64) NOT NULL,
+        tag             VARCHAR(64),
+        relevance_score DECIMAL(4,3)
+    );
+
+    -- Recommendation Service: seed 5,000 products
+    INSERT INTO products (product_id, name, category, price)
+    SELECT 'prod_' || gs, 'Product ' || gs,
+           (ARRAY['telescope','eyepiece','mount','camera','filter'])[floor(random()*5+1)],
+           (random() * 2000 + 50)::DECIMAL
+    FROM generate_series(1, 5000) gs
+    ON CONFLICT (product_id) DO NOTHING;
+
+    -- Recommendation Service: seed 100,000 tags (~20 per product)
+    INSERT INTO product_tags (product_id, tag, relevance_score)
+    SELECT 'prod_' || gs,
+           (ARRAY['beginner','advanced','astrophotography','visual','planetary',
+                  'deepsky','portable','goto','wifi','budget'])[floor(random()*10+1)],
+           (random())::DECIMAL
+    FROM generate_series(1, 5000) gs, generate_series(1, 20);
+
+    -- DO NOT create indexes or run ANALYZE - we want worst-case execution plan
+
+    -- Recommendation Service: create application user with settings that force Nested Loop Cartesian
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'demo_app_user') THEN
+            CREATE ROLE demo_app_user WITH LOGIN PASSWORD 'demo_password';
+        END IF;
+    END
+    $$;
+
+    GRANT SELECT ON products TO demo_app_user;
+    GRANT SELECT ON product_tags TO demo_app_user;
+
+    -- Force worst-case execution plan for demo_app_user
+    ALTER ROLE demo_app_user SET work_mem = '64kB';
+    ALTER ROLE demo_app_user SET enable_hashjoin  = OFF;
+    ALTER ROLE demo_app_user SET enable_mergejoin = OFF;
+
+---
+
+# === postgresql ===
+# Kubernetes manifest for postgres (PostgreSQL database)
+# Extracted from opentelemetry-demo.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    name: tcp-service
+    targetPort: 5432
+  selector:
+    opentelemetry.io/name: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: postgresql
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: postgresql
+        splunk.com/postgresql.database: otel
+      labels:
+        opentelemetry.io/name: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/name: postgresql
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: postgresql
+        image: postgres:17.8
+        imagePullPolicy: IfNotPresent
+        args:
+          - "-c"
+          - "shared_preload_libraries=pg_stat_statements"
+          - "-c"
+          - "pg_stat_statements.track=all"
+        ports:
+        - containerPort: 5432
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: POSTGRES_USER
+          value: root
+        - name: POSTGRES_PASSWORD
+          value: otel
+        - name: POSTGRES_DB
+          value: otel
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 256Mi
+        volumeMounts:
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/00-pg-stat-statements.sh
+          subPath: 00-pg-stat-statements.sh
+          readOnly: true
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/init.sql
+          subPath: init.sql
+          readOnly: true
+      volumes:
+      - name: postgres-init
+        configMap:
+          name: postgres-init-sql
+          defaultMode: 0755
+
+---
+
+# === product-catalog ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for product-catalog
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s): Service, Deployment, and ConfigMap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: product-catalog
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-catalog
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-catalog
+        app.kubernetes.io/component: product-catalog
+        app.kubernetes.io/name: product-catalog
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-catalog
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-catalog:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_CATALOG_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_RELOAD_INTERVAL
+          value: '10'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: "host=postgresql user=otelu password=otelp dbname=otel sslmode=disable"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 200MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            memory: 200Mi
+        volumeMounts:
+        - name: product-catalog-products
+          mountPath: /usr/src/app/products
+      volumes:
+      - name: product-catalog-products
+        configMap:
+          name: product-catalog-products
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-products
+  labels:
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # yamllint disable rule:line-length
+  products.json: |
+    {
+      "products": [
+        {
+          "id": "OLJCESPC7Z",
+          "name": "National Park Foundation Explorascope",
+          "description": "The National Park Foundation's (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.",
+          "picture": "NationalParkFoundationExplorascope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 101,
+            "nanos": 960000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "66VCHSJNUP",
+          "name": "Starsense Explorer Refractor Telescope",
+          "description": "The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app's user-friendly interface and detailed tutorials. It's like having your own personal tour guide of the night sky",
+          "picture": "StarsenseExplorer.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 349,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "1YMWWN1N4O",
+          "name": "Eclipsmart Travel Refractor Telescope",
+          "description": "Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.",
+          "picture": "EclipsmartTravelRefractorTelescope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 129,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes",
+            "travel"
+          ]
+        },
+        {
+          "id": "L9ECAV7KIM",
+          "name": "Lens Cleaning Kit",
+          "description": "Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.",
+          "picture": "LensCleaningKit.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 21,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories"
+          ]
+        },
+        {
+          "id": "2ZYFJ3GM2N",
+          "name": "Roof Binoculars",
+          "description": "This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It's an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.",
+          "picture": "RoofBinoculars.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 209,
+            "nanos": 950000000
+          },
+          "categories": [
+            "binoculars"
+          ]
+        },
+        {
+          "id": "0PUK6V6EV0",
+          "name": "Solar System Color Imager",
+          "description": "You have your new telescope and have observed Saturn and Jupiter. Now you're ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.",
+          "picture": "SolarSystemColorImager.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 175,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "LS4PSXUNUM",
+          "name": "Red Flashlight",
+          "description": "This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red's rugged, IPX4-rated design will withstand your everyday activities.",
+          "picture": "RedFlashlight.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 57,
+            "nanos": 80000000
+          },
+          "categories": [
+            "accessories",
+            "flashlights"
+          ]
+        },
+        {
+          "id": "9SIQT8TOJO",
+          "name": "Optical Tube Assembly",
+          "description": "Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today's top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won't need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.",
+          "picture": "OpticalTubeAssembly.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 3599,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes",
+            "assembly"
+          ]
+        },
+        {
+          "id": "6E92ZMYYFZ",
+          "name": "Solar Filter",
+          "description": "Enhance your viewing experience with EclipSmart Solar Filter for 8\" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.",
+          "picture": "SolarFilter.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 69,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "HQTGWGPNH4",
+          "name": "The Comet Book",
+          "description": "A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as \"Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers\". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)",
+          "picture": "TheCometBook.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 0,
+            "nanos": 990000000
+          },
+          "categories": [
+            "books"
+          ]
+        }
+      ]
+    }
+
+---
+
+# === product-reviews ===
+# Kubernetes manifest for product-reviews
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3551
+    name: tcp-service
+    targetPort: 3551
+  selector:
+    opentelemetry.io/name: product-reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-reviews
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-reviews
+        app.kubernetes.io/component: product-reviews
+        app.kubernetes.io/name: product-reviews
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-reviews
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-reviews:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3551
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_REVIEWS_PORT
+          value: '3551'
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
+          value: 'span_only'
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: 'gen_ai_latest_experimental'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: host=postgresql user=otelu password=otelp dbname=otel
+        - name: LLM_HOST
+          value: llm
+        - name: LLM_PORT
+          value: '8000'
+        - name: LLM_BASE_URL
+          value: http://llm:8000/v1
+        - name: LLM_MODEL
+          value: astronomy-llm
+        - name: OPENAI_API_KEY
+          value: dummy
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === quote ===
+# Kubernetes manifest for quote
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: quote
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: quote
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: quote
+        app.kubernetes.io/component: quote
+        app.kubernetes.io/name: quote
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: quote
+        image: ghcr.io/open-telemetry/demo:2.2.0-quote
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: QUOTE_PORT
+          value: '8080'
+        - name: OTEL_PHP_AUTOLOAD_ENABLED
+          value: 'true'
+        - name: OTEL_PHP_INTERNAL_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 40Mi
+        securityContext:
+          runAsGroup: 33
+          runAsNonRoot: true
+          runAsUser: 33
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === recommendation ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for recommendation
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: recommendation
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: recommendation
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: recommendation
+        app.kubernetes.io/component: recommendation
+        app.kubernetes.io/name: recommendation
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: recommendation
+        image: ghcr.io/splunk/opentelemetry-demo/otel-recommendation:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: RECOMMENDATION_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '750'
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        # PostgreSQL connection for DBMon Cartesian demo
+        - name: POSTGRES_HOST
+          value: "postgresql"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          value: "otel"
+        - name: POSTGRES_USER
+          value: "demo_app_user"
+        - name: POSTGRES_PASSWORD
+          value: "demo_password"
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === shipping ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for shipping
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: shipping
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shipping
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shipping
+        app.kubernetes.io/component: shipping
+        app.kubernetes.io/name: shipping
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: shipping
+        image: ghcr.io/open-telemetry/demo:2.2.0-shipping
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SHIPPING_PORT
+          value: '8080'
+        - name: QUOTE_ADDR
+          value: http://quote:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === sql-server-fraud-setup ===
+# Kubernetes manifest for SQL Server setup
+# Includes secrets and initialization script for MSSQL
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secrets
+type: Opaque
+stringData:
+  SA_PASSWORD: ChangeMe_SuperStrong123!
+  DB_CONNECTION_STRING: Server=tcp:sql-server-fraud.astronomy-shop.svc.cluster.local,1433;Database=FraudDetection;User
+    Id=sa;Password=ChangeMe_SuperStrong123!;Encrypt=True;TrustServerCertificate=True
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mssql-init-script
+data:
+  init-db.sql: |
+    IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'FraudDetection')
+    BEGIN
+      CREATE DATABASE FraudDetection;
+    END
+    GO
+
+---
+
+# === sql-server-fraud ===
+# Kubernetes manifest for sql-server-fraud
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sql-server-fraud
+spec:
+  type: ClusterIP
+  ports:
+  - port: 1433
+    targetPort: 1433
+    protocol: TCP
+    name: tds
+  selector:
+    app: sql-server-fraud
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sql-server-fraud
+spec:
+  serviceName: sql-server-fraud
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  selector:
+    matchLabels:
+      app: sql-server-fraud
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: sqlserver
+        splunk.com/sqlserver.database: fraud
+      labels:
+        app: sql-server-fraud
+    spec:
+      containers:
+      - name: mssql
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 1433
+          name: tds
+        env:
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: MSSQL_PID
+          value: Express
+        - name: SA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mssql-secrets
+              key: SA_PASSWORD
+        volumeMounts:
+        - name: data
+          mountPath: /var/opt/mssql
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'sleep 30
+
+                /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}"
+                -C -i /docker-entrypoint-initdb.d/init-db.sql
+
+                '
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+        readinessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 30
+          periodSeconds: 20
+      volumes:
+      - name: init-script
+        configMap:
+          name: mssql-init-script
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+
+---
+
+# === valkey-cart ===
+# Kubernetes manifest for valkey-cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    name: valkey-cart
+    targetPort: 6379
+  selector:
+    opentelemetry.io/name: valkey-cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: multienv-test
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: valkey-cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: valkey-cart
+        app.kubernetes.io/component: valkey-cart
+        app.kubernetes.io/name: valkey-cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: valkey-cart
+        image: valkey/valkey:9.0.2-alpine3.23
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: valkey-cart
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=multienv-test,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts: null
+      volumes: null
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-dc-shim.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-dc-shim.yaml
@@ -1,0 +1,292 @@
+# Splunk Astronomy Shop Kubernetes Manifest - dc-shim
+# Version: otel-fields-fix
+# Generated on: 2026-06-17T10:44:04Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === shop-dc-shim ===
+### Expects a deployment of Astronomy Shop Demo in the same cluster
+### Uses checkout service from that demo
+### Or add this at config at the end of an astronomy shop demo deployment yaml
+---
+# Shop DC Shim Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: shop-dc-shim
+  labels:
+    opentelemetry.io/name: shop-dc-shim
+    app.kubernetes.io/component: shop-dc-shim
+    app.kubernetes.io/name: shop-dc-shim
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8070
+      name: tcp-service
+      targetPort: 8070
+  selector:
+    opentelemetry.io/name: shop-dc-shim
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shop-dc-shim
+  labels:
+    opentelemetry.io/name: shop-dc-shim
+    app.kubernetes.io/component: shop-dc-shim
+    app.kubernetes.io/name: shop-dc-shim
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shop-dc-shim
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shop-dc-shim
+        app.kubernetes.io/component: shop-dc-shim
+        app.kubernetes.io/name: shop-dc-shim
+        app.kubernetes.io/version: "2.1.3"
+        app.kubernetes.io/part-of: opentelemetry-demo
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+        - name: shop-dc-shim
+          image: ghcr.io/splunk/opentelemetry-demo/otel-shop-dc-shim:2.0.5
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8070
+              name: http
+          command: ["/usr/bin/dumb-init"]
+          args:
+          - --
+          - /bin/bash
+          - -c
+          - |
+            export OTEL_RESOURCE_ATTRIBUTES="service.name=shop-dc-shim-service,deployment.environment=${ENV_VALUE}-datacenter-b01,service.version=otel-fields-fix,service.namespace=shop-dc-shim"
+            sed -i "s|http://splunk-otel-collector-agent:4318|http://${NODE_IP}:4318|g" /app/start-app-dual.sh
+            exec /app/start-app-dual.sh
+          env:
+            - name: WORKSHOP_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: workshop-secret
+                  key: env
+            - name: TPM
+              value: "10"  # Transactions Per Minute - scales both request frequency and processing load
+            # Memory optimization - uncomment to reduce memory usage
+            # - name: AUDIT_LOG_ENABLED
+            #   value: "false"  # Disable audit log generation
+            - name: TRANSACTION_RETENTION_MINUTES
+              value: "30"  # Clean up transactions after 30 minutes (default: 120)
+            - name: TRANSACTION_CLEANUP_INTERVAL_MS
+              value: "1800000"  # Run cleanup every 30 minutes (default: 7200000)
+            - name: SHOP_DC_SHIM_PORT
+              value: "8070"
+            - name: DB_CONNECTION_STRING
+              value: "jdbc:sqlserver://shop-dc-shim-db:1433;databaseName=master;encrypt=false;trustServerCertificate=true"
+            - name: DB_USERNAME
+              value: "sa"
+            - name: DB_PASSWORD
+              value: "ShopPass123!"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkout:8080"
+            - name: EMAIL_SERVICE_URL
+              value: "http://email:8080"
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_COLLECTOR_NAME
+              value: $(NODE_IP)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://$(OTEL_COLLECTOR_NAME):4318"
+            - name: OTEL_SERVICE_NAME
+              value: "shop-dc-shim"
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: "true"
+            - name: APPDYNAMICS_AGENT_ACCOUNT_NAME
+              value: "se-lab"
+            - name: APPDYNAMICS_JAVAAGENT_ENABLED
+              value: "true"
+            - name: APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: workshop-secret
+                  key: appd_token
+                  optional: true
+            - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+              value: "true"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8070
+            initialDelaySeconds: 240
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8070
+            initialDelaySeconds: 420
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+
+---
+
+# === shop-dc-shim-db ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+### Expects a deployment of Astronomy Shop Demo in the same cluster
+### Uses checkout service from that demo
+### Or add this at config at the end of an astronomy shop demo deployment yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shop-dc-shim-db
+
+  labels:
+    opentelemetry.io/name: shop-dc-shim-db
+    app.kubernetes.io/component: shop-dc-shim-db
+    app.kubernetes.io/name: shop-dc-shim-db
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1433
+      name: sqlserver
+      targetPort: 1433
+  selector:
+    opentelemetry.io/name: shop-dc-shim-db
+---
+apiVersion: apps/v1
+kind: Deployment 
+metadata:
+  name: shop-dc-shim-db
+  labels:
+    opentelemetry.io/name: shop-dc-shim-db
+    app.kubernetes.io/component: shop-dc-shim-db
+    app.kubernetes.io/name: shop-dc-shim-db
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shop-dc-shim-db
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: sqlserver
+        splunk.com/sqlserver.database: shopshim
+      labels:
+        opentelemetry.io/name: shop-dc-shim-db
+        app.kubernetes.io/component: shop-dc-shim-db
+        app.kubernetes.io/name: shop-dc-shim-db
+        app.kubernetes.io/version: "2.1.3"
+        app.kubernetes.io/part-of: opentelemetry-demo
+    spec:
+      containers:
+        - name: sqlserver
+          image: mcr.microsoft.com/mssql/server:2022-latest
+          ports:
+            - containerPort: 1433
+          env:
+            - name: ACCEPT_EULA
+              value: "Y"
+            - name: MSSQL_SA_PASSWORD
+              value: "ShopPass123!"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"
+            limits:
+              memory: "3Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: sqlserver-storage
+              mountPath: /var/opt/mssql/data
+      volumes:
+        - name: sqlserver-storage
+          emptyDir: {}
+---
+
+# === shop-dc-loadgenerator ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+### Expects a deployment of Astronomy Shop Demo in the same cluster
+### Uses checkout service from that demo
+### Or add this at config at the end of an astronomy shop demo deployment yaml
+---
+# Shop DC Load Generator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shop-dc-load-generator
+  labels:
+    opentelemetry.io/name: shop-dc-load-generator
+    app.kubernetes.io/component: shop-dc-load-generator
+    app.kubernetes.io/name: shop-dc-load-generator
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shop-dc-load-generator
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shop-dc-load-generator
+        app.kubernetes.io/component: shop-dc-load-generator
+        app.kubernetes.io/name: shop-dc-load-generator
+        app.kubernetes.io/version: "2.1.3"
+        app.kubernetes.io/part-of: opentelemetry-demo
+    spec:
+      serviceAccountName: opentelemetry-demo
+      initContainers:
+        - name: wait-for-shop-dc-shim
+          image: curlimages/curl:8.1.2
+          command: ['sh', '-c']
+          args:
+            - |
+              echo "Waiting for shop-dc-shim service to be ready..."
+              until curl -f --connect-timeout 5 --max-time 20 http://shop-dc-shim:8070/actuator/health; do
+                echo "Shop DC Shim not ready, waiting 20 seconds..."
+                sleep 20
+              done
+              echo "Shop DC Shim is ready, starting load generator..."
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "50m"
+      containers:
+        - name: load-generator
+          image: ghcr.io/splunk/opentelemetry-demo/otel-shop-dc-loadgenerator:2.0.5
+          env:
+            - name: TPM
+              value: "10"  # Transactions Per Minute - adjust to control load (e.g., 5, 10, 25, 50)
+          args: ["--url", "http://shop-dc-shim:8070", "--mode", "continuous", "--duration", "0"]
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-diab.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-diab.yaml
@@ -1,0 +1,3815 @@
+# Splunk Astronomy Shop Kubernetes Manifest
+# Version: otel-fields-fix
+# Generated on: 2026-06-17T10:44:05Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === accounting ===
+# Kubernetes manifest for accounting
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accounting
+  labels:
+    opentelemetry.io/name: accounting
+    app.kubernetes.io/component: accounting
+    app.kubernetes.io/name: accounting
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: accounting
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: accounting
+        app.kubernetes.io/component: accounting
+        app.kubernetes.io/name: accounting
+    spec:
+      serviceAccountName: opentelemetry-demo
+      # DNS Configuration to prevent stale DNS caching
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          # Reduce DNS TTL to 10 seconds for faster updates
+          - name: ndots
+            value: "2"
+          # Number of DNS queries before giving up
+          - name: timeout
+            value: "2"
+          # Number of retries for DNS queries
+          - name: attempts
+            value: "3"
+      containers:
+      - name: accounting
+        image: ghcr.io/splunk/opentelemetry-demo/otel-accounting:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        # Kafka connection retry configuration
+        - name: KAFKA_RECONNECT_BACKOFF_MS
+          value: "1000"
+        - name: KAFKA_RECONNECT_BACKOFF_MAX_MS
+          value: "10000"
+        - name: KAFKA_CONNECTIONS_MAX_IDLE_MS
+          value: "300000"
+        - name: KAFKA_METADATA_MAX_AGE_MS
+          value: "10000"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: DB_CONNECTION_STRING
+          value: Host=postgresql;Username=otelu;Password=otelp;Database=otel
+        - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
+          value: 'false'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=spanlink
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === ad ===
+# Kubernetes manifest for ad
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: ad
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: ad
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: ad
+        app.kubernetes.io/component: ad
+        app.kubernetes.io/name: ad
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: ad
+        image: ghcr.io/splunk/opentelemetry-demo/otel-ad:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./build/install/opentelemetry-demo-ad/bin/Ad
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: AD_PORT
+          value: '8080'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_TRACES_SAMPLER
+          value: rules
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '100'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/usr/src/app/splunk-otel-javaagent-csa.jar -Dsplunk.snapshot.profiler.enabled=true
+            -Dsplunk.snapshot.profiler.sampling.interval=1 -Dsplunk.snapshot.selection.probability=0.1
+            -Xmx440m
+        resources:
+          limits:
+            memory: 600Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === astronomy-loadgen ===
+# Kubernetes manifest for astronomy-loadgen
+# Includes scriptfile ConfigMap used by the deployment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scriptfile
+data:
+  local-file: |
+    /* eslint-disable no-console */
+    const { Console } = require('console');
+    const puppeteer = require('puppeteer');
+    const customUserAgent = 'Mozilla/5.0 (X11; Linux x86_64; Splunk RUM_LoadGen) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36';
+
+    // Debug logging flag (set via DEBUG_LOGGING env var)
+    const debugEnabled = process.env.DEBUG_LOGGING === 'true';
+    if (debugEnabled) console.log('DEBUG: Using User Agent:', customUserAgent);
+
+    // Global browser instance for reuse across cycles
+    let globalBrowser = null;
+
+
+    async function launchBrowser() {
+      console.log('🔹 Starting headless browser...');
+      const browser = await puppeteer.launch({
+        headless: true,
+        defaultViewport: null,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--disable-web-security',
+          '--disable-features=VizDisplayCompositor',
+          '--max-old-space-size=256',
+          '--disable-extensions',
+          '--disable-plugins',
+          '--disable-background-networking',
+          '--disable-background-timer-throttling',
+          '--disable-backgrounding-occluded-windows',
+          '--disable-renderer-backgrounding',
+          '--memory-pressure-off',
+          '--aggressive-cache-discard',
+          '--ignore-certificate-errors',
+          '--allow-insecure-localhost',
+          `--user-agent=${customUserAgent}`
+        ]
+      });
+      console.log('✅ Browser started.');
+      return browser;
+    }
+
+    async function ensureBrowser() {
+      if (!globalBrowser || !globalBrowser.isConnected()) {
+        console.log('🔄 Launching new global browser instance...');
+        globalBrowser = await launchBrowser();
+      }
+      return globalBrowser;
+    }
+
+    function buildBaseUrl() {
+      const raw = (process.env.RUM_FRONTEND_IP || '').trim();
+
+      // If it's empty, default to localhost
+      if (!raw) return 'https://localhost/';
+
+      // If it already starts with http:// or https://, keep it exactly as-is
+      if (/^https?:\/\//i.test(raw)) {
+        return raw.replace(/\/+$/, '') + '/';
+      }
+
+      // Otherwise, prepend https://
+      return `https://${raw.replace(/\/+$/, '')}/`;
+    }
+
+    function getProductIds() {
+      const envProductIds = (process.env.PRODUCT_IDS || '').trim();
+      if (envProductIds) {
+        return envProductIds.split(',').map(id => id.trim()).filter(id => id);
+      }
+      // Hardcoded product IDs if env variable is not set or empty
+      return [
+        'OLJCESPC7Z', // National Park Foundation Explorascope
+        '66VCHSJNUP', // Starsense Explorer Refractor Telescope
+        '1YMWWN1N4O', // Eclipsmart Travel Refractor Telescope
+        'L9ECAV7KIM', // Lens Cleaning Kit
+        '2ZYFJ3GM2N', // Roof Binoculars
+        '0PUK6V6EV0', // Solar System Color Imager
+        'LS4PSXUNUM', // Red Flashlight
+        '9SIQT8TOJO', // Optical Tube Assembly
+        '6E92ZMYYFZ', // Solar Filter
+        'HQTGWGPNH4'  // The Comet Book
+      ];
+    }
+
+    function getRandomProducts() {
+      const allProducts = getProductIds();
+      const numProducts = Math.floor(Math.random() * 3) + 1; // Random number between 1 and 3
+      const shuffled = allProducts.sort(() => Math.random() - 0.5);
+      return shuffled.slice(0, numProducts);
+    }
+
+    // Throttle quick prompts — parsed from env, default 5 min
+    const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
+    let lastQuickPromptTime = 0;
+
+    // Shipping API — random interval between 34s and 1m45s
+    const SHIPPING_MIN_MS = parseInt(process.env.SHIPPING_MIN_MS || '34000', 10);
+    const SHIPPING_MAX_MS = parseInt(process.env.SHIPPING_MAX_MS || '105000', 10);
+    let nextShippingTime = 0;
+    const SHIPPING_API_ENABLED = (process.env.SHIPPING_API || '').toLowerCase() === 'true';
+
+    function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
+
+    /** Generate a random shipping tracking number */
+    function randomTrackingNumber() {
+      const num = Math.floor(Math.random() * 99999) + 10000;
+      return `SHIP-${num}`;
+    }
+
+    /** Schedule next shipping call at a random interval */
+    function scheduleNextShipping() {
+      const interval = SHIPPING_MIN_MS + Math.floor(Math.random() * (SHIPPING_MAX_MS - SHIPPING_MIN_MS));
+      nextShippingTime = Date.now() + interval;
+      if (debugEnabled) console.log(`[DEBUG] Next shipping call in ${Math.round(interval/1000)}s`);
+    }
+
+    /** Fetch shipping info via the frontend-proxy /shipping/ route */
+    async function fetchShippingInfo(page) {
+      if (!SHIPPING_API_ENABLED) return;
+      if (Date.now() < nextShippingTime) return;
+      scheduleNextShipping();
+
+      const tracking = randomTrackingNumber();
+      const base = buildBaseUrl();
+      const url = `${base}shipping/?tracking=${tracking}`;
+      console.log(`📦 Fetching shipping info for ${tracking}...`);
+      try {
+        const result = await page.evaluate(async (fetchUrl) => {
+          const resp = await fetch(fetchUrl);
+          return { status: resp.status, body: await resp.text() };
+        }, url);
+        console.log(`📦 Shipping info: HTTP ${result.status}`);
+        if (debugEnabled) console.log(`[DEBUG] Shipping response: ${result.body}`);
+      } catch (e) {
+        console.log(`⚠️ Shipping info fetch failed: ${e.message}`);
+      }
+    }
+
+    /** Wait until innerText of the page contains a substring */
+    async function waitForText(page, text, timeoutMs = 30000, pollMs = 200) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const found = await page.evaluate(t =>
+          document && document.body && document.body.innerText.includes(t),
+          text
+        );
+        if (found) return true;
+        await delay(pollMs);
+      }
+      throw new Error(`Timed out waiting for text: "${text}"`);
+    }
+
+    async function runOnce() {
+      const browser = await ensureBrowser();
+      let page;
+      let ctx;
+      try {
+        // Fresh browser context per cycle so localStorage / cookies / session
+        // ID reset between cycles. Otherwise every cycle reuses the same RUM
+        // session ID and the funnel sees a single user looping forever.
+        ctx = await browser.createBrowserContext();
+        page = await ctx.newPage();
+        page.setDefaultNavigationTimeout(45000);
+        page.setDefaultTimeout && page.setDefaultTimeout(30000);
+
+        // Log all responses for debugging (when DEBUG_LOGGING=true)
+        if (debugEnabled) {
+          page.on('response', response => {
+            const url = response.url();
+            if (url.includes('api')) {
+              console.log(`[DEBUG] API Response: ${url} (${response.status()})`);
+            }
+          });
+        }
+
+        const base = buildBaseUrl();
+        const productsToOrder = getRandomProducts();
+        console.log(`🛒 Ordering ${productsToOrder.length} product(s): ${productsToOrder.join(', ')}`);
+
+        // Visit homepage first so the user enters the sequential RUM funnel
+        // at step 1. Without this the loadgen lands on /product/<id> and the
+        // funnel records 0 conversions because step 1 is never satisfied.
+        const homeUrl = base.replace(/\/+$/, '/');
+        console.log(`🏠 Visiting homepage ${homeUrl}`);
+        await page.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+        await delay(1500);
+
+        // Loop through each product and add to cart
+        for (const productId of productsToOrder) {
+          const url = new URL(`product/${productId}`, base).toString();
+          console.log(`🌐 Navigating to ${url}`);
+
+          // Set up /api/data response listener BEFORE navigation
+          const apiDataPromise = page.waitForResponse(
+            response => {
+              const url = response.url();
+              const status = response.status();
+              const matches = url.includes('/api/data') && (status === 200 || status === 304);
+              if (matches) {
+                console.log(`✅ /api/data response received: ${status}`);
+              }
+              return matches;
+            },
+            { timeout: 15000 }
+          );
+
+          // Navigate to page
+          await page.goto(url, {
+            waitUntil: 'networkidle2',  // Wait until no more than 2 connections for 500ms
+            timeout: 60000               // 60 second timeout for page load
+          });
+
+          // Now wait for /api/data to complete (may have already completed during goto)
+          console.log('⏳ Ensuring ad service (/api/data) completed...');
+          await apiDataPromise.catch(() => {
+            console.log('⚠️ /api/data did not complete in 15s, continuing anyway...');
+          });
+
+          // Small delay to ensure any follow-up requests finish
+          await delay(500);
+          console.log('✅ Page fully loaded with all API calls complete');
+
+          // Quick prompts - throttled to once every 5 minutes
+          const now = Date.now();
+          if (now - lastQuickPromptTime >= QUICK_PROMPT_INTERVAL_MS) {
+          lastQuickPromptTime = now;
+
+          const quickPrompts = [
+            {
+              label: 'Can you summarize the product reviews?',
+              dataCy: 'QuickPromptSummarize',
+              ariaSelector: '::-p-aria(Can you summarize the product reviews?)',
+              textSelector: '::-p-text(Can you summarize)',
+              offset: { x: 129, y: 15 },
+            },
+            {
+              label: 'Were there any negative reviews?',
+              dataCy: 'QuickPromptNegative',
+              ariaSelector: '::-p-aria(Were there any negative reviews?)',
+              textSelector: '::-p-text(Were there any)',
+              offset: { x: 171.6640625, y: 25 },
+            },
+            {
+              label: 'What age(s) is this recommended for?',
+              dataCy: 'QuickPromptAges',
+              ariaSelector: '::-p-aria(What age\\(s\\) is this recommended for?)',
+              textSelector: '::-p-text(What age\\(s\\) is)',
+              offset: { x: 148.0390625, y: 19 },
+            },
+          ];
+
+          const prompt = quickPrompts[Math.floor(Math.random() * quickPrompts.length)];
+          console.log(`🖱️ Clicking quick prompt: "${prompt.label}"`);
+
+          {
+              const targetPage = page;
+              const timeout = 5000;
+              await puppeteer.Locator.race([
+                  targetPage.locator(prompt.ariaSelector),
+                  targetPage.locator(`[data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(`::-p-xpath(//*[@data-cy=\\"${prompt.dataCy}\\"])`),
+                  targetPage.locator(`:scope >>> [data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(prompt.textSelector)
+              ])
+                  .setTimeout(timeout)
+                  .click({ offset: prompt.offset });
+              console.log('⏳ Waiting for AI response...');
+              await delay(500); // Let request start
+              await page.waitForSelector("[data-cy='AIAnswer']", { timeout: 15000, visible: true }).catch(() => {
+                console.log('⚠️ AI response timeout, continuing...');
+              });
+              await delay(1500); // Allow response to fully render
+          }
+
+          } else {
+            console.log('⏭️ Skipping quick prompts (next run in ' + Math.round((QUICK_PROMPT_INTERVAL_MS - (now - lastQuickPromptTime)) / 1000) + 's)');
+          }
+
+          const addSel = "[data-cy='product-add-to-cart']";
+          await page.waitForSelector(addSel);
+          console.log(`🖱️ Clicking "Add To Cart" for product ${productId}`);
+          await page.click(addSel);
+        }
+
+        // Place order after all products are added to cart
+        const placeSel = "[data-cy='checkout-place-order']";
+        await page.waitForSelector(placeSel);
+        console.log('🖱️ Clicking "Place Order"');
+        await page.click(placeSel);
+
+        // Wait for either success message or error modal
+        console.log('⏳ Waiting for order result...');
+        const orderResult = await Promise.race([
+          waitForText(page, 'Your order is complete!').then(() => 'success'),
+          page.waitForSelector('#modal-close-btn', { timeout: 30000, visible: true }).then(() => 'error-modal')
+        ]);
+
+        if (orderResult === 'success') {
+          console.log('🎉 Order completed successfully!');
+          // Confirmation page useEffect fires the `order.confirmed` RUM span
+          // asynchronously. Wait so the RUM batcher can flush the beacon
+          // before the page / context is torn down.
+          await delay(5000);
+        } else if (orderResult === 'error-modal') {
+          console.log('⚠️ Error modal detected - closing it to continue...');
+          await page.click('#modal-close-btn');
+          await delay(500);
+          console.log('✅ Error modal closed.');
+        }
+
+        // Periodic shipping info fetch (every 2 minutes, gated by SHIPPING_API)
+        await fetchShippingInfo(page);
+      } finally {
+        console.log('🧹 Cleaning up page resources...');
+        try {
+          if (page) {
+            page.removeAllListeners();
+            await page.close({ runBeforeUnload: true }).catch(()=>{});
+          }
+          if (ctx) {
+            await ctx.close().catch(()=>{});
+          }
+        } catch (e) {
+          console.error('⚠️ Error closing page:', e.message);
+        }
+        console.log('✅ Page + context closed cleanly. Browser will be reused for next cycle.');
+      }
+    }
+
+    (async function mainLoop() {
+      const cycleDelayMs = parseInt(process.env.CYCLE_DELAY_MS || '5000', 10);
+      console.log(`⚙️ Cycle delay: ${cycleDelayMs}ms`);
+
+      let cycle = 1;
+      while (true) {
+        console.log(`=== Starting load generation cycle #${cycle} ===`);
+        try {
+          await runOnce();
+          console.log(`✅ Cycle #${cycle} finished OK`);
+        } catch (e) {
+          console.error(`❌ Cycle #${cycle} failed:`, e && e.stack ? e.stack : e);
+        }
+        cycle += 1;
+        await delay(cycleDelayMs);
+      }
+    })();
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astronomy-loadgen-deployment
+  labels:
+    app: astronomy-loadgen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: astronomy-loadgen
+  template:
+    metadata:
+      labels:
+        app: astronomy-loadgen
+    spec:
+      initContainers:
+      - name: wait-for-frontend
+        image: curlimages/curl:8.1.2
+        command: ['sh', '-c']
+        args:
+        - |
+          echo "Waiting for frontend-proxy to be ready..."
+          until curl -f --connect-timeout 5 --max-time 10 http://frontend-proxy:8080; do
+            echo "Frontend not ready, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Frontend is ready, starting loadgen..."
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "50m"
+      containers:
+      - name: astronomy-loadgen
+        image: ghcr.io/splunk/online-boutique/rumloadgen:5.6
+        imagePullPolicy: Always
+        env:
+        # NOTE: For RUM funnels that filter on the public ingress URL (e.g.
+        # `https://astronomy-shop.example.com`), override this value per
+        # deployment so the loadgen browser navigates to the same origin as
+        # real users. The in-cluster default below works for traffic-only
+        # generation but produces RUM events tagged with the internal URL.
+        - name: RUM_FRONTEND_IP
+          value: "http://frontend-proxy:8080"
+        - name: CYCLE_DELAY_MS
+          value: "1000"
+        - name: DEBUG_LOGGING
+          value: ""  # Set to "true" to enable debug logging
+        - name: QUICK_PROMPT_INTERVAL_MS
+          value: "300000"  # How often AI quick prompts run (ms). Default 300000 (5min). Set "0" for every cycle.
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "500m"
+          limits:
+            memory: "1536Mi"
+            cpu: "1000m"
+        volumeMounts:
+        - name: puppeteer
+          subPath: local-file
+          mountPath: /puppeteer/touchwebsite.js
+      volumes:
+      - name: puppeteer
+        configMap:
+          name: scriptfile
+
+---
+
+# === cart ===
+# Kubernetes manifest for cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: cart
+        app.kubernetes.io/component: cart
+        app.kubernetes.io/name: cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: cart
+        image: ghcr.io/splunk/opentelemetry-demo/otel-cart:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CART_PORT
+          value: '8080'
+        - name: ASPNETCORE_URLS
+          value: http://*:$(CART_PORT)
+        - name: VALKEY_ADDR
+          value: valkey-cart:6379
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          limits:
+            memory: 320Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep
+          2; done;
+        image: busybox:latest
+        name: wait-for-valkey-cart
+      volumes: null
+
+---
+
+# === checkout ===
+# Kubernetes manifest for checkout
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: checkout
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: checkout
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: checkout
+        app.kubernetes.io/component: checkout
+        app.kubernetes.io/name: checkout
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: checkout
+        image: ghcr.io/splunk/opentelemetry-demo/otel-checkout:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CHECKOUT_PORT
+          value: '8080'
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: EMAIL_ADDR
+          value: http://email:8080
+        - name: PAYMENT_ADDR
+          value: payment:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 16MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === currency ===
+# Kubernetes manifest for currency
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: currency
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: currency
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: currency
+        app.kubernetes.io/component: currency
+        app.kubernetes.io/name: currency
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: currency
+        image: ghcr.io/open-telemetry/demo:2.2.0-currency
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CURRENCY_PORT
+          value: '8080'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: VERSION
+          value: 2.1.3
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === email ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for email
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: email
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: email
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: email
+        app.kubernetes.io/component: email
+        app.kubernetes.io/name: email
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: email
+        image: ghcr.io/open-telemetry/demo:2.2.0-email
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: EMAIL_PORT
+          value: '8080'
+        - name: APP_ENV
+          value: production
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === flagd ===
+# Kubernetes manifest for flagd
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8013
+    name: rpc
+    targetPort: 8013
+  - port: 8016
+    name: ofrep
+    targetPort: 8016
+  selector:
+    opentelemetry.io/name: flagd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd
+        app.kubernetes.io/component: flagd
+        app.kubernetes.io/name: flagd
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: flagd
+        image: ghcr.io/open-feature/flagd:v0.14.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /flagd-build
+        - start
+        - --port
+        - '8013'
+        - --ofrep-port
+        - '8016'
+        - --uri
+        - file:./etc/flagd/demo.flagd.json
+        ports:
+        - containerPort: 8013
+          name: rpc
+        - containerPort: 8016
+          name: ofrep
+        env:
+        - name: GOMEMLIMIT
+          value: 60MiB
+        resources:
+          limits:
+            memory: 75Mi
+        volumeMounts:
+        - name: config-rw
+          mountPath: /etc/flagd
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === flagd-config ===
+# Kubernetes manifest for flagd-config
+# NOTE: The ConfigMap is generated at stitch time from src/flagd/demo.flagd.json
+# This file only contains the PVC definition
+---
+# PersistentVolumeClaim for shared flagd configuration
+# This PVC is shared between flagd and flagd-ui to enable dynamic flag updates
+# Using ReadWriteOnce with podAffinity to ensure both pods on same node
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flagd-shared-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/component: flagd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flagd-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  demo.flagd.json: |
+    {
+      "$schema": "https://flagd.dev/schema/v0/flags.json",
+      "flags": {
+        "llmInaccurateResponse": {
+          "defaultVariant": "off",
+          "description": "LLM returns an inaccurate product summary for product ID L9ECAV7KIM",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "llmRateLimitError": {
+          "defaultVariant": "off",
+          "description": "LLM intermittently returns a rate limit error",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "productCatalogFailure": {
+          "description": "Fail product catalog service on a specific product",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCacheFailure": {
+          "description": "Fail recommendation service cache",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adManualGc": {
+          "description": "Triggers full manual garbage collections in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adHighCpu": {
+          "description": "Triggers high cpu load in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adFailure": {
+          "description": "Fail ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "kafkaQueueProblems": {
+          "description": "Overloads Kafka queue while simultaneously introducing a consumer side delay leading to a lag spike",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "cartFailure": {
+          "description": "Fail cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentFailure": {
+          "description": "Fail payment service charge requests n%",
+          "state": "ENABLED",
+          "variants": {
+            "100%": 1,
+            "90%": 0.95,
+            "75%": 0.75,
+            "50%": 0.5,
+            "25%": 0.25,
+            "10%": 0.1,
+            "off": 0
+          },
+          "defaultVariant": "50%"
+        },
+        "rumBlueGreen": {
+          "description": "Enable RUM-based payment path (A/B) tracking in user.deployment_type attribute",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentUnreachable": {
+          "description": "Payment service is unavailable",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "loadGeneratorFloodHomepage": {
+          "description": "Flood the frontend with a large amount of requests.",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "imageSlowLoad": {
+          "description": "slow loading images in the frontend",
+          "state": "ENABLED",
+          "variants": {
+            "10sec": 10000,
+            "5sec": 5000,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "failedReadinessProbe": {
+          "description": "readiness probe failure for cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+    
+        },
+        "emailMemoryLeak": {
+          "description": "Memory leak in the email service.",
+          "state": "ENABLED",
+          "variants": {
+            "off": 0,
+            "1x": 1,
+            "10x": 10,
+            "100x": 100,
+            "1000x": 1000,
+            "10000x": 10000
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCartesianQuery": {
+          "description": "DBMon Demo: Triggers a Cartesian join query (500M rows) in recommendation service PostgreSQL calls. Query returns correct results but processes 500M intermediate rows, taking 12+ seconds.",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "secureappAttack": {
+          "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",
+          "state": "ENABLED",
+          "variants": {
+            "minimal": "minimal",
+            "targeted": "targeted",
+            "max": "max"
+          },
+          "defaultVariant": "minimal"
+        }
+      }
+    }
+
+---
+
+# === flagd-ui ===
+# Kubernetes manifest for flagd-ui
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4000
+    name: tcp-service
+    targetPort: 4000
+  selector:
+    opentelemetry.io/name: flagd-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd-ui
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd-ui
+        app.kubernetes.io/component: flagd-ui
+        app.kubernetes.io/name: flagd-ui
+    spec:
+      serviceAccountName: opentelemetry-demo
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: opentelemetry.io/name
+                operator: In
+                values:
+                - flagd
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: flagd-ui
+        image: ghcr.io/open-telemetry/demo:2.2.0-flagd-ui
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 4000
+          name: service
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: SECRET_KEY_BASE
+          value: yYrECL4qbNwleYInGJYvVnSkwJuSQJ4ijPTx5tirGUXrbznFIBFVJdPl5t6O9ASw
+        - name: PHX_HOST
+          value: localhost
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        resources:
+          limits:
+            memory: 250Mi
+        volumeMounts:
+        - mountPath: /app/data
+          name: config-rw
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === fraud-detection ===
+# Kubernetes manifest for fraud-detection
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fraud-detection
+  labels:
+    opentelemetry.io/name: fraud-detection
+    app.kubernetes.io/component: fraud-detection
+    app.kubernetes.io/name: fraud-detection
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: fraud-detection
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: fraud-detection
+        app.kubernetes.io/component: fraud-detection
+        app.kubernetes.io/name: fraud-detection
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: fraud-detection
+        image: ghcr.io/splunk/opentelemetry-demo/otel-fraud-detection:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_INSTRUMENTATION_KAFKA_CLIENTS_ENABLED
+          value: 'false'
+        - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+          value: 'true'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=propagation
+        - name: SQL_SERVER_HOST
+          value: sql-server-fraud.default.svc.cluster.local
+        - name: SQL_SERVER_PORT
+          value: '1433'
+        - name: SQL_SERVER_DATABASE
+          value: FraudDetection
+        - name: SQL_SERVER_USER
+          value: sa
+        - name: SQL_SERVER_PASSWORD
+          value: ChangeMe_SuperStrong123!
+        - name: FRAUD_DETECTION_RATE
+          value: '80'
+        - name: CLEANUP_RETENTION_DAYS
+          value: '4'
+        - name: CLEANUP_INTERVAL_HOURS
+          value: '6'
+        - name: FRAUD_MUTATION_PERCENTAGE
+          value: '25'
+        - name: BAD_QUERY_PERCENTAGE
+          value: '0'
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 512Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 sql-server-fraud.default.svc.cluster.local 1433; do echo
+          waiting for sql-server-fraud; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-sqlserver
+      volumes: null
+
+---
+
+# === frontend ===
+# Kubernetes manifest for frontend
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: frontend
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: PORT
+          value: $(FRONTEND_PORT)
+        - name: FRONTEND_ADDR
+          value: :8080
+        - name: AD_ADDR
+          value: ad:8080
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CHECKOUT_ADDR
+          value: checkout:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: PRODUCT_REVIEWS_ADDR
+          value: product-reviews:3551
+        - name: RECOMMENDATION_ADDR
+          value: recommendation:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: ENV_PLATFORM
+          value: kubernetes
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+        - name: OTEL_LOG_LEVEL
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: api_token
+              optional: true
+        - name: SPLUNK_RUM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: rum_token
+        - name: SPLUNK_APP_NAME
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: app
+        - name: SPLUNK_RUM_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: SPLUNK_RUM_REALM
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: realm
+        resources:
+          limits:
+            memory: 250Mi
+        securityContext:
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === frontend-proxy ===
+# Kubernetes manifest for frontend-proxy
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend-proxy
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend-proxy
+        app.kubernetes.io/component: frontend-proxy
+        app.kubernetes.io/name: frontend-proxy
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend-proxy
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend-proxy:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: ENVOY_ADDR
+          value: 0.0.0.0
+        - name: ENVOY_PORT
+          value: '8080'
+        - name: ENVOY_ADMIN_PORT
+          value: '10000'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8016'
+        - name: FLAGD_UI_HOST
+          value: flagd-ui
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: FRONTEND_HOST
+          value: frontend
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: IMAGE_PROVIDER_HOST
+          value: image-provider
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: LOCUST_WEB_HOST
+          value: load-generator
+        - name: LOCUST_WEB_PORT
+          value: '8089'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_PORT_HTTP
+          value: '4318'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: SECUREAPP_HOST
+          value: secureapp-loadgen
+        - name: SECUREAPP_PORT
+          value: '8080'
+        - name: FEATURE_AUTH_ENABLED
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_auth
+              optional: true
+        - name: FEATURE_USER
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_user
+              optional: true
+        - name: FEATURE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_pw
+              optional: true
+        resources:
+          limits:
+            memory: 65Mi
+        securityContext:
+          runAsGroup: 101
+          runAsNonRoot: true
+          runAsUser: 101
+        volumeMounts: null
+      volumes: null
+---
+
+
+---
+
+# === image-provider ===
+# Kubernetes manifest for image-provider
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8081
+    name: tcp-service
+    targetPort: 8081
+  selector:
+    opentelemetry.io/name: image-provider
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: image-provider
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: image-provider
+        app.kubernetes.io/component: image-provider
+        app.kubernetes.io/name: image-provider
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: image-provider
+        image: ghcr.io/splunk/opentelemetry-demo/otel-image-provider:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 50Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === kafka ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for kafka
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9092
+    name: plaintext
+    targetPort: 9092
+  - port: 9093
+    name: controller
+    targetPort: 9093
+  selector:
+    opentelemetry.io/name: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: kafka
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: kafka
+        app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: kafka
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: kafka
+        image: ghcr.io/open-telemetry/demo:2.2.0-kafka
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+          name: plaintext
+        - containerPort: 9093
+          name: controller
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka:9092
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx400M -Xms400M
+        - name: KAFKA_LISTENERS
+          value: PLAINTEXT://:9092,CONTROLLER://:9093
+        - name: KAFKA_CONTROLLER_LISTENER_NAMES
+          value: CONTROLLER
+        - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+          value: 1@kafka:9093
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 800Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === llm ===
+# Kubernetes manifest for llm
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    name: tcp-service
+    targetPort: 8000
+  selector:
+    opentelemetry.io/name: llm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: llm
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: llm
+        app.kubernetes.io/component: llm
+        app.kubernetes.io/name: llm
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: llm
+        image: ghcr.io/splunk/opentelemetry-demo/otel-llm:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === demo-service-account ===
+# Kubernetes manifest for demo-service-account
+# ServiceAccount used by all Astronomy Shop application pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-demo
+  labels:
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+
+---
+
+# === payment-vA ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version A - Stable/Conservative Version
+# This manifest deploys payment service v1.7.0-a with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-payment-secret
+type: Opaque
+stringData:
+  api-token: "prod-a8cf28f9-1a1a-4994-bafa-cd4b143c3291"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-va
+    app.kubernetes.io/version: "1.7.0-a"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vA
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vA
+        opentelemetry.io/name: payment-va
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-va
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version A
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vA"]
+
+        # Anti-affinity - never on same node as version B
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vB
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.9"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-a"
+
+        # Token from dedicated secret for version A
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: prod-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=otel-fields-fix,payment.variant=A"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging
+        - name: OTEL_LOG_LEVEL
+          value: info
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vA
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === payment-vB ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version B - Optimized/Next-gen Version
+# This manifest deploys payment service v1.7.0-b with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-payment-secret
+type: Opaque
+stringData:
+  api-token: "test-20e26e90-356b-432e-a2c6-956fc03f5609"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-vb
+    app.kubernetes.io/version: "1.7.0-b"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vB
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vB
+        opentelemetry.io/name: payment-vb
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-vb
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version B
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vB"]
+
+        # Anti-affinity - never on same node as version A
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vA
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.10"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-b"
+
+        # Token from dedicated secret for version B
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: test-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=otel-fields-fix,payment.variant=B"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging (more verbose for version B)
+        - name: OTEL_LOG_LEVEL
+          value: debug
+        - name: LOG_LEVEL
+          value: debug
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vB
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === postgresql-setup ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# PostgreSQL Database Initialization ConfigMap
+# This ConfigMap contains scripts that create schemas, tables, and extensions
+# for the accounting, product-catalog, product-reviews, and recommendation services
+#
+# The postgres deployment mounts these as /docker-entrypoint-initdb.d/
+# which PostgreSQL automatically executes on first startup (alphabetical order)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-sql
+  labels:
+    app.kubernetes.io/name: postgres-init
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # Shell script runs first (alphabetically) to create extension in postgres database
+  00-pg-stat-statements.sh: |
+    #!/bin/bash
+    # Create pg_stat_statements extension in the postgres database
+    # This is required for PostgreSQL receiver top query monitoring
+    set -e
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<-EOSQL
+        CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    EOSQL
+    echo "pg_stat_statements extension created in postgres database"
+  init.sql: |
+    -- Copyright The OpenTelemetry Authors
+    -- SPDX-License-Identifier: Apache-2.0
+
+    -- Enable pg_stat_statements for database monitoring (top query tracking)
+    -- Note: This runs in the 'otel' database. The extension is also created
+    -- in the 'postgres' database by 00-pg-stat-statements.sh for top query monitoring.
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+    CREATE USER otelu WITH PASSWORD 'otelp';
+
+    -- Accounting Service: create a schema
+    CREATE SCHEMA accounting;
+    GRANT USAGE ON SCHEMA accounting TO otelu;
+
+    -- Accounting Service: create tables
+    CREATE TABLE accounting."order" (
+        order_id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE accounting.shipping (
+        shipping_tracking_id TEXT PRIMARY KEY,
+        shipping_cost_currency_code TEXT NOT NULL,
+        shipping_cost_units BIGINT NOT NULL,
+        shipping_cost_nanos INT NOT NULL,
+        street_address TEXT,
+        city TEXT,
+        state TEXT,
+        country TEXT,
+        zip_code TEXT,
+        order_id TEXT NOT NULL,
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE accounting.orderitem (
+        item_cost_currency_code TEXT NOT NULL,
+        item_cost_units BIGINT NOT NULL,
+        item_cost_nanos INT NOT NULL,
+        product_id TEXT NOT NULL,
+        quantity INT NOT NULL,
+        order_id TEXT NOT NULL,
+        PRIMARY KEY (order_id, product_id),
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    -- Accounting Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA accounting TO otelu;
+
+    -- Product Catalog Service: create a schema
+    CREATE SCHEMA catalog;
+    GRANT USAGE ON SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: create tables
+    CREATE TABLE catalog.products (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        picture TEXT,
+        price_currency_code TEXT NOT NULL,
+        price_units BIGINT NOT NULL,
+        price_nanos INT NOT NULL,
+        categories TEXT
+    );
+
+    -- Product Catalog Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: add product data
+    INSERT INTO catalog.products (id, name, description, picture, price_currency_code, price_units, price_nanos, categories)
+    VALUES
+        ('OLJCESPC7Z', 'National Park Foundation Explorascope', 'The National Park Foundation''s (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.', 'NationalParkFoundationExplorascope.jpg', 'USD', 101, 960000000, 'telescopes'),
+        ('66VCHSJNUP', 'Starsense Explorer Refractor Telescope', 'The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app''s user-friendly interface and detailed tutorials. It''s like having your own personal tour guide of the night sky', 'StarsenseExplorer.jpg', 'USD', 349, 950000000, 'telescopes'),
+        ('1YMWWN1N4O', 'Eclipsmart Travel Refractor Telescope', 'Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.', 'EclipsmartTravelRefractorTelescope.jpg', 'USD', 129, 950000000, 'telescopes,travel'),
+        ('L9ECAV7KIM', 'Lens Cleaning Kit', 'Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.', 'LensCleaningKit.jpg', 'USD', 21, 950000000, 'accessories'),
+        ('2ZYFJ3GM2N', 'Roof Binoculars', 'This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It''s an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.', 'RoofBinoculars.jpg', 'USD', 209, 950000000, 'binoculars'),
+        ('0PUK6V6EV0', 'Solar System Color Imager', 'You have your new telescope and have observed Saturn and Jupiter. Now you''re ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.', 'SolarSystemColorImager.jpg', 'USD', 175, 0, 'accessories,telescopes'),
+        ('LS4PSXUNUM', 'Red Flashlight', 'This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red''s rugged, IPX4-rated design will withstand your everyday activities.', 'RedFlashlight.jpg', 'USD', 57, 80000000, 'accessories,flashlights'),
+        ('9SIQT8TOJO', 'Optical Tube Assembly', 'Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today''s top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won''t need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.', 'OpticalTubeAssembly.jpg', 'USD', 3599, 0, 'accessories,telescopes,assembly'),
+        ('6E92ZMYYFZ', 'Solar Filter', 'Enhance your viewing experience with EclipSmart Solar Filter for 8" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.', 'SolarFilter.jpg', 'USD', 69, 950000000, 'accessories,telescopes'),
+        ('HQTGWGPNH4', 'The Comet Book', 'A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as "Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)', 'TheCometBook.jpg', 'USD', 0, 990000000, 'books');
+
+    -- Product Review Service: create a schema
+    CREATE SCHEMA reviews;
+    GRANT USAGE ON SCHEMA reviews TO otelu;
+
+    -- Product Review Service: create tables
+    CREATE TABLE reviews.productreviews (
+        id INTEGER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+        product_id VARCHAR(16) NOT NULL,
+        username VARCHAR(64) NOT NULL,
+        description VARCHAR(1024),
+        score NUMERIC(2,1) NOT NULL
+    );
+
+    -- Product Review Service: create index for product_id lookups
+    CREATE INDEX product_id_index ON reviews.productreviews (product_id);
+
+    -- Product Review Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA reviews TO otelu;
+
+    -- Product Review Service:  add product review data
+    INSERT INTO reviews.productreviews (product_id, username, description, score)
+    VALUES
+        ('OLJCESPC7Z', 'stargazer_mike', 'Great entry-level telescope! Easy to set up and provides clear views of the moon and brighter planets. Highly recommend for new astronomers.', '4.5'),
+        ('OLJCESPC7Z', 'nightskylover', 'For the price, this Explorascope delivers excellent performance. I was able to see Jupiter''s moons clearly. A fantastic purchase for casual viewing.', '4.0'),
+        ('OLJCESPC7Z', 'beginner_astro', 'A bit tricky to get used to the manual controls, but once you do, it''s very rewarding. Saw the Orion Nebula for the first time! Good value.', '3.5'),
+        ('OLJCESPC7Z', 'celestial_explorer', 'Perfect for camping trips. It''s lightweight and portable, making it easy to take anywhere. The views are surprisingly good for its size.', '4.0'),
+        ('OLJCESPC7Z', 'telescope_fan', 'Not the most powerful scope, but it''s great for kids and beginners. My children love looking at the moon with it. A solid choice for family fun.', '3.0'),
+
+        ('66VCHSJNUP', 'tech_astro', 'The StarSense app is revolutionary! It made finding celestial objects incredibly easy. This telescope is a game-changer for beginners.', '5.0'),
+        ('66VCHSJNUP', 'app_user', 'Amazing technology, the smartphone integration works flawlessly. I''ve never had so much fun exploring the night sky. Worth every penny.', '4.5'),
+        ('66VCHSJNUP', 'innovator_john', 'Setup was a breeze, and the tutorials in the app are very helpful. The views are crisp and clear. My only minor gripe is battery drain on the phone.', '4.0'),
+        ('66VCHSJNUP', 'clear_skies', 'Finally, a telescope that takes the guesswork out of stargazing. The real-time positioning is incredibly accurate. Highly recommended for anyone new to astronomy.', '5.0'),
+        ('66VCHSJNUP', 'gadget_geek', 'Fantastic product, the app truly guides you. It''s like having a personal astronomer with you. The optical quality is also very good.', '4.5'),
+
+        ('1YMWWN1N4O', 'solar_viewer', 'Perfect for solar observations! The Solar Safe filter gives peace of mind. I used it for the last partial eclipse and it was fantastic.', '5.0'),
+        ('1YMWWN1N4O', 'eclipse_chaser', 'Compact and easy to carry, this telescope is ideal for eclipse events. The included backpack is a nice touch. Views of the sun are incredibly clear and safe.', '4.5'),
+        ('1YMWWN1N4O', 'travel_astro', 'Excellent travel scope for solar viewing. The magnification is much better than binoculars for the sun. A must-have for any solar enthusiast.', '4.0'),
+        ('1YMWWN1N4O', 'sun_gazer', 'Very impressed with the safety features and clarity. Sharing the sun with family has never been easier or safer. Great value for a dedicated solar scope.', '5.0'),
+        ('1YMWWN1N4O', 'safe_viewer', 'The ISO compliant filter is reassuring. It''s a well-designed product for safe solar observation. Highly recommend for educational purposes too.', '4.5'),
+
+        ('L9ECAV7KIM', 'clean_optics', 'This kit is a lifesaver for all my optics. The brush and wipes work perfectly without leaving any residue. My lenses have never been cleaner.', '5.0'),
+        ('L9ECAV7KIM', 'photog_pro', 'Essential for any photographer or telescope owner. It safely removes dust and fingerprints. A high-quality cleaning solution.', '4.5'),
+        ('L9ECAV7KIM', 'daily_cleaner', 'I use this on my binoculars, camera lenses, and even my phone screen. It''s very effective and gentle. A versatile cleaning kit.', '4.0'),
+        ('L9ECAV7KIM', 'tech_maintenance', 'Great value for money. The different cleaning options cover all needs. Keeps my expensive equipment in pristine condition.', '5.0'),
+        ('L9ECAV7KIM', 'sharp_view', 'Works as advertised, my telescope views are much clearer after using this. The fluid and cloth are excellent. Definitely recommend.', '4.5'),
+
+        ('2ZYFJ3GM2N', 'bird_watcher', 'Incredible clarity and brightness, perfect for bird watching. The ED glass really makes a difference. I can spot the subtlest markings.', '5.0'),
+        ('2ZYFJ3GM2N', 'nature_lover', 'These binoculars are fantastic for nature observation. The close focus is a huge advantage for viewing nearby wildlife. Very comfortable to hold.', '4.5'),
+        ('2ZYFJ3GM2N', 'hiker_guy', 'Lightweight and durable, these are my go-to binoculars for hiking. The wide field of view is excellent. Highly recommend for outdoor enthusiasts.', '4.0'),
+        ('2ZYFJ3GM2N', 'stadium_fan', 'Took these to a game and had an amazing view of the action. They perform great in various lighting conditions. A solid all-around binocular.', '4.0'),
+        ('2ZYFJ3GM2N', 'outdoor_adventurer', 'Excellent build quality and optical performance. They feel robust and provide sharp images. A great investment for any outdoor activity.', '4.5'),
+
+        ('0PUK6V6EV0', 'astro_photog', 'This imager is a fantastic step up for planetary photography. The color quality is superb. Easy to use with my existing telescope setup.', '5.0'),
+        ('0PUK6V6EV0', 'planet_shooter', 'Finally capturing stunning images of Saturn and Jupiter! The NexImage 10 makes it so accessible. Great for beginners in astrophotography.', '4.5'),
+        ('0PUK6V6EV0', 'imager_pro', 'Excellent resolution and color rendition for its price point. It''s a perfect solution for those looking to start imaging planets. Highly satisfied.', '4.0'),
+        ('0PUK6V6EV0', 'space_artist', 'The detail I can capture with this imager is incredible. It integrates well with various software. A must-have for serious planetary observers.', '5.0'),
+        ('0PUK6V6EV0', 'digital_sky', 'A solid choice for getting into solar system imaging. The setup was straightforward. Produces beautiful, vibrant planetary images.', '4.5'),
+
+        ('LS4PSXUNUM', 'night_walker', 'The red light is perfect for preserving night vision during astronomy sessions. The hand warmer is an unexpected bonus. Very practical device.', '5.0'),
+        ('LS4PSXUNUM', 'star_party_goer', 'This flashlight is indispensable for star parties. The red mode is gentle on the eyes, and the power bank feature is super handy. Love it!', '4.5'),
+        ('LS4PSXUNUM', 'camper_chris', 'Rugged and versatile, this flashlight is great for camping and night walks. The hand warmer function is a game-changer on cold nights. Highly recommend.', '4.5'),
+        ('LS4PSXUNUM', 'emergency_kit', 'A fantastic multi-tool for my emergency kit. The red light is useful, and the power bank means I can charge my phone. Great design.', '4.0'),
+        ('LS4PSXUNUM', 'astro_accessory', 'Every astronomer needs one of these. The red light is essential, and the hand warmer and power bank make it incredibly useful. A top-tier accessory.', '5.0'),
+
+        ('9SIQT8TOJO', 'deep_sky_master', 'The RASA V2 is a dream come true for deep-sky imaging. The f/2.2 speed drastically cuts down exposure times. My best astrophotography investment yet.', '5.0'),
+        ('9SIQT8TOJO', 'pro_astro', 'Unbelievable performance for wide-field astrophotography. The short focal length makes guiding less critical. Produces stunning, detailed images.', '5.0'),
+        ('9SIQT8TOJO', 'imaging_guru', 'This OTA is a beast! The fast optics mean more data in less time. If you''re serious about deep-sky imaging, this is the one.', '4.5'),
+        ('9SIQT8TOJO', 'advanced_scope', 'Worth every penny for the quality and speed it offers. My images have never been sharper or more vibrant. A truly professional piece of equipment.', '5.0'),
+        ('9SIQT8TOJO', 'precision_optics', 'The engineering behind this RASA is exceptional. It''s incredibly efficient for capturing faint objects. A high-end choice for dedicated imagers.', '4.5'),
+
+        ('6E92ZMYYFZ', 'solar_safety', 'Essential for safe solar viewing with my 8-inch telescope. The Velcro straps ensure it stays securely in place. Peace of mind during solar observations.', '5.0'),
+        ('6E92ZMYYFZ', 'telescope_upgrade', 'This EclipSmart filter is a perfect addition to my setup. The ISO compliance is crucial. Highly recommend for anyone looking to view the sun safely.', '4.5'),
+        ('6E92ZMYYFZ', 'safe_sun_gazer', 'Easy to attach and provides crystal clear, safe views of the sun. The build quality is excellent. A must-have accessory for solar enthusiasts.', '5.0'),
+        ('6E92ZMYYFZ', 'filter_fan', 'Works perfectly with my 8-inch scope. No more worries about accidental dislodgement. Great product for protecting your eyes and equipment.', '4.5'),
+        ('6E92ZMYYFZ', 'eclipse_ready', 'Bought this for the upcoming eclipse, and it fits perfectly. Tested it out, and the views are fantastic and safe. Very happy with this purchase.', '5.0'),
+
+        ('HQTGWGPNH4', 'history_buff', 'A fascinating glimpse into historical astronomical thought. The content is incredibly insightful. A must-read for anyone interested in the history of science.', '5.0'),
+        ('HQTGWGPNH4', 'bookworm_astro', 'Beautifully presented historical document. It''s amazing to see how comets were understood centuries ago. A valuable addition to any astronomy library.', '4.5'),
+        ('HQTGWGPNH4', 'ancient_texts', 'Such a unique and intriguing read. The historical context is captivating. It offers a different perspective on celestial events.', '4.0'),
+        ('HQTGWGPNH4', 'celestial_history', 'I love historical astronomy, and this book delivers. It''s well-researched and provides a window into past beliefs. Highly recommended for scholars.', '5.0'),
+        ('HQTGWGPNH4', 'rare_find', 'A truly special book for enthusiasts of astronomical history. The details about ancient astrologers are very interesting. Great for a deeper understanding.', '4.5');
+
+    -- ============================================================
+    -- Recommendation Service: DBMon Cartesian Join Demo
+    -- ============================================================
+
+    -- Recommendation Service: create tables (public schema)
+    CREATE TABLE IF NOT EXISTS products (
+        id           SERIAL PRIMARY KEY,
+        product_id   VARCHAR(64) UNIQUE NOT NULL,
+        name         VARCHAR(255),
+        category     VARCHAR(64),
+        price        DECIMAL(10,2),
+        created_at   TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS product_tags (
+        id              SERIAL PRIMARY KEY,
+        product_id      VARCHAR(64) NOT NULL,
+        tag             VARCHAR(64),
+        relevance_score DECIMAL(4,3)
+    );
+
+    -- Recommendation Service: seed 5,000 products
+    INSERT INTO products (product_id, name, category, price)
+    SELECT 'prod_' || gs, 'Product ' || gs,
+           (ARRAY['telescope','eyepiece','mount','camera','filter'])[floor(random()*5+1)],
+           (random() * 2000 + 50)::DECIMAL
+    FROM generate_series(1, 5000) gs
+    ON CONFLICT (product_id) DO NOTHING;
+
+    -- Recommendation Service: seed 100,000 tags (~20 per product)
+    INSERT INTO product_tags (product_id, tag, relevance_score)
+    SELECT 'prod_' || gs,
+           (ARRAY['beginner','advanced','astrophotography','visual','planetary',
+                  'deepsky','portable','goto','wifi','budget'])[floor(random()*10+1)],
+           (random())::DECIMAL
+    FROM generate_series(1, 5000) gs, generate_series(1, 20);
+
+    -- DO NOT create indexes or run ANALYZE - we want worst-case execution plan
+
+    -- Recommendation Service: create application user with settings that force Nested Loop Cartesian
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'demo_app_user') THEN
+            CREATE ROLE demo_app_user WITH LOGIN PASSWORD 'demo_password';
+        END IF;
+    END
+    $$;
+
+    GRANT SELECT ON products TO demo_app_user;
+    GRANT SELECT ON product_tags TO demo_app_user;
+
+    -- Force worst-case execution plan for demo_app_user
+    ALTER ROLE demo_app_user SET work_mem = '64kB';
+    ALTER ROLE demo_app_user SET enable_hashjoin  = OFF;
+    ALTER ROLE demo_app_user SET enable_mergejoin = OFF;
+
+---
+
+# === postgresql ===
+# Kubernetes manifest for postgres (PostgreSQL database)
+# Extracted from opentelemetry-demo.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    name: tcp-service
+    targetPort: 5432
+  selector:
+    opentelemetry.io/name: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: postgresql
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: postgresql
+        splunk.com/postgresql.database: otel
+      labels:
+        opentelemetry.io/name: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/name: postgresql
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: postgresql
+        image: postgres:17.8
+        imagePullPolicy: IfNotPresent
+        args:
+          - "-c"
+          - "shared_preload_libraries=pg_stat_statements"
+          - "-c"
+          - "pg_stat_statements.track=all"
+        ports:
+        - containerPort: 5432
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: POSTGRES_USER
+          value: root
+        - name: POSTGRES_PASSWORD
+          value: otel
+        - name: POSTGRES_DB
+          value: otel
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 256Mi
+        volumeMounts:
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/00-pg-stat-statements.sh
+          subPath: 00-pg-stat-statements.sh
+          readOnly: true
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/init.sql
+          subPath: init.sql
+          readOnly: true
+      volumes:
+      - name: postgres-init
+        configMap:
+          name: postgres-init-sql
+          defaultMode: 0755
+
+---
+
+# === product-catalog ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for product-catalog
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s): Service, Deployment, and ConfigMap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: product-catalog
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-catalog
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-catalog
+        app.kubernetes.io/component: product-catalog
+        app.kubernetes.io/name: product-catalog
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-catalog
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-catalog:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_CATALOG_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_RELOAD_INTERVAL
+          value: '10'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: "host=postgresql user=otelu password=otelp dbname=otel sslmode=disable"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 200MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            memory: 200Mi
+        volumeMounts:
+        - name: product-catalog-products
+          mountPath: /usr/src/app/products
+      volumes:
+      - name: product-catalog-products
+        configMap:
+          name: product-catalog-products
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-products
+  labels:
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # yamllint disable rule:line-length
+  products.json: |
+    {
+      "products": [
+        {
+          "id": "OLJCESPC7Z",
+          "name": "National Park Foundation Explorascope",
+          "description": "The National Park Foundation's (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.",
+          "picture": "NationalParkFoundationExplorascope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 101,
+            "nanos": 960000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "66VCHSJNUP",
+          "name": "Starsense Explorer Refractor Telescope",
+          "description": "The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app's user-friendly interface and detailed tutorials. It's like having your own personal tour guide of the night sky",
+          "picture": "StarsenseExplorer.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 349,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "1YMWWN1N4O",
+          "name": "Eclipsmart Travel Refractor Telescope",
+          "description": "Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.",
+          "picture": "EclipsmartTravelRefractorTelescope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 129,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes",
+            "travel"
+          ]
+        },
+        {
+          "id": "L9ECAV7KIM",
+          "name": "Lens Cleaning Kit",
+          "description": "Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.",
+          "picture": "LensCleaningKit.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 21,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories"
+          ]
+        },
+        {
+          "id": "2ZYFJ3GM2N",
+          "name": "Roof Binoculars",
+          "description": "This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It's an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.",
+          "picture": "RoofBinoculars.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 209,
+            "nanos": 950000000
+          },
+          "categories": [
+            "binoculars"
+          ]
+        },
+        {
+          "id": "0PUK6V6EV0",
+          "name": "Solar System Color Imager",
+          "description": "You have your new telescope and have observed Saturn and Jupiter. Now you're ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.",
+          "picture": "SolarSystemColorImager.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 175,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "LS4PSXUNUM",
+          "name": "Red Flashlight",
+          "description": "This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red's rugged, IPX4-rated design will withstand your everyday activities.",
+          "picture": "RedFlashlight.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 57,
+            "nanos": 80000000
+          },
+          "categories": [
+            "accessories",
+            "flashlights"
+          ]
+        },
+        {
+          "id": "9SIQT8TOJO",
+          "name": "Optical Tube Assembly",
+          "description": "Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today's top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won't need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.",
+          "picture": "OpticalTubeAssembly.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 3599,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes",
+            "assembly"
+          ]
+        },
+        {
+          "id": "6E92ZMYYFZ",
+          "name": "Solar Filter",
+          "description": "Enhance your viewing experience with EclipSmart Solar Filter for 8\" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.",
+          "picture": "SolarFilter.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 69,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "HQTGWGPNH4",
+          "name": "The Comet Book",
+          "description": "A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as \"Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers\". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)",
+          "picture": "TheCometBook.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 0,
+            "nanos": 990000000
+          },
+          "categories": [
+            "books"
+          ]
+        }
+      ]
+    }
+
+---
+
+# === product-reviews ===
+# Kubernetes manifest for product-reviews
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3551
+    name: tcp-service
+    targetPort: 3551
+  selector:
+    opentelemetry.io/name: product-reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-reviews
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-reviews
+        app.kubernetes.io/component: product-reviews
+        app.kubernetes.io/name: product-reviews
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-reviews
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-reviews:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3551
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_REVIEWS_PORT
+          value: '3551'
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
+          value: 'span_only'
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: 'gen_ai_latest_experimental'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: host=postgresql user=otelu password=otelp dbname=otel
+        - name: LLM_HOST
+          value: llm
+        - name: LLM_PORT
+          value: '8000'
+        - name: LLM_BASE_URL
+          value: http://llm:8000/v1
+        - name: LLM_MODEL
+          value: astronomy-llm
+        - name: OPENAI_API_KEY
+          value: dummy
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === quote ===
+# Kubernetes manifest for quote
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: quote
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: quote
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: quote
+        app.kubernetes.io/component: quote
+        app.kubernetes.io/name: quote
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: quote
+        image: ghcr.io/open-telemetry/demo:2.2.0-quote
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: QUOTE_PORT
+          value: '8080'
+        - name: OTEL_PHP_AUTOLOAD_ENABLED
+          value: 'true'
+        - name: OTEL_PHP_INTERNAL_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 40Mi
+        securityContext:
+          runAsGroup: 33
+          runAsNonRoot: true
+          runAsUser: 33
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === recommendation ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for recommendation
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: recommendation
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: recommendation
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: recommendation
+        app.kubernetes.io/component: recommendation
+        app.kubernetes.io/name: recommendation
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: recommendation
+        image: ghcr.io/splunk/opentelemetry-demo/otel-recommendation:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: RECOMMENDATION_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '750'
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        # PostgreSQL connection for DBMon Cartesian demo
+        - name: POSTGRES_HOST
+          value: "postgresql"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          value: "otel"
+        - name: POSTGRES_USER
+          value: "demo_app_user"
+        - name: POSTGRES_PASSWORD
+          value: "demo_password"
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === shipping ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for shipping
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: shipping
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shipping
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shipping
+        app.kubernetes.io/component: shipping
+        app.kubernetes.io/name: shipping
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: shipping
+        image: ghcr.io/open-telemetry/demo:2.2.0-shipping
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SHIPPING_PORT
+          value: '8080'
+        - name: QUOTE_ADDR
+          value: http://quote:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === sql-server-fraud-setup ===
+# Kubernetes manifest for SQL Server setup
+# Includes secrets and initialization script for MSSQL
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secrets
+type: Opaque
+stringData:
+  SA_PASSWORD: ChangeMe_SuperStrong123!
+  DB_CONNECTION_STRING: Server=tcp:sql-server-fraud.astronomy-shop.svc.cluster.local,1433;Database=FraudDetection;User
+    Id=sa;Password=ChangeMe_SuperStrong123!;Encrypt=True;TrustServerCertificate=True
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mssql-init-script
+data:
+  init-db.sql: |
+    IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'FraudDetection')
+    BEGIN
+      CREATE DATABASE FraudDetection;
+    END
+    GO
+
+---
+
+# === sql-server-fraud ===
+# Kubernetes manifest for sql-server-fraud
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sql-server-fraud
+spec:
+  type: ClusterIP
+  ports:
+  - port: 1433
+    targetPort: 1433
+    protocol: TCP
+    name: tds
+  selector:
+    app: sql-server-fraud
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sql-server-fraud
+spec:
+  serviceName: sql-server-fraud
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  selector:
+    matchLabels:
+      app: sql-server-fraud
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: sqlserver
+        splunk.com/sqlserver.database: fraud
+      labels:
+        app: sql-server-fraud
+    spec:
+      containers:
+      - name: mssql
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 1433
+          name: tds
+        env:
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: MSSQL_PID
+          value: Express
+        - name: SA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mssql-secrets
+              key: SA_PASSWORD
+        volumeMounts:
+        - name: data
+          mountPath: /var/opt/mssql
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'sleep 30
+
+                /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}"
+                -C -i /docker-entrypoint-initdb.d/init-db.sql
+
+                '
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+        readinessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 30
+          periodSeconds: 20
+      volumes:
+      - name: init-script
+        configMap:
+          name: mssql-init-script
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+
+---
+
+# === valkey-cart ===
+# Kubernetes manifest for valkey-cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    name: valkey-cart
+    targetPort: 6379
+  selector:
+    opentelemetry.io/name: valkey-cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: valkey-cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: valkey-cart
+        app.kubernetes.io/component: valkey-cart
+        app.kubernetes.io/name: valkey-cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: valkey-cart
+        image: valkey/valkey:9.0.2-alpine3.23
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: valkey-cart
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === ingress ===
+# === ingress for DIAB  ===
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+spec:
+  ingressClassName: traefik
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-proxy
+            port:
+              number: 8080
+              
+---
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-lambda.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-lambda.yaml
@@ -1,0 +1,97 @@
+# Splunk Astronomy Shop Kubernetes Manifest - lambda
+# Version: otel-fields-fix
+# Generated on: 2026-06-17T10:44:04Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === planning ===
+# Kubernetes manifest for planning
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planning
+  labels:
+    opentelemetry.io/name: planning
+    app.kubernetes.io/component: planning
+    app.kubernetes.io/name: planning
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: planning
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: planning
+        app.kubernetes.io/component: planning
+        app.kubernetes.io/name: planning
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: planning
+        image: ghcr.io/splunk/opentelemetry-demo/otel-planning:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: KAFKA_TOPIC
+          value: orders
+        - name: KAFKA_GROUP_ID
+          value: planning
+        # Lambda configuration
+        - name: LAMBDA_ENDPOINT
+          value: "https://61d4vss237.execute-api.eu-west-1.amazonaws.com/demo/orders"
+        - name: LAMBDA_CALL_INTERVAL_MINUTES
+          value: "5"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=spanlink,deployment.environment=$(WORKSHOP_ENV)-lambda
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-secureapp.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix-secureapp.yaml
@@ -1,0 +1,123 @@
+# Splunk Astronomy Shop Kubernetes Manifest - secureapp
+# Version: otel-fields-fix
+# Generated on: 2026-06-17T10:44:04Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === secureapp-loadgen ===
+# SecureApp loadgen — Java vulnerability test app.
+# Reports as whatever OTEL_SERVICE_NAME is set to (currently "shipping-api").
+# Exercises 5 vulnerability classes for Splunk SecureApp agent detection.
+# Deployed via separate manifest group (secureapp).
+# See usage.md for configuration details.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: secureapp-loadgen
+  labels:
+    opentelemetry.io/name: secureapp-loadgen
+    app.kubernetes.io/component: secureapp-loadgen
+    app.kubernetes.io/name: secureapp-loadgen
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: secureapp-loadgen
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secureapp-loadgen
+  labels:
+    opentelemetry.io/name: secureapp-loadgen
+    app.kubernetes.io/component: secureapp-loadgen
+    app.kubernetes.io/name: secureapp-loadgen
+    app.kubernetes.io/version: "2.1.3"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: secureapp-loadgen
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: secureapp-loadgen
+        app.kubernetes.io/component: secureapp-loadgen
+        app.kubernetes.io/name: secureapp-loadgen
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: secureapp-loadgen
+        image: ghcr.io/splunk/opentelemetry-demo/otel-secureapp-loadgen:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./entrypoint.sh
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
+        - name: OTEL_SERVICE_NAME
+          value: "shipping-api"
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/app/splunk-otel-javaagent.jar
+            -Dargento.allow.security.events=true
+            -Dargento.wait.events.for.first.transaction=false
+            -Dotel.instrumentation.common.peer-service-mapping=shipping:8080=shipping
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      volumes: null
+
+---

--- a/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix.yaml
+++ b/kubernetes/BETA/splunk-astronomy-shop-otel-fields-fix.yaml
@@ -1,0 +1,3792 @@
+# Splunk Astronomy Shop Kubernetes Manifest
+# Version: otel-fields-fix
+# Generated on: 2026-06-17T10:44:03Z
+#
+# This manifest combines service deployments for the Splunk Astronomy Shop
+# Services are defined in services.yaml
+---
+
+# === accounting ===
+# Kubernetes manifest for accounting
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accounting
+  labels:
+    opentelemetry.io/name: accounting
+    app.kubernetes.io/component: accounting
+    app.kubernetes.io/name: accounting
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: accounting
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: accounting
+        app.kubernetes.io/component: accounting
+        app.kubernetes.io/name: accounting
+    spec:
+      serviceAccountName: opentelemetry-demo
+      # DNS Configuration to prevent stale DNS caching
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          # Reduce DNS TTL to 10 seconds for faster updates
+          - name: ndots
+            value: "2"
+          # Number of DNS queries before giving up
+          - name: timeout
+            value: "2"
+          # Number of retries for DNS queries
+          - name: attempts
+            value: "3"
+      containers:
+      - name: accounting
+        image: ghcr.io/splunk/opentelemetry-demo/otel-accounting:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        # Kafka connection retry configuration
+        - name: KAFKA_RECONNECT_BACKOFF_MS
+          value: "1000"
+        - name: KAFKA_RECONNECT_BACKOFF_MAX_MS
+          value: "10000"
+        - name: KAFKA_CONNECTIONS_MAX_IDLE_MS
+          value: "300000"
+        - name: KAFKA_METADATA_MAX_AGE_MS
+          value: "10000"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: DB_CONNECTION_STRING
+          value: Host=postgresql;Username=otelu;Password=otelp;Database=otel
+        - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
+          value: 'false'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=spanlink
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            memory: 256Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === ad ===
+# Kubernetes manifest for ad
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: ad
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ad
+  labels:
+    opentelemetry.io/name: ad
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: ad
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: ad
+        app.kubernetes.io/component: ad
+        app.kubernetes.io/name: ad
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: ad
+        image: ghcr.io/splunk/opentelemetry-demo/otel-ad:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          export OTEL_RESOURCE_ATTRIBUTES="service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,deployment.environment=${DEPLOYMENT_ENVIRONMENT}"
+          exec ./build/install/opentelemetry-demo-ad/bin/Ad
+        env:
+        - name: DEPLOYMENT_ENVIRONMENT
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: AD_PORT
+          value: '8080'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        - name: SPLUNK_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_TRACES_SAMPLER
+          value: rules
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '100'
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/usr/src/app/splunk-otel-javaagent-csa.jar -Dsplunk.snapshot.profiler.enabled=true
+            -Dsplunk.snapshot.profiler.sampling.interval=1 -Dsplunk.snapshot.selection.probability=0.1
+            -Xmx440m
+        resources:
+          limits:
+            memory: 600Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === astronomy-loadgen ===
+# Kubernetes manifest for astronomy-loadgen
+# Includes scriptfile ConfigMap used by the deployment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scriptfile
+data:
+  local-file: |
+    /* eslint-disable no-console */
+    const { Console } = require('console');
+    const puppeteer = require('puppeteer');
+    const customUserAgent = 'Mozilla/5.0 (X11; Linux x86_64; Splunk RUM_LoadGen) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36';
+
+    // Debug logging flag (set via DEBUG_LOGGING env var)
+    const debugEnabled = process.env.DEBUG_LOGGING === 'true';
+    if (debugEnabled) console.log('DEBUG: Using User Agent:', customUserAgent);
+
+    // Global browser instance for reuse across cycles
+    let globalBrowser = null;
+
+
+    async function launchBrowser() {
+      console.log('🔹 Starting headless browser...');
+      const browser = await puppeteer.launch({
+        headless: true,
+        defaultViewport: null,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--disable-web-security',
+          '--disable-features=VizDisplayCompositor',
+          '--max-old-space-size=256',
+          '--disable-extensions',
+          '--disable-plugins',
+          '--disable-background-networking',
+          '--disable-background-timer-throttling',
+          '--disable-backgrounding-occluded-windows',
+          '--disable-renderer-backgrounding',
+          '--memory-pressure-off',
+          '--aggressive-cache-discard',
+          '--ignore-certificate-errors',
+          '--allow-insecure-localhost',
+          `--user-agent=${customUserAgent}`
+        ]
+      });
+      console.log('✅ Browser started.');
+      return browser;
+    }
+
+    async function ensureBrowser() {
+      if (!globalBrowser || !globalBrowser.isConnected()) {
+        console.log('🔄 Launching new global browser instance...');
+        globalBrowser = await launchBrowser();
+      }
+      return globalBrowser;
+    }
+
+    function buildBaseUrl() {
+      const raw = (process.env.RUM_FRONTEND_IP || '').trim();
+
+      // If it's empty, default to localhost
+      if (!raw) return 'https://localhost/';
+
+      // If it already starts with http:// or https://, keep it exactly as-is
+      if (/^https?:\/\//i.test(raw)) {
+        return raw.replace(/\/+$/, '') + '/';
+      }
+
+      // Otherwise, prepend https://
+      return `https://${raw.replace(/\/+$/, '')}/`;
+    }
+
+    function getProductIds() {
+      const envProductIds = (process.env.PRODUCT_IDS || '').trim();
+      if (envProductIds) {
+        return envProductIds.split(',').map(id => id.trim()).filter(id => id);
+      }
+      // Hardcoded product IDs if env variable is not set or empty
+      return [
+        'OLJCESPC7Z', // National Park Foundation Explorascope
+        '66VCHSJNUP', // Starsense Explorer Refractor Telescope
+        '1YMWWN1N4O', // Eclipsmart Travel Refractor Telescope
+        'L9ECAV7KIM', // Lens Cleaning Kit
+        '2ZYFJ3GM2N', // Roof Binoculars
+        '0PUK6V6EV0', // Solar System Color Imager
+        'LS4PSXUNUM', // Red Flashlight
+        '9SIQT8TOJO', // Optical Tube Assembly
+        '6E92ZMYYFZ', // Solar Filter
+        'HQTGWGPNH4'  // The Comet Book
+      ];
+    }
+
+    function getRandomProducts() {
+      const allProducts = getProductIds();
+      const numProducts = Math.floor(Math.random() * 3) + 1; // Random number between 1 and 3
+      const shuffled = allProducts.sort(() => Math.random() - 0.5);
+      return shuffled.slice(0, numProducts);
+    }
+
+    // Throttle quick prompts — parsed from env, default 5 min
+    const QUICK_PROMPT_INTERVAL_MS = parseInt(process.env.QUICK_PROMPT_INTERVAL_MS || '300000', 10);
+    let lastQuickPromptTime = 0;
+
+    // Shipping API — random interval between 34s and 1m45s
+    const SHIPPING_MIN_MS = parseInt(process.env.SHIPPING_MIN_MS || '34000', 10);
+    const SHIPPING_MAX_MS = parseInt(process.env.SHIPPING_MAX_MS || '105000', 10);
+    let nextShippingTime = 0;
+    const SHIPPING_API_ENABLED = (process.env.SHIPPING_API || '').toLowerCase() === 'true';
+
+    function delay(ms) { return new Promise(res => setTimeout(res, ms)); }
+
+    /** Generate a random shipping tracking number */
+    function randomTrackingNumber() {
+      const num = Math.floor(Math.random() * 99999) + 10000;
+      return `SHIP-${num}`;
+    }
+
+    /** Schedule next shipping call at a random interval */
+    function scheduleNextShipping() {
+      const interval = SHIPPING_MIN_MS + Math.floor(Math.random() * (SHIPPING_MAX_MS - SHIPPING_MIN_MS));
+      nextShippingTime = Date.now() + interval;
+      if (debugEnabled) console.log(`[DEBUG] Next shipping call in ${Math.round(interval/1000)}s`);
+    }
+
+    /** Fetch shipping info via the frontend-proxy /shipping/ route */
+    async function fetchShippingInfo(page) {
+      if (!SHIPPING_API_ENABLED) return;
+      if (Date.now() < nextShippingTime) return;
+      scheduleNextShipping();
+
+      const tracking = randomTrackingNumber();
+      const base = buildBaseUrl();
+      const url = `${base}shipping/?tracking=${tracking}`;
+      console.log(`📦 Fetching shipping info for ${tracking}...`);
+      try {
+        const result = await page.evaluate(async (fetchUrl) => {
+          const resp = await fetch(fetchUrl);
+          return { status: resp.status, body: await resp.text() };
+        }, url);
+        console.log(`📦 Shipping info: HTTP ${result.status}`);
+        if (debugEnabled) console.log(`[DEBUG] Shipping response: ${result.body}`);
+      } catch (e) {
+        console.log(`⚠️ Shipping info fetch failed: ${e.message}`);
+      }
+    }
+
+    /** Wait until innerText of the page contains a substring */
+    async function waitForText(page, text, timeoutMs = 30000, pollMs = 200) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const found = await page.evaluate(t =>
+          document && document.body && document.body.innerText.includes(t),
+          text
+        );
+        if (found) return true;
+        await delay(pollMs);
+      }
+      throw new Error(`Timed out waiting for text: "${text}"`);
+    }
+
+    async function runOnce() {
+      const browser = await ensureBrowser();
+      let page;
+      let ctx;
+      try {
+        // Fresh browser context per cycle so localStorage / cookies / session
+        // ID reset between cycles. Otherwise every cycle reuses the same RUM
+        // session ID and the funnel sees a single user looping forever.
+        ctx = await browser.createBrowserContext();
+        page = await ctx.newPage();
+        page.setDefaultNavigationTimeout(45000);
+        page.setDefaultTimeout && page.setDefaultTimeout(30000);
+
+        // Log all responses for debugging (when DEBUG_LOGGING=true)
+        if (debugEnabled) {
+          page.on('response', response => {
+            const url = response.url();
+            if (url.includes('api')) {
+              console.log(`[DEBUG] API Response: ${url} (${response.status()})`);
+            }
+          });
+        }
+
+        const base = buildBaseUrl();
+        const productsToOrder = getRandomProducts();
+        console.log(`🛒 Ordering ${productsToOrder.length} product(s): ${productsToOrder.join(', ')}`);
+
+        // Visit homepage first so the user enters the sequential RUM funnel
+        // at step 1. Without this the loadgen lands on /product/<id> and the
+        // funnel records 0 conversions because step 1 is never satisfied.
+        const homeUrl = base.replace(/\/+$/, '/');
+        console.log(`🏠 Visiting homepage ${homeUrl}`);
+        await page.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+        await delay(1500);
+
+        // Loop through each product and add to cart
+        for (const productId of productsToOrder) {
+          const url = new URL(`product/${productId}`, base).toString();
+          console.log(`🌐 Navigating to ${url}`);
+
+          // Set up /api/data response listener BEFORE navigation
+          const apiDataPromise = page.waitForResponse(
+            response => {
+              const url = response.url();
+              const status = response.status();
+              const matches = url.includes('/api/data') && (status === 200 || status === 304);
+              if (matches) {
+                console.log(`✅ /api/data response received: ${status}`);
+              }
+              return matches;
+            },
+            { timeout: 15000 }
+          );
+
+          // Navigate to page
+          await page.goto(url, {
+            waitUntil: 'networkidle2',  // Wait until no more than 2 connections for 500ms
+            timeout: 60000               // 60 second timeout for page load
+          });
+
+          // Now wait for /api/data to complete (may have already completed during goto)
+          console.log('⏳ Ensuring ad service (/api/data) completed...');
+          await apiDataPromise.catch(() => {
+            console.log('⚠️ /api/data did not complete in 15s, continuing anyway...');
+          });
+
+          // Small delay to ensure any follow-up requests finish
+          await delay(500);
+          console.log('✅ Page fully loaded with all API calls complete');
+
+          // Quick prompts - throttled to once every 5 minutes
+          const now = Date.now();
+          if (now - lastQuickPromptTime >= QUICK_PROMPT_INTERVAL_MS) {
+          lastQuickPromptTime = now;
+
+          const quickPrompts = [
+            {
+              label: 'Can you summarize the product reviews?',
+              dataCy: 'QuickPromptSummarize',
+              ariaSelector: '::-p-aria(Can you summarize the product reviews?)',
+              textSelector: '::-p-text(Can you summarize)',
+              offset: { x: 129, y: 15 },
+            },
+            {
+              label: 'Were there any negative reviews?',
+              dataCy: 'QuickPromptNegative',
+              ariaSelector: '::-p-aria(Were there any negative reviews?)',
+              textSelector: '::-p-text(Were there any)',
+              offset: { x: 171.6640625, y: 25 },
+            },
+            {
+              label: 'What age(s) is this recommended for?',
+              dataCy: 'QuickPromptAges',
+              ariaSelector: '::-p-aria(What age\\(s\\) is this recommended for?)',
+              textSelector: '::-p-text(What age\\(s\\) is)',
+              offset: { x: 148.0390625, y: 19 },
+            },
+          ];
+
+          const prompt = quickPrompts[Math.floor(Math.random() * quickPrompts.length)];
+          console.log(`🖱️ Clicking quick prompt: "${prompt.label}"`);
+
+          {
+              const targetPage = page;
+              const timeout = 5000;
+              await puppeteer.Locator.race([
+                  targetPage.locator(prompt.ariaSelector),
+                  targetPage.locator(`[data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(`::-p-xpath(//*[@data-cy=\\"${prompt.dataCy}\\"])`),
+                  targetPage.locator(`:scope >>> [data-cy='${prompt.dataCy}']`),
+                  targetPage.locator(prompt.textSelector)
+              ])
+                  .setTimeout(timeout)
+                  .click({ offset: prompt.offset });
+              console.log('⏳ Waiting for AI response...');
+              await delay(500); // Let request start
+              await page.waitForSelector("[data-cy='AIAnswer']", { timeout: 15000, visible: true }).catch(() => {
+                console.log('⚠️ AI response timeout, continuing...');
+              });
+              await delay(1500); // Allow response to fully render
+          }
+
+          } else {
+            console.log('⏭️ Skipping quick prompts (next run in ' + Math.round((QUICK_PROMPT_INTERVAL_MS - (now - lastQuickPromptTime)) / 1000) + 's)');
+          }
+
+          const addSel = "[data-cy='product-add-to-cart']";
+          await page.waitForSelector(addSel);
+          console.log(`🖱️ Clicking "Add To Cart" for product ${productId}`);
+          await page.click(addSel);
+        }
+
+        // Place order after all products are added to cart
+        const placeSel = "[data-cy='checkout-place-order']";
+        await page.waitForSelector(placeSel);
+        console.log('🖱️ Clicking "Place Order"');
+        await page.click(placeSel);
+
+        // Wait for either success message or error modal
+        console.log('⏳ Waiting for order result...');
+        const orderResult = await Promise.race([
+          waitForText(page, 'Your order is complete!').then(() => 'success'),
+          page.waitForSelector('#modal-close-btn', { timeout: 30000, visible: true }).then(() => 'error-modal')
+        ]);
+
+        if (orderResult === 'success') {
+          console.log('🎉 Order completed successfully!');
+          // Confirmation page useEffect fires the `order.confirmed` RUM span
+          // asynchronously. Wait so the RUM batcher can flush the beacon
+          // before the page / context is torn down.
+          await delay(5000);
+        } else if (orderResult === 'error-modal') {
+          console.log('⚠️ Error modal detected - closing it to continue...');
+          await page.click('#modal-close-btn');
+          await delay(500);
+          console.log('✅ Error modal closed.');
+        }
+
+        // Periodic shipping info fetch (every 2 minutes, gated by SHIPPING_API)
+        await fetchShippingInfo(page);
+      } finally {
+        console.log('🧹 Cleaning up page resources...');
+        try {
+          if (page) {
+            page.removeAllListeners();
+            await page.close({ runBeforeUnload: true }).catch(()=>{});
+          }
+          if (ctx) {
+            await ctx.close().catch(()=>{});
+          }
+        } catch (e) {
+          console.error('⚠️ Error closing page:', e.message);
+        }
+        console.log('✅ Page + context closed cleanly. Browser will be reused for next cycle.');
+      }
+    }
+
+    (async function mainLoop() {
+      const cycleDelayMs = parseInt(process.env.CYCLE_DELAY_MS || '5000', 10);
+      console.log(`⚙️ Cycle delay: ${cycleDelayMs}ms`);
+
+      let cycle = 1;
+      while (true) {
+        console.log(`=== Starting load generation cycle #${cycle} ===`);
+        try {
+          await runOnce();
+          console.log(`✅ Cycle #${cycle} finished OK`);
+        } catch (e) {
+          console.error(`❌ Cycle #${cycle} failed:`, e && e.stack ? e.stack : e);
+        }
+        cycle += 1;
+        await delay(cycleDelayMs);
+      }
+    })();
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astronomy-loadgen-deployment
+  labels:
+    app: astronomy-loadgen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: astronomy-loadgen
+  template:
+    metadata:
+      labels:
+        app: astronomy-loadgen
+    spec:
+      initContainers:
+      - name: wait-for-frontend
+        image: curlimages/curl:8.1.2
+        command: ['sh', '-c']
+        args:
+        - |
+          echo "Waiting for frontend-proxy to be ready..."
+          until curl -f --connect-timeout 5 --max-time 10 http://frontend-proxy:8080; do
+            echo "Frontend not ready, waiting 10 seconds..."
+            sleep 10
+          done
+          echo "Frontend is ready, starting loadgen..."
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "50m"
+      containers:
+      - name: astronomy-loadgen
+        image: ghcr.io/splunk/online-boutique/rumloadgen:5.6
+        imagePullPolicy: Always
+        env:
+        # NOTE: For RUM funnels that filter on the public ingress URL (e.g.
+        # `https://astronomy-shop.example.com`), override this value per
+        # deployment so the loadgen browser navigates to the same origin as
+        # real users. The in-cluster default below works for traffic-only
+        # generation but produces RUM events tagged with the internal URL.
+        - name: RUM_FRONTEND_IP
+          value: "http://frontend-proxy:8080"
+        - name: CYCLE_DELAY_MS
+          value: "1000"
+        - name: DEBUG_LOGGING
+          value: ""  # Set to "true" to enable debug logging
+        - name: QUICK_PROMPT_INTERVAL_MS
+          value: "300000"  # How often AI quick prompts run (ms). Default 300000 (5min). Set "0" for every cycle.
+        - name: SHIPPING_API
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: shipping_api
+              optional: true
+        resources:
+          requests:
+            memory: "768Mi"
+            cpu: "500m"
+          limits:
+            memory: "1536Mi"
+            cpu: "1000m"
+        volumeMounts:
+        - name: puppeteer
+          subPath: local-file
+          mountPath: /puppeteer/touchwebsite.js
+      volumes:
+      - name: puppeteer
+        configMap:
+          name: scriptfile
+
+---
+
+# === cart ===
+# Kubernetes manifest for cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart
+  labels:
+    opentelemetry.io/name: cart
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: cart
+        app.kubernetes.io/component: cart
+        app.kubernetes.io/name: cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: cart
+        image: ghcr.io/splunk/opentelemetry-demo/otel-cart:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CART_PORT
+          value: '8080'
+        - name: ASPNETCORE_URLS
+          value: http://*:$(CART_PORT)
+        - name: VALKEY_ADDR
+          value: valkey-cart:6379
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318/v1/logs
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: 'true'
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          limits:
+            memory: 320Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep
+          2; done;
+        image: busybox:latest
+        name: wait-for-valkey-cart
+      volumes: null
+
+---
+
+# === checkout ===
+# Kubernetes manifest for checkout
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: checkout
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+  labels:
+    opentelemetry.io/name: checkout
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: checkout
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: checkout
+        app.kubernetes.io/component: checkout
+        app.kubernetes.io/name: checkout
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: checkout
+        image: ghcr.io/splunk/opentelemetry-demo/otel-checkout:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CHECKOUT_PORT
+          value: '8080'
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: EMAIL_ADDR
+          value: http://email:8080
+        - name: PAYMENT_ADDR
+          value: payment:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 16MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      volumes: null
+
+---
+
+# === currency ===
+# Kubernetes manifest for currency
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: currency
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: currency
+  labels:
+    opentelemetry.io/name: currency
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: currency
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: currency
+        app.kubernetes.io/component: currency
+        app.kubernetes.io/name: currency
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: currency
+        image: ghcr.io/open-telemetry/demo:2.2.0-currency
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: CURRENCY_PORT
+          value: '8080'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: VERSION
+          value: 2.1.3
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === email ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for email
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: email
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email
+  labels:
+    opentelemetry.io/name: email
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: email
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: email
+        app.kubernetes.io/component: email
+        app.kubernetes.io/name: email
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: email
+        image: ghcr.io/open-telemetry/demo:2.2.0-email
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: EMAIL_PORT
+          value: '8080'
+        - name: APP_ENV
+          value: production
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === flagd ===
+# Kubernetes manifest for flagd
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8013
+    name: rpc
+    targetPort: 8013
+  - port: 8016
+    name: ofrep
+    targetPort: 8016
+  selector:
+    opentelemetry.io/name: flagd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd
+  labels:
+    opentelemetry.io/name: flagd
+    app.kubernetes.io/component: flagd
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd
+        app.kubernetes.io/component: flagd
+        app.kubernetes.io/name: flagd
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: flagd
+        image: ghcr.io/open-feature/flagd:v0.14.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /flagd-build
+        - start
+        - --port
+        - '8013'
+        - --ofrep-port
+        - '8016'
+        - --uri
+        - file:./etc/flagd/demo.flagd.json
+        ports:
+        - containerPort: 8013
+          name: rpc
+        - containerPort: 8016
+          name: ofrep
+        env:
+        - name: GOMEMLIMIT
+          value: 60MiB
+        resources:
+          limits:
+            memory: 75Mi
+        volumeMounts:
+        - name: config-rw
+          mountPath: /etc/flagd
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === flagd-config ===
+# Kubernetes manifest for flagd-config
+# NOTE: The ConfigMap is generated at stitch time from src/flagd/demo.flagd.json
+# This file only contains the PVC definition
+---
+# PersistentVolumeClaim for shared flagd configuration
+# This PVC is shared between flagd and flagd-ui to enable dynamic flag updates
+# Using ReadWriteOnce with podAffinity to ensure both pods on same node
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flagd-shared-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+    app.kubernetes.io/component: flagd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flagd-config
+  labels:
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  demo.flagd.json: |
+    {
+      "$schema": "https://flagd.dev/schema/v0/flags.json",
+      "flags": {
+        "llmInaccurateResponse": {
+          "defaultVariant": "off",
+          "description": "LLM returns an inaccurate product summary for product ID L9ECAV7KIM",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "llmRateLimitError": {
+          "defaultVariant": "off",
+          "description": "LLM intermittently returns a rate limit error",
+          "state": "ENABLED",
+          "variants": {
+            "off": false,
+            "on": true
+          }
+        },
+        "productCatalogFailure": {
+          "description": "Fail product catalog service on a specific product",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCacheFailure": {
+          "description": "Fail recommendation service cache",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adManualGc": {
+          "description": "Triggers full manual garbage collections in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adHighCpu": {
+          "description": "Triggers high cpu load in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adFailure": {
+          "description": "Fail ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "kafkaQueueProblems": {
+          "description": "Overloads Kafka queue while simultaneously introducing a consumer side delay leading to a lag spike",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "cartFailure": {
+          "description": "Fail cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentFailure": {
+          "description": "Fail payment service charge requests n%",
+          "state": "ENABLED",
+          "variants": {
+            "100%": 1,
+            "90%": 0.95,
+            "75%": 0.75,
+            "50%": 0.5,
+            "25%": 0.25,
+            "10%": 0.1,
+            "off": 0
+          },
+          "defaultVariant": "50%"
+        },
+        "rumBlueGreen": {
+          "description": "Enable RUM-based payment path (A/B) tracking in user.deployment_type attribute",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentUnreachable": {
+          "description": "Payment service is unavailable",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "loadGeneratorFloodHomepage": {
+          "description": "Flood the frontend with a large amount of requests.",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "imageSlowLoad": {
+          "description": "slow loading images in the frontend",
+          "state": "ENABLED",
+          "variants": {
+            "10sec": 10000,
+            "5sec": 5000,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "failedReadinessProbe": {
+          "description": "readiness probe failure for cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+    
+        },
+        "emailMemoryLeak": {
+          "description": "Memory leak in the email service.",
+          "state": "ENABLED",
+          "variants": {
+            "off": 0,
+            "1x": 1,
+            "10x": 10,
+            "100x": 100,
+            "1000x": 1000,
+            "10000x": 10000
+          },
+          "defaultVariant": "off"
+        },
+        "recommendationCartesianQuery": {
+          "description": "DBMon Demo: Triggers a Cartesian join query (500M rows) in recommendation service PostgreSQL calls. Query returns correct results but processes 500M intermediate rows, taking 12+ seconds.",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "secureappAttack": {
+          "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",
+          "state": "ENABLED",
+          "variants": {
+            "minimal": "minimal",
+            "targeted": "targeted",
+            "max": "max"
+          },
+          "defaultVariant": "minimal"
+        }
+      }
+    }
+
+---
+
+# === flagd-ui ===
+# Kubernetes manifest for flagd-ui
+# Split from combined flagd/flagd-ui deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4000
+    name: tcp-service
+    targetPort: 4000
+  selector:
+    opentelemetry.io/name: flagd-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd-ui
+  labels:
+    opentelemetry.io/name: flagd-ui
+    app.kubernetes.io/component: flagd-ui
+    app.kubernetes.io/name: flagd-ui
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: flagd-ui
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: flagd-ui
+        app.kubernetes.io/component: flagd-ui
+        app.kubernetes.io/name: flagd-ui
+    spec:
+      serviceAccountName: opentelemetry-demo
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: opentelemetry.io/name
+                operator: In
+                values:
+                - flagd
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: flagd-ui
+        image: ghcr.io/open-telemetry/demo:2.2.0-flagd-ui
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 4000
+          name: service
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: SECRET_KEY_BASE
+          value: yYrECL4qbNwleYInGJYvVnSkwJuSQJ4ijPTx5tirGUXrbznFIBFVJdPl5t6O9ASw
+        - name: PHX_HOST
+          value: localhost
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        resources:
+          limits:
+            memory: 250Mi
+        volumeMounts:
+        - mountPath: /app/data
+          name: config-rw
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+        image: busybox
+        name: init-config
+        volumeMounts:
+        - mountPath: /config-ro
+          name: config-ro
+        - mountPath: /config-rw
+          name: config-rw
+      volumes:
+      - name: config-rw
+        persistentVolumeClaim:
+          claimName: flagd-shared-config
+      - configMap:
+          name: flagd-config
+        name: config-ro
+
+---
+
+# === fraud-detection ===
+# Kubernetes manifest for fraud-detection
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 1 resource(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fraud-detection
+  labels:
+    opentelemetry.io/name: fraud-detection
+    app.kubernetes.io/component: fraud-detection
+    app.kubernetes.io/name: fraud-detection
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: fraud-detection
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: fraud-detection
+        app.kubernetes.io/component: fraud-detection
+        app.kubernetes.io/name: fraud-detection
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: fraud-detection
+        image: ghcr.io/splunk/opentelemetry-demo/otel-fraud-detection:2.0.5
+        imagePullPolicy: Always
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADDR
+          value: kafka:9092
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_INSTRUMENTATION_KAFKA_CLIENTS_ENABLED
+          value: 'false'
+        - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+          value: 'true'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=propagation
+        - name: SQL_SERVER_HOST
+          value: sql-server-fraud.default.svc.cluster.local
+        - name: SQL_SERVER_PORT
+          value: '1433'
+        - name: SQL_SERVER_DATABASE
+          value: FraudDetection
+        - name: SQL_SERVER_USER
+          value: sa
+        - name: SQL_SERVER_PASSWORD
+          value: ChangeMe_SuperStrong123!
+        - name: FRAUD_DETECTION_RATE
+          value: '80'
+        - name: CLEANUP_RETENTION_DAYS
+          value: '4'
+        - name: CLEANUP_INTERVAL_HOURS
+          value: '6'
+        - name: FRAUD_MUTATION_PERCENTAGE
+          value: '25'
+        - name: BAD_QUERY_PERCENTAGE
+          value: '0'
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 512Mi
+        volumeMounts: null
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-kafka
+      - command:
+        - sh
+        - -c
+        - until nc -z -v -w30 sql-server-fraud.default.svc.cluster.local 1433; do echo
+          waiting for sql-server-fraud; sleep 2; done;
+        image: busybox:latest
+        name: wait-for-sqlserver
+      volumes: null
+
+---
+
+# === frontend ===
+# Kubernetes manifest for frontend
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    opentelemetry.io/name: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: frontend
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: PORT
+          value: $(FRONTEND_PORT)
+        - name: FRONTEND_ADDR
+          value: :8080
+        - name: AD_ADDR
+          value: ad:8080
+        - name: CART_ADDR
+          value: cart:8080
+        - name: CHECKOUT_ADDR
+          value: checkout:8080
+        - name: CURRENCY_ADDR
+          value: currency:8080
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: PRODUCT_REVIEWS_ADDR
+          value: product-reviews:3551
+        - name: RECOMMENDATION_ADDR
+          value: recommendation:8080
+        - name: SHIPPING_ADDR
+          value: http://shipping:8080
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: ENV_PLATFORM
+          value: kubernetes
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+        - name: OTEL_LOG_LEVEL
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: api_token
+              optional: true
+        - name: SPLUNK_RUM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: rum_token
+        - name: SPLUNK_APP_NAME
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: app
+        - name: SPLUNK_RUM_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+        - name: SPLUNK_RUM_REALM
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: realm
+        resources:
+          limits:
+            memory: 250Mi
+        securityContext:
+          runAsGroup: 1001
+          runAsNonRoot: true
+          runAsUser: 1001
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === frontend-proxy ===
+# Kubernetes manifest for frontend-proxy
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: frontend-proxy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-proxy
+  labels:
+    opentelemetry.io/name: frontend-proxy
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: frontend-proxy
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: frontend-proxy
+        app.kubernetes.io/component: frontend-proxy
+        app.kubernetes.io/name: frontend-proxy
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: frontend-proxy
+        image: ghcr.io/splunk/opentelemetry-demo/otel-frontend-proxy:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: ENVOY_ADDR
+          value: 0.0.0.0
+        - name: ENVOY_PORT
+          value: '8080'
+        - name: ENVOY_ADMIN_PORT
+          value: '10000'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8016'
+        - name: FLAGD_UI_HOST
+          value: flagd-ui
+        - name: FLAGD_UI_PORT
+          value: '4000'
+        - name: FRONTEND_HOST
+          value: frontend
+        - name: FRONTEND_PORT
+          value: '8080'
+        - name: IMAGE_PROVIDER_HOST
+          value: image-provider
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: LOCUST_WEB_HOST
+          value: load-generator
+        - name: LOCUST_WEB_PORT
+          value: '8089'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_PORT_HTTP
+          value: '4318'
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: SECUREAPP_HOST
+          value: secureapp-loadgen
+        - name: SECUREAPP_PORT
+          value: '8080'
+        - name: FEATURE_AUTH_ENABLED
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_auth
+              optional: true
+        - name: FEATURE_USER
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_user
+              optional: true
+        - name: FEATURE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: flagd_pw
+              optional: true
+        resources:
+          limits:
+            memory: 65Mi
+        securityContext:
+          runAsGroup: 101
+          runAsNonRoot: true
+          runAsUser: 101
+        volumeMounts: null
+      volumes: null
+---
+
+
+---
+
+# === image-provider ===
+# Kubernetes manifest for image-provider
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8081
+    name: tcp-service
+    targetPort: 8081
+  selector:
+    opentelemetry.io/name: image-provider
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-provider
+  labels:
+    opentelemetry.io/name: image-provider
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: image-provider
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: image-provider
+        app.kubernetes.io/component: image-provider
+        app.kubernetes.io/name: image-provider
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: image-provider
+        image: ghcr.io/splunk/opentelemetry-demo/otel-image-provider:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: IMAGE_PROVIDER_PORT
+          value: '8081'
+        - name: OTEL_COLLECTOR_PORT_GRPC
+          value: '4317'
+        - name: OTEL_COLLECTOR_HOST
+          value: $(OTEL_COLLECTOR_NAME)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 50Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === kafka ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for kafka
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9092
+    name: plaintext
+    targetPort: 9092
+  - port: 9093
+    name: controller
+    targetPort: 9093
+  selector:
+    opentelemetry.io/name: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  labels:
+    opentelemetry.io/name: kafka
+    app.kubernetes.io/component: kafka
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: kafka
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: kafka
+        app.kubernetes.io/component: kafka
+        app.kubernetes.io/name: kafka
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: kafka
+        image: ghcr.io/open-telemetry/demo:2.2.0-kafka
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9092
+          name: plaintext
+        - containerPort: 9093
+          name: controller
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka:9092
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: KAFKA_HEAP_OPTS
+          value: -Xmx400M -Xms400M
+        - name: KAFKA_LISTENERS
+          value: PLAINTEXT://:9092,CONTROLLER://:9093
+        - name: KAFKA_CONTROLLER_LISTENER_NAMES
+          value: CONTROLLER
+        - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+          value: 1@kafka:9093
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 800Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === llm ===
+# Kubernetes manifest for llm
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    name: tcp-service
+    targetPort: 8000
+  selector:
+    opentelemetry.io/name: llm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+  labels:
+    opentelemetry.io/name: llm
+    app.kubernetes.io/component: llm
+    app.kubernetes.io/name: llm
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: llm
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: llm
+        app.kubernetes.io/component: llm
+        app.kubernetes.io/name: llm
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: llm
+        image: ghcr.io/splunk/opentelemetry-demo/otel-llm:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 100Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === demo-service-account ===
+# Kubernetes manifest for demo-service-account
+# ServiceAccount used by all Astronomy Shop application pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-demo
+  labels:
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+
+---
+
+# === payment-vA ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version A - Stable/Conservative Version
+# This manifest deploys payment service v1.7.0-a with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prod-payment-secret
+type: Opaque
+stringData:
+  api-token: "prod-a8cf28f9-1a1a-4994-bafa-cd4b143c3291"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-va
+    app.kubernetes.io/version: "1.7.0-a"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vA
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vA
+        opentelemetry.io/name: payment-va
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-va
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version A
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vA"]
+
+        # Anti-affinity - never on same node as version B
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vB
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.9"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-a"
+
+        # Token from dedicated secret for version A
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: prod-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=otel-fields-fix,payment.variant=A"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging
+        - name: OTEL_LOG_LEVEL
+          value: info
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-va
+  labels:
+    app: payment
+    version: vA
+    opentelemetry.io/name: payment-va
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vA
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === payment-vB ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Payment Service Version B - Optimized/Next-gen Version
+# This manifest deploys payment service v1.7.0-b with version-specific configuration
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-payment-secret
+type: Opaque
+stringData:
+  api-token: "test-20e26e90-356b-432e-a2c6-956fc03f5609"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment-vb
+    app.kubernetes.io/version: "1.7.0-b"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment
+      version: vB
+  template:
+    metadata:
+      labels:
+        app: payment
+        version: vB
+        opentelemetry.io/name: payment-vb
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment-vb
+    spec:
+      serviceAccountName: opentelemetry-demo
+
+      # Node affinity and anti-affinity for separation
+      affinity:
+        # Prefer nodes labeled for version B
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: payment-version
+                operator: In
+                values: ["vB"]
+
+        # Anti-affinity - never on same node as version A
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: payment
+                version: vA
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      - name: payment
+        image: ghcr.io/splunk/opentelemetry-demo/otel-payment:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+
+        env:
+        # Version configuration (baked into image, can override)
+        - name: PAYMENT_VERSION
+          value: "350.10"
+
+        # Service version for logger (must match image tag)
+        - name: SERVICE_VERSION
+          value: "1.7.2-b"
+
+        # Token from dedicated secret for version B
+        - name: PAYMENT_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: test-payment-secret
+              key: api-token
+              optional: false
+
+        # Service configuration
+        - name: PAYMENT_PORT
+          value: "8080"
+
+        # OpenTelemetry service name
+        - name: OTEL_SERVICE_NAME
+          value: "payment"
+
+        # Feature flags
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: "8013"
+
+        # Get node IP for collector
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+
+        # OpenTelemetry collector configuration
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: grpc
+
+        # Resource attributes (includes version-specific tags)
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=payment,service.version=otel-fields-fix,payment.variant=B"
+
+        # Splunk OpenTelemetry configuration
+        - name: SPLUNK_INSTRUMENTATION_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_METRICS_ENABLED
+          value: "true"
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+
+        # Logging (more verbose for version B)
+        - name: OTEL_LOG_LEVEL
+          value: debug
+        - name: LOG_LEVEL
+          value: debug
+
+        # Workshop environment (dynamic)
+        - name: WORKSHOP_ENV
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: env
+              optional: true
+
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 100m
+          limits:
+            memory: 120Mi
+            cpu: 200m
+
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+            - ALL
+
+        livenessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
+        readinessProbe:
+          grpc:
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-vb
+  labels:
+    app: payment
+    version: vB
+    opentelemetry.io/name: payment-vb
+spec:
+  type: ClusterIP
+  selector:
+    app: payment
+    version: vB
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: grpc
+
+---
+
+# === postgresql-setup ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# PostgreSQL Database Initialization ConfigMap
+# This ConfigMap contains scripts that create schemas, tables, and extensions
+# for the accounting, product-catalog, product-reviews, and recommendation services
+#
+# The postgres deployment mounts these as /docker-entrypoint-initdb.d/
+# which PostgreSQL automatically executes on first startup (alphabetical order)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-sql
+  labels:
+    app.kubernetes.io/name: postgres-init
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # Shell script runs first (alphabetically) to create extension in postgres database
+  00-pg-stat-statements.sh: |
+    #!/bin/bash
+    # Create pg_stat_statements extension in the postgres database
+    # This is required for PostgreSQL receiver top query monitoring
+    set -e
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<-EOSQL
+        CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    EOSQL
+    echo "pg_stat_statements extension created in postgres database"
+  init.sql: |
+    -- Copyright The OpenTelemetry Authors
+    -- SPDX-License-Identifier: Apache-2.0
+
+    -- Enable pg_stat_statements for database monitoring (top query tracking)
+    -- Note: This runs in the 'otel' database. The extension is also created
+    -- in the 'postgres' database by 00-pg-stat-statements.sh for top query monitoring.
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+    CREATE USER otelu WITH PASSWORD 'otelp';
+
+    -- Accounting Service: create a schema
+    CREATE SCHEMA accounting;
+    GRANT USAGE ON SCHEMA accounting TO otelu;
+
+    -- Accounting Service: create tables
+    CREATE TABLE accounting."order" (
+        order_id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE accounting.shipping (
+        shipping_tracking_id TEXT PRIMARY KEY,
+        shipping_cost_currency_code TEXT NOT NULL,
+        shipping_cost_units BIGINT NOT NULL,
+        shipping_cost_nanos INT NOT NULL,
+        street_address TEXT,
+        city TEXT,
+        state TEXT,
+        country TEXT,
+        zip_code TEXT,
+        order_id TEXT NOT NULL,
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE accounting.orderitem (
+        item_cost_currency_code TEXT NOT NULL,
+        item_cost_units BIGINT NOT NULL,
+        item_cost_nanos INT NOT NULL,
+        product_id TEXT NOT NULL,
+        quantity INT NOT NULL,
+        order_id TEXT NOT NULL,
+        PRIMARY KEY (order_id, product_id),
+        FOREIGN KEY (order_id) REFERENCES accounting."order"(order_id) ON DELETE CASCADE
+    );
+
+    -- Accounting Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA accounting TO otelu;
+
+    -- Product Catalog Service: create a schema
+    CREATE SCHEMA catalog;
+    GRANT USAGE ON SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: create tables
+    CREATE TABLE catalog.products (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        picture TEXT,
+        price_currency_code TEXT NOT NULL,
+        price_units BIGINT NOT NULL,
+        price_nanos INT NOT NULL,
+        categories TEXT
+    );
+
+    -- Product Catalog Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA catalog TO otelu;
+
+    -- Product Catalog Service: add product data
+    INSERT INTO catalog.products (id, name, description, picture, price_currency_code, price_units, price_nanos, categories)
+    VALUES
+        ('OLJCESPC7Z', 'National Park Foundation Explorascope', 'The National Park Foundation''s (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.', 'NationalParkFoundationExplorascope.jpg', 'USD', 101, 960000000, 'telescopes'),
+        ('66VCHSJNUP', 'Starsense Explorer Refractor Telescope', 'The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app''s user-friendly interface and detailed tutorials. It''s like having your own personal tour guide of the night sky', 'StarsenseExplorer.jpg', 'USD', 349, 950000000, 'telescopes'),
+        ('1YMWWN1N4O', 'Eclipsmart Travel Refractor Telescope', 'Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.', 'EclipsmartTravelRefractorTelescope.jpg', 'USD', 129, 950000000, 'telescopes,travel'),
+        ('L9ECAV7KIM', 'Lens Cleaning Kit', 'Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.', 'LensCleaningKit.jpg', 'USD', 21, 950000000, 'accessories'),
+        ('2ZYFJ3GM2N', 'Roof Binoculars', 'This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It''s an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.', 'RoofBinoculars.jpg', 'USD', 209, 950000000, 'binoculars'),
+        ('0PUK6V6EV0', 'Solar System Color Imager', 'You have your new telescope and have observed Saturn and Jupiter. Now you''re ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.', 'SolarSystemColorImager.jpg', 'USD', 175, 0, 'accessories,telescopes'),
+        ('LS4PSXUNUM', 'Red Flashlight', 'This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red''s rugged, IPX4-rated design will withstand your everyday activities.', 'RedFlashlight.jpg', 'USD', 57, 80000000, 'accessories,flashlights'),
+        ('9SIQT8TOJO', 'Optical Tube Assembly', 'Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today''s top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won''t need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.', 'OpticalTubeAssembly.jpg', 'USD', 3599, 0, 'accessories,telescopes,assembly'),
+        ('6E92ZMYYFZ', 'Solar Filter', 'Enhance your viewing experience with EclipSmart Solar Filter for 8" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.', 'SolarFilter.jpg', 'USD', 69, 950000000, 'accessories,telescopes'),
+        ('HQTGWGPNH4', 'The Comet Book', 'A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as "Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)', 'TheCometBook.jpg', 'USD', 0, 990000000, 'books');
+
+    -- Product Review Service: create a schema
+    CREATE SCHEMA reviews;
+    GRANT USAGE ON SCHEMA reviews TO otelu;
+
+    -- Product Review Service: create tables
+    CREATE TABLE reviews.productreviews (
+        id INTEGER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+        product_id VARCHAR(16) NOT NULL,
+        username VARCHAR(64) NOT NULL,
+        description VARCHAR(1024),
+        score NUMERIC(2,1) NOT NULL
+    );
+
+    -- Product Review Service: create index for product_id lookups
+    CREATE INDEX product_id_index ON reviews.productreviews (product_id);
+
+    -- Product Review Service: grant permission to schema
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA reviews TO otelu;
+
+    -- Product Review Service:  add product review data
+    INSERT INTO reviews.productreviews (product_id, username, description, score)
+    VALUES
+        ('OLJCESPC7Z', 'stargazer_mike', 'Great entry-level telescope! Easy to set up and provides clear views of the moon and brighter planets. Highly recommend for new astronomers.', '4.5'),
+        ('OLJCESPC7Z', 'nightskylover', 'For the price, this Explorascope delivers excellent performance. I was able to see Jupiter''s moons clearly. A fantastic purchase for casual viewing.', '4.0'),
+        ('OLJCESPC7Z', 'beginner_astro', 'A bit tricky to get used to the manual controls, but once you do, it''s very rewarding. Saw the Orion Nebula for the first time! Good value.', '3.5'),
+        ('OLJCESPC7Z', 'celestial_explorer', 'Perfect for camping trips. It''s lightweight and portable, making it easy to take anywhere. The views are surprisingly good for its size.', '4.0'),
+        ('OLJCESPC7Z', 'telescope_fan', 'Not the most powerful scope, but it''s great for kids and beginners. My children love looking at the moon with it. A solid choice for family fun.', '3.0'),
+
+        ('66VCHSJNUP', 'tech_astro', 'The StarSense app is revolutionary! It made finding celestial objects incredibly easy. This telescope is a game-changer for beginners.', '5.0'),
+        ('66VCHSJNUP', 'app_user', 'Amazing technology, the smartphone integration works flawlessly. I''ve never had so much fun exploring the night sky. Worth every penny.', '4.5'),
+        ('66VCHSJNUP', 'innovator_john', 'Setup was a breeze, and the tutorials in the app are very helpful. The views are crisp and clear. My only minor gripe is battery drain on the phone.', '4.0'),
+        ('66VCHSJNUP', 'clear_skies', 'Finally, a telescope that takes the guesswork out of stargazing. The real-time positioning is incredibly accurate. Highly recommended for anyone new to astronomy.', '5.0'),
+        ('66VCHSJNUP', 'gadget_geek', 'Fantastic product, the app truly guides you. It''s like having a personal astronomer with you. The optical quality is also very good.', '4.5'),
+
+        ('1YMWWN1N4O', 'solar_viewer', 'Perfect for solar observations! The Solar Safe filter gives peace of mind. I used it for the last partial eclipse and it was fantastic.', '5.0'),
+        ('1YMWWN1N4O', 'eclipse_chaser', 'Compact and easy to carry, this telescope is ideal for eclipse events. The included backpack is a nice touch. Views of the sun are incredibly clear and safe.', '4.5'),
+        ('1YMWWN1N4O', 'travel_astro', 'Excellent travel scope for solar viewing. The magnification is much better than binoculars for the sun. A must-have for any solar enthusiast.', '4.0'),
+        ('1YMWWN1N4O', 'sun_gazer', 'Very impressed with the safety features and clarity. Sharing the sun with family has never been easier or safer. Great value for a dedicated solar scope.', '5.0'),
+        ('1YMWWN1N4O', 'safe_viewer', 'The ISO compliant filter is reassuring. It''s a well-designed product for safe solar observation. Highly recommend for educational purposes too.', '4.5'),
+
+        ('L9ECAV7KIM', 'clean_optics', 'This kit is a lifesaver for all my optics. The brush and wipes work perfectly without leaving any residue. My lenses have never been cleaner.', '5.0'),
+        ('L9ECAV7KIM', 'photog_pro', 'Essential for any photographer or telescope owner. It safely removes dust and fingerprints. A high-quality cleaning solution.', '4.5'),
+        ('L9ECAV7KIM', 'daily_cleaner', 'I use this on my binoculars, camera lenses, and even my phone screen. It''s very effective and gentle. A versatile cleaning kit.', '4.0'),
+        ('L9ECAV7KIM', 'tech_maintenance', 'Great value for money. The different cleaning options cover all needs. Keeps my expensive equipment in pristine condition.', '5.0'),
+        ('L9ECAV7KIM', 'sharp_view', 'Works as advertised, my telescope views are much clearer after using this. The fluid and cloth are excellent. Definitely recommend.', '4.5'),
+
+        ('2ZYFJ3GM2N', 'bird_watcher', 'Incredible clarity and brightness, perfect for bird watching. The ED glass really makes a difference. I can spot the subtlest markings.', '5.0'),
+        ('2ZYFJ3GM2N', 'nature_lover', 'These binoculars are fantastic for nature observation. The close focus is a huge advantage for viewing nearby wildlife. Very comfortable to hold.', '4.5'),
+        ('2ZYFJ3GM2N', 'hiker_guy', 'Lightweight and durable, these are my go-to binoculars for hiking. The wide field of view is excellent. Highly recommend for outdoor enthusiasts.', '4.0'),
+        ('2ZYFJ3GM2N', 'stadium_fan', 'Took these to a game and had an amazing view of the action. They perform great in various lighting conditions. A solid all-around binocular.', '4.0'),
+        ('2ZYFJ3GM2N', 'outdoor_adventurer', 'Excellent build quality and optical performance. They feel robust and provide sharp images. A great investment for any outdoor activity.', '4.5'),
+
+        ('0PUK6V6EV0', 'astro_photog', 'This imager is a fantastic step up for planetary photography. The color quality is superb. Easy to use with my existing telescope setup.', '5.0'),
+        ('0PUK6V6EV0', 'planet_shooter', 'Finally capturing stunning images of Saturn and Jupiter! The NexImage 10 makes it so accessible. Great for beginners in astrophotography.', '4.5'),
+        ('0PUK6V6EV0', 'imager_pro', 'Excellent resolution and color rendition for its price point. It''s a perfect solution for those looking to start imaging planets. Highly satisfied.', '4.0'),
+        ('0PUK6V6EV0', 'space_artist', 'The detail I can capture with this imager is incredible. It integrates well with various software. A must-have for serious planetary observers.', '5.0'),
+        ('0PUK6V6EV0', 'digital_sky', 'A solid choice for getting into solar system imaging. The setup was straightforward. Produces beautiful, vibrant planetary images.', '4.5'),
+
+        ('LS4PSXUNUM', 'night_walker', 'The red light is perfect for preserving night vision during astronomy sessions. The hand warmer is an unexpected bonus. Very practical device.', '5.0'),
+        ('LS4PSXUNUM', 'star_party_goer', 'This flashlight is indispensable for star parties. The red mode is gentle on the eyes, and the power bank feature is super handy. Love it!', '4.5'),
+        ('LS4PSXUNUM', 'camper_chris', 'Rugged and versatile, this flashlight is great for camping and night walks. The hand warmer function is a game-changer on cold nights. Highly recommend.', '4.5'),
+        ('LS4PSXUNUM', 'emergency_kit', 'A fantastic multi-tool for my emergency kit. The red light is useful, and the power bank means I can charge my phone. Great design.', '4.0'),
+        ('LS4PSXUNUM', 'astro_accessory', 'Every astronomer needs one of these. The red light is essential, and the hand warmer and power bank make it incredibly useful. A top-tier accessory.', '5.0'),
+
+        ('9SIQT8TOJO', 'deep_sky_master', 'The RASA V2 is a dream come true for deep-sky imaging. The f/2.2 speed drastically cuts down exposure times. My best astrophotography investment yet.', '5.0'),
+        ('9SIQT8TOJO', 'pro_astro', 'Unbelievable performance for wide-field astrophotography. The short focal length makes guiding less critical. Produces stunning, detailed images.', '5.0'),
+        ('9SIQT8TOJO', 'imaging_guru', 'This OTA is a beast! The fast optics mean more data in less time. If you''re serious about deep-sky imaging, this is the one.', '4.5'),
+        ('9SIQT8TOJO', 'advanced_scope', 'Worth every penny for the quality and speed it offers. My images have never been sharper or more vibrant. A truly professional piece of equipment.', '5.0'),
+        ('9SIQT8TOJO', 'precision_optics', 'The engineering behind this RASA is exceptional. It''s incredibly efficient for capturing faint objects. A high-end choice for dedicated imagers.', '4.5'),
+
+        ('6E92ZMYYFZ', 'solar_safety', 'Essential for safe solar viewing with my 8-inch telescope. The Velcro straps ensure it stays securely in place. Peace of mind during solar observations.', '5.0'),
+        ('6E92ZMYYFZ', 'telescope_upgrade', 'This EclipSmart filter is a perfect addition to my setup. The ISO compliance is crucial. Highly recommend for anyone looking to view the sun safely.', '4.5'),
+        ('6E92ZMYYFZ', 'safe_sun_gazer', 'Easy to attach and provides crystal clear, safe views of the sun. The build quality is excellent. A must-have accessory for solar enthusiasts.', '5.0'),
+        ('6E92ZMYYFZ', 'filter_fan', 'Works perfectly with my 8-inch scope. No more worries about accidental dislodgement. Great product for protecting your eyes and equipment.', '4.5'),
+        ('6E92ZMYYFZ', 'eclipse_ready', 'Bought this for the upcoming eclipse, and it fits perfectly. Tested it out, and the views are fantastic and safe. Very happy with this purchase.', '5.0'),
+
+        ('HQTGWGPNH4', 'history_buff', 'A fascinating glimpse into historical astronomical thought. The content is incredibly insightful. A must-read for anyone interested in the history of science.', '5.0'),
+        ('HQTGWGPNH4', 'bookworm_astro', 'Beautifully presented historical document. It''s amazing to see how comets were understood centuries ago. A valuable addition to any astronomy library.', '4.5'),
+        ('HQTGWGPNH4', 'ancient_texts', 'Such a unique and intriguing read. The historical context is captivating. It offers a different perspective on celestial events.', '4.0'),
+        ('HQTGWGPNH4', 'celestial_history', 'I love historical astronomy, and this book delivers. It''s well-researched and provides a window into past beliefs. Highly recommended for scholars.', '5.0'),
+        ('HQTGWGPNH4', 'rare_find', 'A truly special book for enthusiasts of astronomical history. The details about ancient astrologers are very interesting. Great for a deeper understanding.', '4.5');
+
+    -- ============================================================
+    -- Recommendation Service: DBMon Cartesian Join Demo
+    -- ============================================================
+
+    -- Recommendation Service: create tables (public schema)
+    CREATE TABLE IF NOT EXISTS products (
+        id           SERIAL PRIMARY KEY,
+        product_id   VARCHAR(64) UNIQUE NOT NULL,
+        name         VARCHAR(255),
+        category     VARCHAR(64),
+        price        DECIMAL(10,2),
+        created_at   TIMESTAMP DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS product_tags (
+        id              SERIAL PRIMARY KEY,
+        product_id      VARCHAR(64) NOT NULL,
+        tag             VARCHAR(64),
+        relevance_score DECIMAL(4,3)
+    );
+
+    -- Recommendation Service: seed 5,000 products
+    INSERT INTO products (product_id, name, category, price)
+    SELECT 'prod_' || gs, 'Product ' || gs,
+           (ARRAY['telescope','eyepiece','mount','camera','filter'])[floor(random()*5+1)],
+           (random() * 2000 + 50)::DECIMAL
+    FROM generate_series(1, 5000) gs
+    ON CONFLICT (product_id) DO NOTHING;
+
+    -- Recommendation Service: seed 100,000 tags (~20 per product)
+    INSERT INTO product_tags (product_id, tag, relevance_score)
+    SELECT 'prod_' || gs,
+           (ARRAY['beginner','advanced','astrophotography','visual','planetary',
+                  'deepsky','portable','goto','wifi','budget'])[floor(random()*10+1)],
+           (random())::DECIMAL
+    FROM generate_series(1, 5000) gs, generate_series(1, 20);
+
+    -- DO NOT create indexes or run ANALYZE - we want worst-case execution plan
+
+    -- Recommendation Service: create application user with settings that force Nested Loop Cartesian
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'demo_app_user') THEN
+            CREATE ROLE demo_app_user WITH LOGIN PASSWORD 'demo_password';
+        END IF;
+    END
+    $$;
+
+    GRANT SELECT ON products TO demo_app_user;
+    GRANT SELECT ON product_tags TO demo_app_user;
+
+    -- Force worst-case execution plan for demo_app_user
+    ALTER ROLE demo_app_user SET work_mem = '64kB';
+    ALTER ROLE demo_app_user SET enable_hashjoin  = OFF;
+    ALTER ROLE demo_app_user SET enable_mergejoin = OFF;
+
+---
+
+# === postgresql ===
+# Kubernetes manifest for postgres (PostgreSQL database)
+# Extracted from opentelemetry-demo.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    name: tcp-service
+    targetPort: 5432
+  selector:
+    opentelemetry.io/name: postgresql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    opentelemetry.io/name: postgresql
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: postgresql
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: postgresql
+        splunk.com/postgresql.database: otel
+      labels:
+        opentelemetry.io/name: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/name: postgresql
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: postgresql
+        image: postgres:17.8
+        imagePullPolicy: IfNotPresent
+        args:
+          - "-c"
+          - "shared_preload_libraries=pg_stat_statements"
+          - "-c"
+          - "pg_stat_statements.track=all"
+        ports:
+        - containerPort: 5432
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: POSTGRES_USER
+          value: root
+        - name: POSTGRES_PASSWORD
+          value: otel
+        - name: POSTGRES_DB
+          value: otel
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 256Mi
+        volumeMounts:
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/00-pg-stat-statements.sh
+          subPath: 00-pg-stat-statements.sh
+          readOnly: true
+        - name: postgres-init
+          mountPath: /docker-entrypoint-initdb.d/init.sql
+          subPath: init.sql
+          readOnly: true
+      volumes:
+      - name: postgres-init
+        configMap:
+          name: postgres-init-sql
+          defaultMode: 0755
+
+---
+
+# === product-catalog ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for product-catalog
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 3 resource(s): Service, Deployment, and ConfigMap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: product-catalog
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-catalog
+  labels:
+    opentelemetry.io/name: product-catalog
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-catalog
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-catalog
+        app.kubernetes.io/component: product-catalog
+        app.kubernetes.io/name: product-catalog
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-catalog
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-catalog:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_CATALOG_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_RELOAD_INTERVAL
+          value: '10'
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: "host=postgresql user=otelu password=otelp dbname=otel sslmode=disable"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: GOMEMLIMIT
+          value: 200MiB
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            memory: 200Mi
+        volumeMounts:
+        - name: product-catalog-products
+          mountPath: /usr/src/app/products
+      volumes:
+      - name: product-catalog-products
+        configMap:
+          name: product-catalog-products
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-products
+  labels:
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  # yamllint disable rule:line-length
+  products.json: |
+    {
+      "products": [
+        {
+          "id": "OLJCESPC7Z",
+          "name": "National Park Foundation Explorascope",
+          "description": "The National Park Foundation's (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.",
+          "picture": "NationalParkFoundationExplorascope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 101,
+            "nanos": 960000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "66VCHSJNUP",
+          "name": "Starsense Explorer Refractor Telescope",
+          "description": "The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app's user-friendly interface and detailed tutorials. It's like having your own personal tour guide of the night sky",
+          "picture": "StarsenseExplorer.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 349,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "1YMWWN1N4O",
+          "name": "Eclipsmart Travel Refractor Telescope",
+          "description": "Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.",
+          "picture": "EclipsmartTravelRefractorTelescope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 129,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes",
+            "travel"
+          ]
+        },
+        {
+          "id": "L9ECAV7KIM",
+          "name": "Lens Cleaning Kit",
+          "description": "Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.",
+          "picture": "LensCleaningKit.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 21,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories"
+          ]
+        },
+        {
+          "id": "2ZYFJ3GM2N",
+          "name": "Roof Binoculars",
+          "description": "This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It's an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.",
+          "picture": "RoofBinoculars.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 209,
+            "nanos": 950000000
+          },
+          "categories": [
+            "binoculars"
+          ]
+        },
+        {
+          "id": "0PUK6V6EV0",
+          "name": "Solar System Color Imager",
+          "description": "You have your new telescope and have observed Saturn and Jupiter. Now you're ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.",
+          "picture": "SolarSystemColorImager.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 175,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "LS4PSXUNUM",
+          "name": "Red Flashlight",
+          "description": "This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red's rugged, IPX4-rated design will withstand your everyday activities.",
+          "picture": "RedFlashlight.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 57,
+            "nanos": 80000000
+          },
+          "categories": [
+            "accessories",
+            "flashlights"
+          ]
+        },
+        {
+          "id": "9SIQT8TOJO",
+          "name": "Optical Tube Assembly",
+          "description": "Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today's top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won't need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.",
+          "picture": "OpticalTubeAssembly.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 3599,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes",
+            "assembly"
+          ]
+        },
+        {
+          "id": "6E92ZMYYFZ",
+          "name": "Solar Filter",
+          "description": "Enhance your viewing experience with EclipSmart Solar Filter for 8\" telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.",
+          "picture": "SolarFilter.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 69,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "HQTGWGPNH4",
+          "name": "The Comet Book",
+          "description": "A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as \"Comets and their General and Particular Meanings, According to Ptolomé, Albumasar, Haly, Aliquind and other Astrologers\". The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)",
+          "picture": "TheCometBook.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 0,
+            "nanos": 990000000
+          },
+          "categories": [
+            "books"
+          ]
+        }
+      ]
+    }
+
+---
+
+# === product-reviews ===
+# Kubernetes manifest for product-reviews
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3551
+    name: tcp-service
+    targetPort: 3551
+  selector:
+    opentelemetry.io/name: product-reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-reviews
+  labels:
+    opentelemetry.io/name: product-reviews
+    app.kubernetes.io/component: product-reviews
+    app.kubernetes.io/name: product-reviews
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: product-reviews
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: product-reviews
+        app.kubernetes.io/component: product-reviews
+        app.kubernetes.io/name: product-reviews
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: product-reviews
+        image: ghcr.io/splunk/opentelemetry-demo/otel-product-reviews:2.0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3551
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: PRODUCT_REVIEWS_PORT
+          value: '3551'
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
+          value: 'span_only'
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: 'gen_ai_latest_experimental'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: DB_CONNECTION_STRING
+          value: host=postgresql user=otelu password=otelp dbname=otel
+        - name: LLM_HOST
+          value: llm
+        - name: LLM_PORT
+          value: '8000'
+        - name: LLM_BASE_URL
+          value: http://llm:8000/v1
+        - name: LLM_MODEL
+          value: astronomy-llm
+        - name: OPENAI_API_KEY
+          value: dummy
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === quote ===
+# Kubernetes manifest for quote
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: quote
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quote
+  labels:
+    opentelemetry.io/name: quote
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: quote
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: quote
+        app.kubernetes.io/component: quote
+        app.kubernetes.io/name: quote
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: quote
+        image: ghcr.io/open-telemetry/demo:2.2.0-quote
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: QUOTE_PORT
+          value: '8080'
+        - name: OTEL_PHP_AUTOLOAD_ENABLED
+          value: 'true'
+        - name: OTEL_PHP_INTERNAL_METRICS_ENABLED
+          value: 'true'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 40Mi
+        securityContext:
+          runAsGroup: 33
+          runAsNonRoot: true
+          runAsUser: 33
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === recommendation ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for recommendation
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: recommendation
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendation
+  labels:
+    opentelemetry.io/name: recommendation
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: recommendation
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: recommendation
+        app.kubernetes.io/component: recommendation
+        app.kubernetes.io/name: recommendation
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: recommendation
+        image: ghcr.io/splunk/opentelemetry-demo/otel-recommendation:2.0.5
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: RECOMMENDATION_PORT
+          value: '8080'
+        - name: PRODUCT_CATALOG_ADDR
+          value: product-catalog:8080
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: 'true'
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+        - name: FLAGD_HOST
+          value: flagd
+        - name: FLAGD_PORT
+          value: '8013'
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+          value: '750'
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'true'
+        # PostgreSQL connection for DBMon Cartesian demo
+        - name: POSTGRES_HOST
+          value: "postgresql"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          value: "otel"
+        - name: POSTGRES_USER
+          value: "demo_app_user"
+        - name: POSTGRES_PASSWORD
+          value: "demo_password"
+        resources:
+          limits:
+            memory: 500Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === shipping ===
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for shipping
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: shipping
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  labels:
+    opentelemetry.io/name: shipping
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: shipping
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: shipping
+        app.kubernetes.io/component: shipping
+        app.kubernetes.io/name: shipping
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: shipping
+        image: ghcr.io/open-telemetry/demo:2.2.0-shipping
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: SHIPPING_PORT
+          value: '8080'
+        - name: QUOTE_ADDR
+          value: http://quote:8080
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        volumeMounts: null
+      volumes: null
+
+---
+
+# === sql-server-fraud-setup ===
+# Kubernetes manifest for SQL Server setup
+# Includes secrets and initialization script for MSSQL
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secrets
+type: Opaque
+stringData:
+  SA_PASSWORD: ChangeMe_SuperStrong123!
+  DB_CONNECTION_STRING: Server=tcp:sql-server-fraud.astronomy-shop.svc.cluster.local,1433;Database=FraudDetection;User
+    Id=sa;Password=ChangeMe_SuperStrong123!;Encrypt=True;TrustServerCertificate=True
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mssql-init-script
+data:
+  init-db.sql: |
+    IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'FraudDetection')
+    BEGIN
+      CREATE DATABASE FraudDetection;
+    END
+    GO
+
+---
+
+# === sql-server-fraud ===
+# Kubernetes manifest for sql-server-fraud
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sql-server-fraud
+spec:
+  type: ClusterIP
+  ports:
+  - port: 1433
+    targetPort: 1433
+    protocol: TCP
+    name: tds
+  selector:
+    app: sql-server-fraud
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sql-server-fraud
+spec:
+  serviceName: sql-server-fraud
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  selector:
+    matchLabels:
+      app: sql-server-fraud
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: sqlserver
+        splunk.com/sqlserver.database: fraud
+      labels:
+        app: sql-server-fraud
+    spec:
+      containers:
+      - name: mssql
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 1433
+          name: tds
+        env:
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: MSSQL_PID
+          value: Express
+        - name: SA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mssql-secrets
+              key: SA_PASSWORD
+        volumeMounts:
+        - name: data
+          mountPath: /var/opt/mssql
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - 'sleep 30
+
+                /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}"
+                -C -i /docker-entrypoint-initdb.d/init-db.sql
+
+                '
+        resources:
+          requests:
+            cpu: 250m
+            memory: 1Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+        readinessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 1433
+          initialDelaySeconds: 30
+          periodSeconds: 20
+      volumes:
+      - name: init-script
+        configMap:
+          name: mssql-init-script
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+
+---
+
+# === valkey-cart ===
+# Kubernetes manifest for valkey-cart
+# Auto-generated from opentelemetry-demo.yaml
+# Contains 2 resource(s)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    name: valkey-cart
+    targetPort: 6379
+  selector:
+    opentelemetry.io/name: valkey-cart
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-cart
+  labels:
+    opentelemetry.io/name: valkey-cart
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: otel-fields-fix
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: valkey-cart
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: valkey-cart
+        app.kubernetes.io/component: valkey-cart
+        app.kubernetes.io/name: valkey-cart
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: valkey-cart
+        image: valkey/valkey:9.0.2-alpine3.23
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: valkey-cart
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=otel-fields-fix,service.kafka=no
+        resources:
+          limits:
+            memory: 20Mi
+        securityContext:
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts: null
+      volumes: null
+
+---

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -13,6 +13,19 @@ clusterReceiver:
   # Disabled eventsEnabled and k8s_objects - these generate non-HEC data
   # that gets refused by Splunk Platform endpoints
   eventsEnabled: true
+  # Bump from 500Mi/200m — pod was OOM-restarting under export back-pressure
+  # (memorylimiter soft=450Mi vs pod limit=500Mi had only 50Mi headroom).
+  # 149 restarts in 14d on dev-astronomy traced to signalfx/HEC exporter
+  # timeouts back-pressuring the pipeline. Chart does not expose liveness/
+  # readiness probe tuning — if restarts persist post-upgrade, patch
+  # deployment probes via kubectl after helm install.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 500Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
 
 agent:
   extraEnvs:

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -198,6 +198,18 @@ agent:
                   enabled: true
                 postgresql.connection.max:
                   enabled: true
+      receiver_creator/kafka:
+        watch_observers: [k8s_observer]
+        receivers:
+          kafka_metrics:
+            rule: type == "pod" && labels["app.kubernetes.io/component"] == "kafka"
+            config:
+              cluster_alias: kafka-${WORKSHOP_ENVIRONMENT}
+              brokers: ["`endpoint`:9092"]
+              scrapers:
+                - brokers
+                - topics
+                - consumers
     exporters:
       # Exports dbmon events as logs
       otlp_http/dbmon:
@@ -313,7 +325,7 @@ agent:
         metrics:
           exporters: [signalfx]
           processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
-          receivers: [host_metrics, kubeletstats, otlp, receiver_creator]
+          receivers: [host_metrics, kubeletstats, otlp, receiver_creator, receiver_creator/kafka]
         traces:
           # signalfx exporter removed from traces — chart 0.153.1 align.
           # OTLP alone is sufficient for trace correlation; dropping signalfx

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -315,7 +315,11 @@ agent:
           processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
           receivers: [host_metrics, kubeletstats, otlp, receiver_creator]
         traces:
-          exporters: [signalfx, otlp_http]
+          # signalfx exporter removed from traces — chart 0.153.1 align.
+          # OTLP alone is sufficient for trace correlation; dropping signalfx
+          # here reduces load on the exporter currently timing out under
+          # back-pressure on the cluster-receiver.
+          exporters: [otlp_http]
           processors: [memory_limiter, filter/drop_flagd, transform/dc_not_error, k8s_attributes, batch, resourcedetection, resource, resource/add_environment]
           receivers: [otlp, jaeger, zipkin]
         # DBMon logs pipeline - sends query samples and top queries to Splunk O11y

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -214,9 +214,14 @@ agent:
       # Inject environment as a resource attribute for traces
       resource/add_environment:
         attributes:
+          # `insert` (not `upsert`): only inject WORKSHOP_ENVIRONMENT when the
+          # service hasn't set deployment.environment itself. Services like
+          # planning and report-generator set their own variant suffix
+          # (e.g. ${WORKSHOP_ENV}-lambda, ${WORKSHOP_ENV}-throttle-demo) and
+          # were getting clobbered by upsert.
           - key: deployment.environment
             value: ${WORKSHOP_ENVIRONMENT}
-            action: upsert
+            action: insert
       filter/drop_flagd:
         traces:
           span:

--- a/planning-lambda/Planning_Init_Lambda/lambda_function.py
+++ b/planning-lambda/Planning_Init_Lambda/lambda_function.py
@@ -49,6 +49,25 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     Returns:
         API Gateway response.
     """
+    # Parse body up front so extract_env can inspect its "env" field
+    # before any span/log emission that would inherit the ContextVar default.
+    body = event.get("body", "{}")
+    body_parse_failed = False
+    if isinstance(body, str):
+        try:
+            body = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            body_parse_failed = True
+            body = {"raw": body}
+
+    # Extract per-invocation env (from body, ClientContext, SNS, or HTTP header)
+    # and set the ContextVar FIRST so every subsequent log/span carries the
+    # correct deployment.environment for gateway routing.
+    env_raw = extract_env(body if isinstance(body, dict) else {}, context)
+    if env_raw == "unknown":
+        env_raw = extract_env(event, context)
+    set_current_env(env_raw)
+
     # Extract parent trace context from incoming headers
     parent_context = extract_context(event)
 
@@ -81,26 +100,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         parent_context=parent_context
     ) as span:
         try:
-            # Parse body
-            body = event.get("body", "{}")
-            if isinstance(body, str):
-                try:
-                    body = json.loads(body) if body else {}
-                except json.JSONDecodeError:
-                    logger.warning("Failed to parse request body as JSON")
-                    body = {"raw": body}
+            if body_parse_failed:
+                logger.warning("Failed to parse request body as JSON")
 
             span.set_attribute("request.body_size", len(json.dumps(body)))
 
-            # Extract per-invocation env (from body, ClientContext, SNS, or HTTP header)
-            # and stamp on root span so gateway collector can route by env.
-            env_raw = extract_env(body if isinstance(body, dict) else {}, context)
-            if env_raw == "unknown":
-                # Fall back to the full event for non-body sources (ClientContext, SNS).
-                env_raw = extract_env(event, context)
-            # Stash on the ContextVar so the OTLP log handler stamps each
-            # log record with this env for gateway routing.
-            set_current_env(env_raw)
             env_tagged = stamp_env(span, env_raw)
 
             # Log request info

--- a/planning-lambda/Planning_Init_Lambda/samconfig.toml
+++ b/planning-lambda/Planning_Init_Lambda/samconfig.toml
@@ -9,7 +9,7 @@ resolve_s3 = true
 s3_prefix = "splunk-astronomy-planning"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "Stage=\"planning\" OtelCollectorEndpoint=\"\""
+parameter_overrides = "Stage=\"planning\" OtelCollectorEndpoint=\"http://10.0.134.189:4317\""
 image_repositories = []
 
 [default.build.parameters]

--- a/planning-lambda/Planning_Init_Lambda/template.yaml
+++ b/planning-lambda/Planning_Init_Lambda/template.yaml
@@ -18,6 +18,9 @@ Globals:
       Variables:
         LOG_LEVEL: INFO
         OTEL_SERVICE_NAME: Planning_Init_Lambda
+        # Default Resource attr for pre-handler / unknown-env records; per-record
+        # deployment.environment set by the handler wins after set_current_env().
+        OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=unknown-lambda"
         # Set OTEL_EXPORTER_OTLP_ENDPOINT to send traces to your collector
         # OTEL_EXPORTER_OTLP_ENDPOINT: http://your-collector:4317
 

--- a/planning-lambda/shared/lambda_client.py
+++ b/planning-lambda/shared/lambda_client.py
@@ -16,7 +16,7 @@ from .tracing import create_span, inject_context
 from .logging import get_logger
 from .env import for_invoke, STAMPED_ATTR, tag as tag_env
 
-logger = get_logger(__name__)
+logger = get_logger()
 
 # Lambda client with retry configuration
 _lambda_client = None

--- a/planning-lambda/shared/otel_logs.py
+++ b/planning-lambda/shared/otel_logs.py
@@ -93,6 +93,11 @@ def init_log_exporter(service_name: str) -> Optional[LoggingHandler]:
     if not endpoint:
         return None
 
+    # OTEL_SERVICE_NAME env var is the spec-governed source of service identity;
+    # the caller-provided arg is a fallback only. Prevents accidental hijack
+    # when a caller passes __name__ (e.g. a shared utility module).
+    service_name = os.getenv("OTEL_SERVICE_NAME", service_name)
+
     resource = Resource.create({
         "service.name": service_name,
         "service.namespace": "opentelemetry-demo",

--- a/planning-lambda/shared/otel_metrics.py
+++ b/planning-lambda/shared/otel_metrics.py
@@ -45,6 +45,8 @@ def init_meter(service_name: str) -> metrics.Meter:
     if _meter is not None:
         return _meter
 
+    service_name = os.getenv("OTEL_SERVICE_NAME", service_name)
+
     endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     if not endpoint:
         # Fall back to the no-op default global meter.

--- a/planning-lambda/shared/tracing.py
+++ b/planning-lambda/shared/tracing.py
@@ -52,7 +52,7 @@ def init_tracer(service_name: str = None) -> trace.Tracer:
     if _tracer is not None:
         return _tracer
 
-    service_name = service_name or os.getenv("OTEL_SERVICE_NAME", "planning-lambda")
+    service_name = os.getenv("OTEL_SERVICE_NAME", service_name or "planning-lambda")
 
     # Create resource with service info
     resource = Resource.create({

--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -112,7 +112,7 @@
         "on": true,
         "off": false
       },
-      "defaultVariant": "off"
+      "defaultVariant": "on"
     },
     "paymentUnreachable": {
       "description": "Payment service is unavailable",
@@ -172,7 +172,7 @@
         "on": true,
         "off": false
       },
-      "defaultVariant": "off"
+      "defaultVariant": "on"
     },
     "secureappAttack": {
       "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",


### PR DESCRIPTION
## Summary

For 2.0.6, flip two demo flags to default `on` so the scenarios they showcase are visible immediately on a fresh deploy without manual toggling via flagd-ui.

### Flags changed (in `src/flagd/demo.flagd.json`)

| Flag | Before | After |
|---|---|---|
| `rumBlueGreen` | `off` | `on` |
| `recommendationCartesianQuery` | `off` | `on` |

### Why

- **`rumBlueGreen`** — payment path A/B (`user.deployment_type` attribute) is the headline RUM scenario; defaulting off means a fresh deploy shows no A/B split until someone flips the flag.
- **`recommendationCartesianQuery`** — DBMon 12s Cartesian-join demo (500M-row intermediate, correct results but slow). Defaulting off means the slow-query story is invisible on fresh deploys.

Both flags remain user-toggleable via flagd-ui (state stays `ENABLED`).

## Test plan

- [ ] `helm install` on a clean cluster → verify `user.deployment_type` shows A/B split in RUM out of the box
- [ ] Same deploy → verify recommendation service produces 12s+ Postgres queries (visible in DBMon Top Queries)
- [ ] Toggle each flag to `off` via flagd-ui → confirm scenario disappears