### PR TITLE
fix(promote): treat values.yaml as first-class release asset

### DIFF
--- a/.github/scripts/stage-values-with-header.sh
+++ b/.github/scripts/stage-values-with-header.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copy the git-tracked values.yaml into a staging dir with a version header
+# prepended. The git-tracked file in kubernetes/ stays untouched; the header
+# only lands on the release asset copy.
+#
+# Usage: stage-values-with-header.sh <VERSION> [STAGING_DIR]
+# Prints the staged file path on stdout (empty if source values.yaml missing).
+#
+# Header is YAML `#` comments so helm / kubectl ignore it.
+
+set -e
+
+VERSION="${1:?VERSION required}"
+STAGING_DIR="${2:-release-staging}"
+
+SRC="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
+
+if [ ! -f "$SRC" ]; then
+  echo "stage-values-with-header: no values file at $SRC — skipping" >&2
+  exit 0
+fi
+
+mkdir -p "$STAGING_DIR"
+DEST="${STAGING_DIR}/$(basename "$SRC")"
+
+GIT_SHA_SHORT="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+GIT_SHA_SHORT="${GIT_SHA_SHORT:0:7}"
+GEN_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+{
+  echo "# splunk-astronomy-shop helm values"
+  echo "# Version:    ${VERSION}"
+  echo "# Generated:  ${GEN_TS}"
+  echo "# Source:     ${SRC} @ ${GIT_SHA_SHORT}"
+  echo "#"
+  echo "# Deploy:"
+  echo "#   helm upgrade --install splunk-otel-collector \\"
+  echo "#     splunk-otel-collector-chart/splunk-otel-collector \\"
+  echo "#     -f splunk-astronomy-shop-${VERSION}-values.yaml"
+  echo "#"
+  cat "$SRC"
+} > "$DEST"
+
+echo "$DEST"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -81,6 +81,7 @@ jobs:
           OUTPUT_DIR="kubernetes"
 
           chmod +x .github/scripts/stitch-manifests.sh
+          chmod +x .github/scripts/stage-values-with-header.sh
 
           echo "Stitching regular manifest..."
           .github/scripts/stitch-manifests.sh prod "" "$OUTPUT_DIR" ""
@@ -128,8 +129,10 @@ jobs:
           # Also attach the helm values.yaml for this version so
           # `helm upgrade --install ... -f splunk-astronomy-shop-${VERSION}-values.yaml`
           # can be scripted straight from the release assets.
-          VALUES_FILE="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
-          [ -f "$VALUES_FILE" ] && ASSETS="$ASSETS $VALUES_FILE"
+          # Version header is prepended to the release-asset copy (source
+          # in kubernetes/ stays untouched).
+          STAGED_VALUES=$(.github/scripts/stage-values-with-header.sh "$VERSION")
+          [ -n "$STAGED_VALUES" ] && [ -f "$STAGED_VALUES" ] && ASSETS="$ASSETS $STAGED_VALUES"
 
           # Delete existing beta pre-release for this version if it exists
           if gh release view "${TAG}-beta" &>/dev/null; then

--- a/.github/workflows/prod-build-manifest.yml
+++ b/.github/workflows/prod-build-manifest.yml
@@ -82,6 +82,7 @@ jobs:
           chmod +x .github/scripts/manage-hotfix.py
           chmod +x .github/scripts/bump-version.py
           chmod +x .github/scripts/show-image-versions.py
+          chmod +x .github/scripts/stage-values-with-header.sh
 
       - name: Ensure single-version mode (remove per-service test versions)
         run: |
@@ -307,8 +308,10 @@ jobs:
           # `helm upgrade --install ... -f splunk-astronomy-shop-${VERSION}-values.yaml`
           # can be scripted from the release assets. Mirrors the
           # equivalent step in prod-release.yml / create-release-tag.yml.
