### PR TITLE
fix(accounting): make ORDER_VALIDATION_ADDR default unset

### DIFF
--- a/src/accounting/accounting-k8s.yaml
+++ b/src/accounting/accounting-k8s.yaml
@@ -73,13 +73,10 @@ spec:
         - name: DB_CONNECTION_STRING
           value: Host=postgresql;Username=otelu;Password=otelp;Database=otel
         # Optional fire-and-forget call to order-validation (throttle-demo).
-        # Safe to leave set even when throttle-demo manifest is not applied:
-        # DNS NXDOMAIN / connection refused / timeout all swallowed by
-        # TriggerValidation, which also enforces a 120s HttpClient timeout
-        # (covers the slowest validation tier).
-        # To disable entirely, unset.
-        - name: ORDER_VALIDATION_ADDR
-          value: http://order-validation:8080
+        # Disabled by default (unset). To enable, set to the service URL
+        # e.g. http://order-validation:8080 — throttle-demo manifest deploys
+        # that service. When set but service absent, TriggerValidation
+        # swallows DNS NXDOMAIN / connection refused / timeout (120s cap).
         - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
           value: 'false'
         - name: OTEL_RESOURCE_ATTRIBUTES


### PR DESCRIPTION
## Summary
- base manifest hardcoded `ORDER_VALIDATION_ADDR=http://order-validation:8080` so every accounting deploy attempted the fire-and-forget call
- when the throttle-demo manifest is not applied the service does not exist, causing NXDOMAIN on every Kafka consume (silently swallowed, but wasteful and unexpected)
- CLAUDE.md already says "empty/unset disables" — the default now matches that

## Follow-up (separate PR)
`throttle-demo` variant stitching should inject `ORDER_VALIDATION_ADDR` on accounting when it deploys order-validation. Otherwise operators applying throttle-demo won't see the call actually happen.

## Test plan
- [ ] Verify accounting starts cleanly without the env
- [ ] Verify TriggerValidation short-circuits when addr is unset (no calls made)
- [ ] Once throttle-demo injection is in place, verify the call resumes end-to-end