### PR TITLE
fix(secureapp-java): honor SERVER_PORT in entrypoint health probe

### DIFF
--- a/src/secureapp-loadgen/java-only-v1/entrypoint.sh
+++ b/src/secureapp-loadgen/java-only-v1/entrypoint.sh
@@ -12,7 +12,8 @@ JAVA_PID=$!
 # Wait for the app to become healthy
 echo "Waiting for health check..."
 retries=0
-until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
+HEALTH_PORT="${SERVER_PORT:-8080}"
+until curl -sf "http://localhost:${HEALTH_PORT}/health" > /dev/null 2>&1; do
   retries=$((retries + 1))
   if [ $retries -ge 60 ]; then
     echo "ERROR: App failed to start after 120s"

--- a/src/secureapp-loadgen/unified-v2/apps/java-secureapp-loadgen/entrypoint.sh
+++ b/src/secureapp-loadgen/unified-v2/apps/java-secureapp-loadgen/entrypoint.sh
@@ -12,7 +12,8 @@ JAVA_PID=$!
 # Wait for the app to become healthy
 echo "Waiting for health check..."
 retries=0
-until curl -sf http://localhost:8080/health > /dev/null 2>&1; do
+HEALTH_PORT="${SERVER_PORT:-8080}"
+until curl -sf "http://localhost:${HEALTH_PORT}/health" > /dev/null 2>&1; do
   retries=$((retries + 1))
   if [ $retries -ge 60 ]; then
     echo "ERROR: App failed to start after 120s"


### PR DESCRIPTION
## Summary
- entrypoint.sh health probe was hardcoded to `http://localhost:8080/health`; after PR #277 moved the sidecar to `-Dserver.port=8180`, the probe never succeeded and the initContainer aborted after 120s
- fix reads `SERVER_PORT` env with fallback `8080`, matching the port the JVM actually binds to
- applied to both entrypoint variants (`java-only-v1/` and `unified-v2/apps/java-secureapp-loadgen/`)

## Impact observed
Workshop v2.0.7-beta: `ad` pod stuck in `Init:CrashLoopBackOff` with **563 sidecar restarts in 2 days**. Main ad container unaffected (native-sidecar pattern keeps main up when sidecar dies), but the noise is real.

## Requires
Rebuild of `ghcr.io/splunk/opentelemetry-demo/otel-secureapp-loadgen-java` image (no-cache) and republish `2.0.7-beta` tag.

## Test plan
- [ ] Rebuild java secureapp image
- [ ] Restart ad pod on workshop; confirm 2/2 Running with 0 sidecar restarts sustained > 5 min
- [ ] Confirm sidecar logs show "App is healthy." instead of "App failed to start after 120s"