-          VALUES_FILE="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
-          [ -f "$VALUES_FILE" ] && ASSETS="$ASSETS $VALUES_FILE"
+          # Version header is prepended to the release-asset copy (source
+          # in kubernetes/ stays untouched).
+          STAGED_VALUES=$(.github/scripts/stage-values-with-header.sh "$VERSION")
+          [ -n "$STAGED_VALUES" ] && [ -f "$STAGED_VALUES" ] && ASSETS="$ASSETS $STAGED_VALUES"
 
           # Delete existing release if regenerating
           if gh release view "$TAG" &>/dev/null; then

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -344,6 +344,7 @@ jobs:
           chmod +x .github/scripts/show-image-versions.py
           chmod +x .github/scripts/stitch-manifests.sh
           chmod +x .github/scripts/get-services.py
+          chmod +x .github/scripts/stage-values-with-header.sh
 
       - name: Save current version before bump
         id: old-version
@@ -575,9 +576,11 @@ jobs:
           # `helm upgrade --install ... -f splunk-astronomy-shop-${VERSION}-values.yaml`
           # can be scripted straight from the release assets. The
           # earlier "Ensure values.yaml exists" step guarantees the
-          # file is present (cloned from previous version if new).
-          VALUES_FILE="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
-          [ -f "$VALUES_FILE" ] && ASSETS="$ASSETS $VALUES_FILE"
+          # source file is present (cloned from previous version if new).
+          # Version header is prepended to the release-asset copy (source
+          # in kubernetes/ stays untouched).
+          STAGED_VALUES=$(.github/scripts/stage-values-with-header.sh "$VERSION")
+          [ -n "$STAGED_VALUES" ] && [ -f "$STAGED_VALUES" ] && ASSETS="$ASSETS $STAGED_VALUES"
 
           # Delete existing pre-release if regenerating
           if gh release view "v${VERSION}" &>/dev/null; then

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -77,13 +77,14 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "SCOPE=${SCOPE}" >> $GITHUB_ENV
 
-          # Values file lives in the repo
-          VALUES="kubernetes/splunk-astronomy-shop-${VERSION}-values.yaml"
-          echo "VALUES=${VALUES}" >> $GITHUB_ENV
-
-          # Manifest filenames (downloaded from release assets)
+          # Manifest + values filenames (downloaded from release assets)
           DOWNLOAD_DIR="release-assets"
           echo "DOWNLOAD_DIR=${DOWNLOAD_DIR}" >> $GITHUB_ENV
+
+          # Values file also comes from release assets (attached by
+          # prod-build-manifest / create-release-tag / prod-release).
+          VALUES="${DOWNLOAD_DIR}/splunk-astronomy-shop-${VERSION}-values.yaml"
+          echo "VALUES=${VALUES}" >> $GITHUB_ENV
 
           echo "MANIFEST=${DOWNLOAD_DIR}/splunk-astronomy-shop-${VERSION}.yaml" >> $GITHUB_ENV
           echo "MANIFEST_DIAB=${DOWNLOAD_DIR}/splunk-astronomy-shop-${VERSION}-diab.yaml" >> $GITHUB_ENV
@@ -125,7 +126,10 @@ jobs:
           echo "✅ Release \`v${VERSION}\` found" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Download all manifest assets from the release
+          # Download all manifest + values assets from the release.
+          # Pattern matches both `splunk-astronomy-shop-<ver>.yaml`,
+          # `splunk-astronomy-shop-<ver>-{diab,lambda,dc-shim,...}.yaml`,
+          # and `splunk-astronomy-shop-<ver>-values.yaml`.
           echo "Downloading assets from release v${VERSION}..."
           gh release download "v${VERSION}" \
             --pattern "splunk-astronomy-shop-*.yaml" \
@@ -140,7 +144,8 @@ jobs:
             "splunk-astronomy-shop-${VERSION}-lambda.yaml" \
             "splunk-astronomy-shop-${VERSION}-dc-shim.yaml" \
             "splunk-astronomy-shop-${VERSION}-secureapp.yaml" \
