### PR TITLE
fix(updater): always scope image regex to image_name

### DIFF
--- a/.github/scripts/update-manifest-images.py
+++ b/.github/scripts/update-manifest-images.py
@@ -79,17 +79,16 @@ def update_manifest_image(service, registry, image_name, version):
             f"src/{service}/payment-vB-k8s.yaml",
             f"src/{service}/{service}-k8s.yaml",
         ]
-        results = [_patch_file(p, new_image) for p in targets]
+        results = [_patch_file(p, new_image, image_name=image_name) for p in targets]
         return any(results)
 
-    # Shared manifest_file case: multiple svcs point at one file (e.g.
-    # secureapp-loadgen-*). Scope the sed to the specific image_name so
-    # sibling deployments aren't clobbered.
+    # Scope every sedge by image_name so sibling images in the same
+    # manifest (main container + sidecar containers) are not clobbered.
+    # Applies to both the manifest_file override case (shared file, e.g.
+    # sidecar in target's own manifest) AND the default per-svc path.
     override = _lookup_manifest_file(service)
-    if override:
-        return _patch_file(override, new_image, image_name=image_name)
-
-    return _patch_file(f"src/{service}/{service}-k8s.yaml", new_image)
+    target = override or f"src/{service}/{service}-k8s.yaml"
+    return _patch_file(target, new_image, image_name=image_name)
 
 def main():
     if len(sys.argv) != 5:

--- a/services.yaml
+++ b/services.yaml
@@ -221,7 +221,6 @@ services:
   - name: secureapp-loadgen-java
     build: true
     manifest: false  # sidecar lives in ad-k8s.yaml, not standalone
-    group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
     build_target: java
@@ -232,7 +231,6 @@ services:
   - name: secureapp-loadgen-node
     build: true
     manifest: false  # sidecar lives in frontend-k8s.yaml
-    group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
     build_target: node
@@ -240,7 +238,6 @@ services:
   - name: secureapp-loadgen-python
     build: true
     manifest: false  # sidecar lives in recommendation-k8s.yaml
-    group: secureapp
     platform: "linux/amd64"
     dockerfile: src/secureapp-loadgen/unified-v2/Dockerfile
     build_target: python


### PR DESCRIPTION
2.0.7-beta build failure fix. `ad` sedge was clobbering both main + sidecar image lines with `otel-ad:...`, so the subsequent `secureapp-loadgen-java` sedge found no matching line and errored. Force scoped-by-image_name regex on all paths (both manifest_file override and default).