### PR TITLE
fix(frontend): session replay asset packing on HTTP workshops, pin RUM to v3.0.0

### DIFF
--- a/src/frontend/pages/_document.tsx
+++ b/src/frontend/pages/_document.tsx
@@ -125,9 +125,21 @@ export default class MyDocument extends Document<{ envString: string }> {
                         var features = isHttpWorkshop
                             ? { packAssets: { styles: true, images: true, fonts: false }, cacheAssets: true }
                             : { packAssets: { styles: true } };
+                        var rumVersion = 'unknown';
+                        try {
+                            // Version lives on the tracer provider's resource attributes,
+                            // not as a top-level SplunkRum property.
+                            var attrs = window.SplunkRum && window.SplunkRum.provider &&
+                                        window.SplunkRum.provider.resource &&
+                                        window.SplunkRum.provider.resource.attributes;
+                            if (attrs) rumVersion = attrs['splunk.rumVersionFull'] || attrs['splunk.rumVersion'] || 'unknown';
+                        } catch (e) { /* noop */ }
+                        var recorderSrc = 'unknown';
+                        var recorderScript = document.querySelector('script[src*="splunk-otel-web-session-recorder"]');
+                        if (recorderScript) recorderSrc = recorderScript.getAttribute('src');
                         console.log(
-                            '[splunk-rum] SplunkRum version:', (window.SplunkRum && window.SplunkRum.version) || 'unknown',
-                            '\\n[splunk-session-recorder] version:', (window.SplunkSessionRecorder && window.SplunkSessionRecorder.version) || 'unknown',
+                            '[splunk-rum] version:', rumVersion,
+                            '\\n[splunk-session-recorder] script:', recorderSrc,
                             '\\n[splunk-session-recorder] protocol:', loc.protocol, 'hostname:', loc.hostname,
                             '\\n[splunk-session-recorder] isHttpWorkshop:', isHttpWorkshop,
                             '\\n[splunk-session-recorder] features:', JSON.stringify(features)

--- a/src/frontend/pages/_document.tsx
+++ b/src/frontend/pages/_document.tsx
@@ -67,7 +67,7 @@ export default class MyDocument extends Document<{ envString: string }> {
           {/* Load user attributes generator - must load before RUM initialization */}
           <script src="/global-attributes.js"></script>
           <script
-              src="https://cdn.signalfx.com/o11y-gdi-rum/next/splunk-otel-web.js"
+              src="https://cdn.signalfx.com/o11y-gdi-rum/v3.0.0/splunk-otel-web.js"
               crossOrigin="anonymous"
           />
           <script
@@ -106,7 +106,7 @@ export default class MyDocument extends Document<{ envString: string }> {
               }}
           />
           <script
-              src="https://cdn.signalfx.com/o11y-gdi-rum/next/splunk-otel-web-session-recorder.js"
+              src="https://cdn.signalfx.com/o11y-gdi-rum/v3.0.0/splunk-otel-web-session-recorder.js"
               crossOrigin="anonymous"
           />
           <script
@@ -123,7 +123,18 @@ export default class MyDocument extends Document<{ envString: string }> {
                         // into the recording so replay renders without live fetch.
                         // Skip localhost — dev doesn't need the extra payload.
                         var features = isHttpWorkshop
-                            ? { packAssets: { styles: true, images: true, fonts: false }, cacheAssets: true }
+                            ? {
+                                packAssets: {
+                                    styles: true,
+                                    fonts: false,
+                                    // Explicit object form: pack every image, not
+                                    // just the ones currently in the viewport, so
+                                    // above-the-fold hero images on the initial
+                                    // page load are also captured.
+                                    images: { pack: true, onlyViewportImages: false }
+                                },
+                                cacheAssets: true
+                              }
                             : { packAssets: { styles: true } };
                         var rumVersion = 'unknown';
                         try {

--- a/src/frontend/pages/_document.tsx
+++ b/src/frontend/pages/_document.tsx
@@ -113,24 +113,32 @@ export default class MyDocument extends Document<{ envString: string }> {
               id="splunk-session-recorder-init"
               dangerouslySetInnerHTML={{
                 __html: `
-                    SplunkSessionRecorder.init({
-                        realm: window.ENV.SPLUNK_RUM_REALM,
-                        rumAccessToken: window.ENV.SPLUNK_RUM_TOKEN,
-                        maskAllText: false,
+                    (function () {
+                        var loc = window.location;
+                        var isHttp = loc.protocol === 'http:';
+                        var isLocal = loc.hostname === 'localhost' || loc.hostname === '127.0.0.1';
+                        var isHttpWorkshop = isHttp && !isLocal;
                         // HTTP workshop instances serve images over HTTP; the HTTPS
                         // replay player blocks them as mixed content. Pack assets
                         // into the recording so replay renders without live fetch.
                         // Skip localhost — dev doesn't need the extra payload.
-                        features: (function () {
-                            var loc = window.location;
-                            var isHttp = loc.protocol === 'http:';
-                            var isLocal = loc.hostname === 'localhost' || loc.hostname === '127.0.0.1';
-                            var isHttpWorkshop = isHttp && !isLocal;
-                            return isHttpWorkshop
-                                ? { packAssets: { styles: true, images: true, fonts: false }, cacheAssets: true }
-                                : { packAssets: { styles: true } };
-                        })()
-                    });
+                        var features = isHttpWorkshop
+                            ? { packAssets: { styles: true, images: true, fonts: false }, cacheAssets: true }
+                            : { packAssets: { styles: true } };
+                        console.log(
+                            '[splunk-rum] SplunkRum version:', (window.SplunkRum && window.SplunkRum.version) || 'unknown',
+                            '\\n[splunk-session-recorder] version:', (window.SplunkSessionRecorder && window.SplunkSessionRecorder.version) || 'unknown',
+                            '\\n[splunk-session-recorder] protocol:', loc.protocol, 'hostname:', loc.hostname,
+                            '\\n[splunk-session-recorder] isHttpWorkshop:', isHttpWorkshop,
+                            '\\n[splunk-session-recorder] features:', JSON.stringify(features)
+                        );
+                        SplunkSessionRecorder.init({
+                            realm: window.ENV.SPLUNK_RUM_REALM,
+                            rumAccessToken: window.ENV.SPLUNK_RUM_TOKEN,
+                            maskAllText: false,
+                            features: features
+                        });
+                    })();
                 `,
               }}
           />

--- a/src/frontend/pages/_document.tsx
+++ b/src/frontend/pages/_document.tsx
@@ -116,7 +116,20 @@ export default class MyDocument extends Document<{ envString: string }> {
                     SplunkSessionRecorder.init({
                         realm: window.ENV.SPLUNK_RUM_REALM,
                         rumAccessToken: window.ENV.SPLUNK_RUM_TOKEN,
-                        maskAllText: false
+                        maskAllText: false,
+                        // HTTP workshop instances serve images over HTTP; the HTTPS
+                        // replay player blocks them as mixed content. Pack assets
+                        // into the recording so replay renders without live fetch.
+                        // Skip localhost — dev doesn't need the extra payload.
+                        features: (function () {
+                            var loc = window.location;
+                            var isHttp = loc.protocol === 'http:';
+                            var isLocal = loc.hostname === 'localhost' || loc.hostname === '127.0.0.1';
+                            var isHttpWorkshop = isHttp && !isLocal;
+                            return isHttpWorkshop
+                                ? { packAssets: { styles: true, images: true, fonts: false }, cacheAssets: true }
+                                : { packAssets: { styles: true } };
+                        })()
                     });
                 `,
               }}


### PR DESCRIPTION
## What

Fix Splunk RUM session replay on plain-HTTP workshop instances, and pin the RUM + session-recorder scripts to a fixed release.

All changes are in `src/frontend/pages/_document.tsx`.

## Why

On HTTP workshop deploys the HTTPS replay player blocks images as mixed content, so recorded sessions render without their assets. Packing the assets into the recording sidesteps the live cross-origin fetch. `next` was also floating the RUM script version, making replay behaviour non-reproducible across workshops.

## Changes

- **Pin RUM + session recorder to `v3.0.0`** — was `next` (floating). Reproducible replay behaviour across workshops.
- **Pack assets for session replay on HTTP workshops** — detect HTTP + non-localhost origin; enable `packAssets` (styles + all images, not just viewport) and `cacheAssets`. Localhost/dev keeps the light config (styles only) to avoid the extra payload.
- **Widen image packing** — explicit `images: { pack: true, onlyViewportImages: false }` so above-the-fold hero images on initial load are captured too.
- **Log resolved config** — print RUM version (read from tracer provider resource attributes `splunk.rumVersionFull` / `splunk.rumVersion`), recorder script src, protocol/hostname, workshop detection, and final `features` to console for field debugging.

## Test

Deployed to workshop instances; verified replay renders packed images over HTTP and the console logs the resolved version + feature config. Targeting inclusion in 2.0.8.
