### PR TITLE
fix(react-native-app): override @remix-run/server-runtime to ^2.17.5 (CVE-2026-42342)

### DIFF
--- a/src/react-native-app/package-lock.json
+++ b/src/react-native-app/package-lock.json
@@ -7187,21 +7187,21 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
-      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.5.tgz",
+      "integrity": "sha512-SyJ5n2pQyo4ERGvjjLvL2PpRWBzlC2qzO5KkkOE2ygOiNcgOu9WQnnom9GI8KgsTRCO8JnIeLHFRcmxZnVBjfw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
+        "@remix-run/router": "1.23.3",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.7.2",

--- a/src/react-native-app/package.json
+++ b/src/react-native-app/package.json
@@ -89,6 +89,7 @@
     "postcss": "^8.5.10",
     "lodash": "^4.18.0",
     "fast-xml-parser": "^5.7.0",
-    "@xmldom/xmldom": "^0.8.13"
+    "@xmldom/xmldom": "^0.8.13",
+    "@remix-run/server-runtime": "^2.17.5"
   }
 }


### PR DESCRIPTION
## CVE-2026-42342 — @remix-run/server-runtime DoS via unbounded path expansion

**FOSSA ticket:** vuln-84609
**Origin path:** \`src/react-native-app/package-lock.json\`
**Severity:** HIGH
**Current:** 2.17.4 (transitive via @remix-run/node)
**Remediation:** 2.17.5

## Change

Add \`"@remix-run/server-runtime": "^2.17.5"\` to \`overrides\` in \`src/react-native-app/package.json\`. npm regenerates the lockfile with a single flattened entry at 2.17.5.

## Verification

\`\`\`
$ grep -A1 "node_modules/@remix-run/server-runtime\\\"" package-lock.json
  "node_modules/@remix-run/server-runtime": {
    "version": "2.17.5",
\`\`\`