### PR TITLE
fix(services): flip secureapp-loadgen-{node,python} manifest to true

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -219,7 +219,7 @@ services:
     manifest_file: src/secureapp-loadgen/unified-v2/secureapp-loadgen-k8s.yaml
   - name: secureapp-loadgen-node
     build: true
-    manifest: false  # shares manifest_file with secureapp-loadgen-java
+    manifest: true  # shares manifest_file with secureapp-loadgen-java; stitcher dedupes
     group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
@@ -227,7 +227,7 @@ services:
     manifest_file: src/secureapp-loadgen/unified-v2/secureapp-loadgen-k8s.yaml
   - name: secureapp-loadgen-python
     build: true
-    manifest: false  # shares manifest_file with secureapp-loadgen-java
+    manifest: true  # shares manifest_file with secureapp-loadgen-java; stitcher dedupes
     group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile


### PR DESCRIPTION
## Root cause of 2.0.6 release fix commit

When cutting 2.0.6, the release/2.0.6 branch needed a manual sed to fix 3 image tags in \`src/secureapp-loadgen/unified-v2/secureapp-loadgen-k8s.yaml\` — the pipeline had left them all at 2.0.5.

The workflow's manifest update step iterates services with \`manifest: true\`. Only \`secureapp-loadgen-java\` was set to true; \`node\` + \`python\` were \`manifest: false\` on the theory that they shared the manifest_file. Result: only java's image name was passed to \`update-manifest-images.py\`, and even that appears to have not landed in this run (needs separate pipeline debugging).

## Fix

Flip both node + python to \`manifest: true\`. Each still points at the same \`manifest_file\`, and:

- **stitcher** dedupe assoc-array (\`STITCHED_MANIFESTS\` in \`stitch-manifests.sh\`) already emits the shared manifest only once — no double-stitching.
- **update-manifest-images.py** now runs 3x per release, once per svc name. Each invocation carries its own \`image_name\` (\`otel-secureapp-loadgen-{java,node,python}\`), and the scoped regex targets only that per-lang image line in the shared file. All 3 lines get bumped automatically.

## Verification for next release

- 2.0.7 build should update all 3 secureapp image tags in the shared manifest without any manual sed.
- Stitched \`-secureapp\` manifest should contain each Deployment/Service exactly once (no duplication from the 3 svcs pointing at one file).