### PR TITLE
fix(astronomy-loadgen): wait-for-frontend init also honors workshop-secret

### DIFF
--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -407,11 +407,21 @@ spec:
       initContainers:
       - name: wait-for-frontend
         image: curlimages/curl:8.1.2
+        env:
+        # Same source-of-truth as the main container: prefer public URL
+        # from workshop-secret; fall back to in-cluster ingress when absent.
+        - name: RUM_FRONTEND_IP
+          valueFrom:
+            secretKeyRef:
+              name: workshop-secret
+              key: url
+              optional: true
         command: ['sh', '-c']
         args:
         - |
-          echo "Waiting for frontend-proxy to be ready..."
-          until curl -f --connect-timeout 5 --max-time 10 http://frontend-proxy:8080; do
+          TARGET="${RUM_FRONTEND_IP:-http://frontend-proxy:8080}"
+          echo "Waiting for ${TARGET} to be ready..."
+          until curl -f -k --connect-timeout 5 --max-time 10 "${TARGET}"; do
             echo "Frontend not ready, waiting 10 seconds..."
             sleep 10
           done


### PR DESCRIPTION
## Summary
Follow-up to #280. Main container now picks `RUM_FRONTEND_IP` from `workshop-secret.url`, but the `wait-for-frontend` init container still hardcoded `http://frontend-proxy:8080`.

Consequences on public-URL deployments:
- Init probes internal DNS while main container drives the public origin — readiness gate can pass in scenarios the loadgen would fail (or vice versa)
- End-to-end "is the ingress reachable?" check is bypassed

## Fix
- Init reads the same `RUM_FRONTEND_IP` `secretKeyRef` (`optional: true`)
- Computes `TARGET` at runtime, probes that URL
- Falls back to `http://frontend-proxy:8080` when the secret is absent (matches main container `buildBaseUrl` fallback)
- Added `-k` to curl so self-signed certs on internal ingresses don't break the probe

## Test plan
- [ ] Deployment with `workshop-secret.url=https://workshop.splunko11y.com` → init logs `Waiting for https://workshop.splunko11y.com/ to be ready...` and succeeds
- [ ] Deployment without `workshop-secret` → init falls back to `http://frontend-proxy:8080`, no regression