### PR TITLE
feat(release): attach values.yaml in prod-build-manifest workflow too

### DIFF
--- a/.github/workflows/prod-build-manifest.yml
+++ b/.github/workflows/prod-build-manifest.yml
@@ -303,6 +303,13 @@ jobs:
             [ -f "$MFILE" ] && ASSETS="$ASSETS $MFILE"
           done
 
+          # Also attach the helm values.yaml for this version so
+          # `helm upgrade --install ... -f splunk-astronomy-shop-${VERSION}-values.yaml`
+          # can be scripted from the release assets. Mirrors the
+          # equivalent step in prod-release.yml / create-release-tag.yml.
+          VALUES_FILE="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
+          [ -f "$VALUES_FILE" ] && ASSETS="$ASSETS $VALUES_FILE"
+
           # Delete existing release if regenerating
           if gh release view "$TAG" &>/dev/null; then
             echo "Replacing existing release $TAG..."


### PR DESCRIPTION
## Summary
PR #282 added values.yaml attachment to `prod-release.yml` (beta path) and `create-release-tag.yml` (GA merge path). Missed **`prod-build-manifest.yml`** — the standalone workflow used for re-stitching manifests without a code change (e.g. after a flagd default flip).

Confirmed by running the manifest-only rebuild for `v2.0.7` after PR #285 merged: release assets refreshed but `values.yaml` dropped, needed manual re-upload.

## Fix
Same 3-line block. Every code path that publishes to a release now keeps values.yaml attached.

## Test plan
- [ ] Trigger `prod-build-manifest.yml` with `publish_release=true` for any existing version → confirm `splunk-astronomy-shop-<VERSION>-values.yaml` in release assets