### PR TITLE
fix(collector-2.0.7): sqlserver receiver hardening per Splunk DBMon doc

### DIFF
--- a/kubernetes/splunk-astronomy-shop-2.0.7-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.7-values.yaml
@@ -71,6 +71,8 @@ agent:
               resource_attributes:
                 sqlserver.instance.name:
                   enabled: true
+                sqlserver.computer.name:
+                  enabled: true
               events:
                 db.server.query_sample:
                   enabled: true
@@ -116,13 +118,15 @@ agent:
             config:
               collection_interval: 10s
               top_query_collection:
-                lookback_time: 120s
+                lookback_time: 300s
               username: sa
               password: "ChangeMe_SuperStrong123!"
               server: '`host`'
               port: 1433
               resource_attributes:
                 sqlserver.instance.name:
+                  enabled: true
+                sqlserver.computer.name:
                   enabled: true
               events:
                 db.server.query_sample:


### PR DESCRIPTION
Follow-up to #272 (2.0.7 values). Compared sqlserver receiver blocks against https://help.splunk.com/en/splunk-observability-cloud/monitor-databases/get-data-in/configure-receivers/microsoft-sql-server-receiver and closed 2 gaps:

1. **`sqlserver.computer.name: enabled: true`** added on both receivers (was missing). Doc recommends enabling; helps identify host in DBMon Databases panel.
2. **`top_query_collection.lookback_time` aligned to 300s** on both receivers (fraud was 120s, shopshim was 300s). More inclusive top-query window.

## Deferred (demo-acceptable)

- `sa` credentials — doc recommends non-admin user with `VIEW SERVER STATE` (pre-2022) or `VIEW SERVER PERFORMANCE STATE` (2022+) only.
- Plaintext passwords in values file — should move to `secretKeyRef` in a later hardening pass.