### PR TITLE
fix(fraud-detection): bump Gradle 9.4.0 -> 9.6.1 (CVE-2026-3505 bcpg 1.84)

### DIFF
--- a/src/fraud-detection/gradle/wrapper/gradle-wrapper.properties
+++ b/src/fraud-detection/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## CVE-2026-3505 — Bouncy Castle OpenPGP APIs (bcpg)

**FOSSA ticket:** vuln-84836
**Origin path:** src/fraud-detection/build.gradle.kts
**Severity:** HIGH

## Root cause

bcpg is **not declared** in build.gradle.kts. It's bundled inside the **Gradle wrapper distribution**:
- Gradle 9.4.0 → bcpg-jdk18on **1.81** (vulnerable, range \`[1.81, 1.81.1)\`)
- Gradle 9.6.1 → bcpg-jdk18on **1.84** (safe, in remediation set >= 1.84)

Runtime exposure = zero. bcpg is used only by Gradle's OpenPGP signing tooling at build time; it is not on the application runtime classpath and is not shipped in the container image. FOSSA flags it because the wrapper distribution is scanned as an OSS dep of the repo.

## Change

Bump wrapper 9.4.0 -> 9.6.1 in \`src/fraud-detection/gradle/wrapper/gradle-wrapper.properties\`. Also adds \`distributionSha256Sum\` for integrity verification of the wrapper download.

## Verification

- Gradle 9.6.1 bcpg version confirmed by inspecting the official distribution zip:
\`\`\`
unzip -l gradle-9.6.1-bin.zip | grep bcpg
  gradle-9.6.1/lib/plugins/bcpg-jdk18on-1.84.jar
\`\`\`
- 1.84 satisfies CVE-2026-3505 remediation set (>= 1.84).

## Follow-up (not in this PR)

Same class of vuln likely affects:
- \`src/ad/gradle/wrapper\` (also on 9.4.0, bcpg 1.81)
- \`src/shop-dc-shim/gradle/wrapper\` (8.12.1, bcpg 1.78.1 — vulnerable via \`[1.74, 1.80.2)\`)

If FOSSA opens tickets for those, apply the same wrapper bump.