### PR TITLE
fix(flagd): default 3 flags to off to match live EU state

### DIFF
--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -8,7 +8,7 @@
         "on": true,
         "off": false
       },
-      "defaultVariant": "on"
+      "defaultVariant": "off"
     },
     "llmInaccurateResponse": {
       "defaultVariant": "off",
@@ -112,7 +112,7 @@
         "on": true,
         "off": false
       },
-      "defaultVariant": "on"
+      "defaultVariant": "off"
     },
     "paymentUnreachable": {
       "description": "Payment service is unavailable",
@@ -172,7 +172,7 @@
         "on": true,
         "off": false
       },
-      "defaultVariant": "on"
+      "defaultVariant": "off"
     },
     "secureappAttack": {
       "description": "Controls secureapp loadgen pace. Minimal spreads vuln probes across ~2 days. Max fires all attacks aggressively every few minutes.",


### PR DESCRIPTION
## Summary
Compared the `flagd-config` ConfigMap on **astronomy-shop-eu** against the live flagd Resolve endpoint. 16/19 flags agreed. Three diverged — someone toggled them off via `/feature/` at some point, and runtime edits don't persist back to the CM.

| Flag | CM was | Live is | New CM default |
|---|---|---|---|
| `orderValidationThrottle` | `on` | `off` | `off` |
| `rumBlueGreen` | `on` | `off` | `off` |
| `recommendationCartesianQuery` | `on` | `off` | `off` |

## Why now
Every redeploy of the CM re-enabled these three, then someone flipped them off again. Locking the source default to match the intended live behaviour ends the ping-pong.

## Effect after merge
- `orderValidationThrottle=off` → order-validation returns precomputed stub. k8s CPU-throttle demo dormant unless flipped on for a specific demo.
- `rumBlueGreen=off` → RUM `deployment.type=green` attribute not set. A/B payment story off.
- `recommendationCartesianQuery=off` → old Cartesian bad-query demo dormant. Ring-graph guardian in fraud-detection is the replacement story.

## Test plan
- [ ] Merge → regenerate 2.0.7 manifests → apply to EU → confirm CM defaults match live state