### PR TITLE
v2.0.6-2: payment profiling + fraud semconv + collector strip + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ test/tracetesting/tracetesting-vars.yaml
 !src/currency/build
 
 planning-lambda/Planning_Init/.aws-sam/*
+planning-lambda/Planning_Init_Lambda/.aws-sam/*
 
 # Generated/stitched Kubernetes manifests (attached to GitHub Releases instead)
 kubernetes/splunk-astronomy-shop-*.yaml

--- a/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.5-values.yaml
@@ -234,6 +234,19 @@ agent:
           - key: deployment.environment
             value: ${WORKSHOP_ENVIRONMENT}
             action: insert
+      # Strip verbose/duplicative resource attrs on metrics pipeline so
+      # SignalFx exporter stays under its 36-dimension cap. Recommendation
+      # (Python OTel SDK) emits otel.sdk.* metrics with 37 dims → drops.
+      # Keep container.id (queried). service.kafka is demo-only tag; low value.
+      resource/strip_verbose:
+        attributes:
+          - {action: delete, key: process.runtime.description}
+          - {action: delete, key: process.executable.path}
+          - {action: delete, key: process.command_line}
+          - {action: delete, key: process.command_args}
+          - {action: delete, key: process.parent_pid}
+          - {action: delete, key: process.owner}
+          - {action: delete, key: service.kafka}
       filter/drop_flagd:
         traces:
           span:
@@ -324,7 +337,7 @@ agent:
       pipelines:
         metrics:
           exporters: [signalfx]
-          processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
+          processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, resource/strip_verbose, transform/dbmon]
           receivers: [host_metrics, kubeletstats, otlp, receiver_creator, receiver_creator/kafka]
         traces:
           # signalfx exporter removed from traces — chart 0.153.1 align.

--- a/src/fraud-detection/fraud-detection-k8s.yaml
+++ b/src/fraud-detection/fraud-detection-k8s.yaml
@@ -56,6 +56,12 @@ spec:
           value: 'false'
         - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
           value: 'true'
+        # Emit both legacy `db.system=mssql` and new
+        # `db.system.name=microsoft.sql_server` (stable semconv v1.30+).
+        # Drop `/dup` -> `database` once DBMon dashboards fully consume the
+        # new attribute.
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: database/dup
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.1.3,service.kafka=propagation
         - name: SQL_SERVER_HOST

--- a/src/payment/payment-vA-k8s.yaml
+++ b/src/payment/payment-vA-k8s.yaml
@@ -127,9 +127,13 @@ spec:
         - name: SPLUNK_METRICS_ENABLED
           value: "true"
         - name: SPLUNK_PROFILER_ENABLED
-          value: "false"
+          value: "true"
         - name: SPLUNK_PROFILER_MEMORY_ENABLED
-          value: "false"
+          value: "true"
+        # @splunk/otel v4 profiler ignores OTEL_EXPORTER_OTLP_PROTOCOL and
+        # always uses OTLP-HTTP; force it at 4318 since traces use gRPC 4317.
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
 
         # Logging
         - name: OTEL_LOG_LEVEL

--- a/src/payment/payment-vB-k8s.yaml
+++ b/src/payment/payment-vB-k8s.yaml
@@ -127,9 +127,13 @@ spec:
         - name: SPLUNK_METRICS_ENABLED
           value: "true"
         - name: SPLUNK_PROFILER_ENABLED
-          value: "false"
+          value: "true"
         - name: SPLUNK_PROFILER_MEMORY_ENABLED
-          value: "false"
+          value: "true"
+        # @splunk/otel v4 profiler ignores OTEL_EXPORTER_OTLP_PROTOCOL and
+        # always uses OTLP-HTTP; force it at 4318 since traces use gRPC 4317.
+        - name: SPLUNK_PROFILER_LOGS_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4318
 
         # Logging (more verbose for version B)
         - name: OTEL_LOG_LEVEL


### PR DESCRIPTION
## Summary

Rebuild of PR #253 on top of current main (which now includes #254 + #255). PR #253 became unmergeable due to overlapping changes on payment/collector values files; this branch cherry-picks the 4 clean commits onto latest main.

### Commits

- **chore**: broaden gitignore for `planning-lambda/Planning_Init_Lambda/.aws-sam/*` (currently only `build.toml` ignored)
- **fix(fraud-detection)**: opt-in stable DB semconv (`OTEL_SEMCONV_STABILITY_OPT_IN=database/dup`) — dual-emit legacy `db.system=mssql` + stable `db.system.name=microsoft.sql_server`
- **fix(collector)**: add `resource/strip_verbose` processor to **2.0.5-values.yaml** metrics pipeline (7 attrs) — fixes SignalFx 36-dim cap drops on Python OTel SDK metrics
- **fix(payment)**: enable CPU + memory profiling on vA/vB; explicit `SPLUNK_PROFILER_LOGS_ENDPOINT` pinned to port 4318 (Splunk @otel v4 profiler always OTLP-HTTP; without this it hits gRPC 4317 → "Expected HTTP/, RTSP/ or ICE/" parser errors)

### Relationship to 2.0.6-values.yaml

The `2.0.6-values.yaml` file (created in PR #254) already ships a 14-attr strip_verbose (extended after live testing on dev-astronomy — Python HTTP server metrics needed 7 more attrs beyond the original 7). This PR only adds the 7-attr version to the older `2.0.5-values.yaml` so anyone still on that chart benefits.

Supersedes #253.

## Test plan

- [ ] fraud-detection JDBC spans emit both `db.system=mssql` and `db.system.name=microsoft.sql_server` in APM
- [ ] Collector (2.0.5) no longer drops Python SDK datapoints with "number of dimensions is larger than 36"
- [ ] payment vA/vB profiling data appears in Splunk APM AlwaysOn Profiling; no `Expected HTTP/` parser errors in pod logs
- [ ] git status clean of `Planning_Init_Lambda/.aws-sam/` untracked files