### PR TITLE
feat(release): attach values.yaml to GitHub release assets

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -125,6 +125,12 @@ jobs:
             [ -f "$MFILE" ] && ASSETS="$ASSETS $MFILE"
           done
 
+          # Also attach the helm values.yaml for this version so
+          # `helm upgrade --install ... -f splunk-astronomy-shop-${VERSION}-values.yaml`
+          # can be scripted straight from the release assets.
+          VALUES_FILE="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
+          [ -f "$VALUES_FILE" ] && ASSETS="$ASSETS $VALUES_FILE"
+
           # Delete existing beta pre-release for this version if it exists
           if gh release view "${TAG}-beta" &>/dev/null; then
             echo "Cleaning up beta pre-release..."

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -571,6 +571,14 @@ jobs:
             [ -f "$MFILE" ] && ASSETS="$ASSETS $MFILE"
           done
 
+          # Also attach the helm values.yaml for this version so
+          # `helm upgrade --install ... -f splunk-astronomy-shop-${VERSION}-values.yaml`
+          # can be scripted straight from the release assets. The
+          # earlier "Ensure values.yaml exists" step guarantees the
+          # file is present (cloned from previous version if new).
+          VALUES_FILE="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
+          [ -f "$VALUES_FILE" ] && ASSETS="$ASSETS $VALUES_FILE"
+
           # Delete existing pre-release if regenerating
           if gh release view "v${VERSION}" &>/dev/null; then
             echo "Replacing existing pre-release v${VERSION}..."


### PR DESCRIPTION
## Summary
- Both the beta pre-release path (`prod-release.yml`) and the GA release path (`create-release-tag.yml`) currently attach only stitched manifests to the GitHub release
- Adds the corresponding helm `values.yaml` for the version to the same asset bundle so operators can pull manifests + values from one place

```
gh release download v2.0.7 -p '*.yaml'
helm upgrade --install splunk-otel-collector ... \
  -f splunk-astronomy-shop-2.0.7-values.yaml
```

## No selection logic needed
The existing "Ensure values.yaml exists for this version" step in `update-and-release` guarantees the file is always present at release time — cloned from the previous version if a fresh file is not committed for the new version. So the added code just picks up whatever is there.

## Test plan
- [ ] Beta build via `prod-release.yml` beta=true → `v2.0.7-beta` release asset list includes `splunk-astronomy-shop-2.0.7-beta-values.yaml`
- [ ] GA path (merge release PR → `create-release-tag.yml`) → `v2.0.7` release asset list includes `splunk-astronomy-shop-2.0.7-values.yaml`