### PR TITLE
chore(services): drop group: secureapp from sidecar-only entries

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -221,7 +221,6 @@ services:
   - name: secureapp-loadgen-java
     build: true
     manifest: false  # sidecar lives in ad-k8s.yaml, not standalone
-    group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
     build_target: java
@@ -232,7 +231,6 @@ services:
   - name: secureapp-loadgen-node
     build: true
     manifest: false  # sidecar lives in frontend-k8s.yaml
-    group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
     build_target: node
@@ -240,7 +238,6 @@ services:
   - name: secureapp-loadgen-python
     build: true
     manifest: false  # sidecar lives in recommendation-k8s.yaml
-    group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
     build_target: python


### PR DESCRIPTION
Follow-up to #271 (sidecar model) + #274 (sidecar manifest_file). With all 3 secureapp svcs at `manifest: false`, the group label was a no-op — `get-services.py --group secureapp` filters by `manifest: true` so returns empty, stitcher produces no `-secureapp.yaml`. Remove the ghost label. No functional change. **Hold merge until user validates 2.0.7-beta deploys correctly with sidecar model.**