-            "splunk-astronomy-shop-${VERSION}-throttle-demo.yaml"; do
+            "splunk-astronomy-shop-${VERSION}-throttle-demo.yaml" \
+            "splunk-astronomy-shop-${VERSION}-values.yaml"; do
             if [ -f "${DOWNLOAD_DIR}/${FILE}" ]; then
               echo "| \`${FILE}\` | ✅ Downloaded |" >> $GITHUB_STEP_SUMMARY
             else
@@ -149,24 +154,24 @@ jobs:
           done
           echo "" >> $GITHUB_STEP_SUMMARY
 
-      - name: Verify values.yaml exists (required)
+      - name: Verify values.yaml downloaded (required)
         run: |
           echo "### Values File Check" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ -f "$VALUES" ]; then
-            echo "✅ **Values file found:** \`$VALUES\`" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Values file downloaded:** \`$VALUES\`" >> $GITHUB_STEP_SUMMARY
           else
-            echo "::error::Values file not found: $VALUES"
-            echo "❌ **Values file NOT found:** \`$VALUES\`" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Values file not found in release: $VALUES"
+            echo "❌ **Values file NOT found in release v${VERSION}:** \`$(basename "$VALUES")\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**The values.yaml file is required for promotion.**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Please ensure the file exists in \`kubernetes/\` before running this workflow." >> $GITHUB_STEP_SUMMARY
+            echo "Ensure the release has the values file attached (prod-build-manifest / create-release-tag / prod-release all attach it)." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Available files in kubernetes/:" >> $GITHUB_STEP_SUMMARY
+            echo "Assets currently in \`$DOWNLOAD_DIR\`:" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            ls -la kubernetes/ 2>/dev/null || echo "Directory not found" >> $GITHUB_STEP_SUMMARY
+            ls -la "$DOWNLOAD_DIR" 2>/dev/null || echo "Directory not found" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi


### PR DESCRIPTION
## Summary

Two-part change to make `values.yaml` a first-class release asset — attached at build time with a self-identifying header, consumed by promote from release assets (not from the git tree).

**Write side (`prod-build-manifest`, `create-release-tag`, `prod-release`):**
- New helper `.github/scripts/stage-values-with-header.sh` copies the git-tracked `kubernetes/splunk-astronomy-shop-<ver>-values.yaml` into a staging dir with a `#`-comment header (version, generation timestamp, source path, git SHA)
- Helm + kubectl ignore YAML comments, so no behavior change on deploy
- Git-tracked file stays untouched; only the release asset carries the header

**Read side (`promote`):**
- `VALUES` env var now points into `release-assets/` (same dir as manifests)
- Existing `--pattern "splunk-astronomy-shop-*.yaml"` download picks the values file up for free
- Verify step + summary updated to reflect release-asset provenance

## Why
Previously `promote.yml` read `kubernetes/splunk-astronomy-shop-<ver>-values.yaml` straight from the checked-out repo — silently picked up whatever was on the source branch at promote time, not what shipped with the release. Re-promoting an older release could deploy wrong values.

Both `prod-build-manifest` and `create-release-tag` already attached the raw values file. This PR adds provenance (header) at attach time and swaps promote to read from the release, closing the loop.

## Header sample
```yaml
# splunk-astronomy-shop helm values
# Version:    2.0.7
# Generated:  2026-07-30T12:45:43Z
# Source:     kubernetes/splunk-astronomy-shop-2.0.7-values.yaml @ 7851bc3
#
# Deploy:
#   helm upgrade --install splunk-otel-collector \
#     splunk-otel-collector-chart/splunk-otel-collector \
#     -f splunk-astronomy-shop-2.0.7-values.yaml
#
clusterReceiver:
  ...
```

## Test plan
- [ ] Trigger `prod-build-manifest` for v2.0.7 — verify header present at top of the attached values.yaml
- [ ] Re-promote v2.0.7 — verify "Values file downloaded" in workflow summary
- [ ] Regression: dry-run promote still succeeds
- [ ] Confirm PROD + DIAB + Workshop targets receive the header-carrying values.yaml