### PR TITLE
fix(secureapp-sidecar): honor SERVER_PORT env in python + java sidecars

### DIFF
--- a/src/ad/ad-k8s.yaml
+++ b/src/ad/ad-k8s.yaml
@@ -151,6 +151,7 @@ spec:
         - name: JAVA_TOOL_OPTIONS
           value: >-
             -javaagent:/app/splunk-otel-javaagent.jar
+            -Dserver.port=8180
             -Dargento.allow.security.events=true
             -Dargento.wait.events.for.first.transaction=false
         - name: LOADGEN_ENABLED

--- a/src/secureapp-loadgen/unified-v2/apps/python-secureapp-loadgen/gunicorn.conf.py
+++ b/src/secureapp-loadgen/unified-v2/apps/python-secureapp-loadgen/gunicorn.conf.py
@@ -1,7 +1,10 @@
 """Gunicorn configuration for SecureApp Python datagen.
 """
+import os
 
-bind = "0.0.0.0:8080"
+# Read SERVER_PORT env so the container can bind to a non-default port
+# when deployed as a sidecar alongside a service that already uses 8080.
+bind = f"0.0.0.0:{os.environ.get('SERVER_PORT', '8080')}"
 workers = 1
 threads = 4
 timeout = 120


### PR DESCRIPTION
Sidecar deployment broke ad (java sidecar) and recommendation (python sidecar) — both ignored SERVER_PORT and bound to default 8080, colliding with target container. Verified live on dev-astronomy 2.0.7-beta. Python: gunicorn.conf.py hardcoded 8080; now reads SERVER_PORT. Java: uses JVM system property, add -Dserver.port=8180 to JAVA_TOOL_OPTIONS. Node was already fine. Python needs image rebuild (2.0.8 or a hotfix).