### PR TITLE
early 2.0.8-changes

### DIFF
--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -465,7 +465,7 @@ agent:
       pipelines:
         metrics:
           exporters: [signalfx]
-          processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, resource/strip_verbose, transform/dbmon]
+          processors: [memory_limiter, k8s_attributes, batch, resource_detection, resource, resource/add_environment, resource/strip_verbose, transform/dbmon]
           receivers: [host_metrics, kubelet_stats, otlp, receiver_creator, receiver_creator/kafka]
         traces:
           # signalfx exporter removed from traces — chart 0.153.1 align.
@@ -473,12 +473,12 @@ agent:
           # here reduces load on the exporter currently timing out under
           # back-pressure on the cluster-receiver.
           exporters: [otlp_http]
-          processors: [memory_limiter, filter/drop_flagd, transform/dc_not_error, k8s_attributes, batch, resourcedetection, resource, resource/add_environment]
+          processors: [memory_limiter, filter/drop_flagd, transform/dc_not_error, k8s_attributes, batch, resource_detection, resource, resource/add_environment]
           receivers: [otlp, jaeger, zipkin]
         # DBMon logs pipeline - sends query samples and top queries to Splunk O11y
         logs/dbmon:
           receivers: [receiver_creator]
-          processors: [memory_limiter, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
+          processors: [memory_limiter, batch, resource_detection, resource, resource/add_environment, transform/dbmon]
           exporters: [otlp_http/dbmon]
         # SecureApp logs routing. otlp logs enter via logs/split, the
         # routing/logs connector splits scope=="secureapp" off to /v3/event,
@@ -488,7 +488,7 @@ agent:
         # mirror the chart default (splunk-otel-collector logs pipeline).
         logs:
           receivers: [file_log, routing/logs]
-          processors: [memory_limiter, k8s_attributes, filter/logs, batch, resourcedetection, resource, resource/logs, resource/add_environment]
+          processors: [memory_limiter, k8s_attributes, filter/logs, batch, resource_detection, resource, resource/logs, resource/add_environment]
           exporters: [splunk_hec/o11y, splunk_hec/platform_logs]
         logs/split:
           receivers: [otlp]

--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -75,6 +75,42 @@ data:
       return `https://${raw.replace(/\/+$/, '')}/`;
     }
 
+    // --- flagd feature flags via OFREP --------------------------------------
+    // flagd serves the OpenFeature Remote Evaluation Protocol over HTTP on
+    // port 8016 (see src/flagd/flagd-k8s.yaml). Node 24 has global fetch, so
+    // no OpenFeature SDK / gRPC deps are needed — one POST per flag. flagd
+    // returns the live value, so flipping a flag in flagd-ui is reflected on
+    // the next cycle with no loadgen restart. Disable with
+    // FLAGD_OFREP_ENABLED=false; override endpoint with FLAGD_OFREP_URL.
+    const FLAGD_OFREP_ENABLED = (process.env.FLAGD_OFREP_ENABLED || 'true').toLowerCase() !== 'false';
+    const FLAGD_OFREP_URL = (process.env.FLAGD_OFREP_URL || 'http://flagd:8016').replace(/\/+$/, '');
+
+    /**
+     * Evaluate a single flag via OFREP. Returns `def` on any failure (flagd
+     * unreachable, non-2xx, timeout, missing flag) so flag lookups never block
+     * or crash a load cycle.
+     */
+    async function getFlag(key, def) {
+      if (!FLAGD_OFREP_ENABLED) return def;
+      try {
+        const resp = await fetch(`${FLAGD_OFREP_URL}/ofrep/v1/evaluate/flags/${key}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ context: { targetingKey: 'rumloadgen' } }),
+          signal: AbortSignal.timeout(2000)
+        });
+        if (!resp.ok) {
+          if (debugEnabled) console.log(`[DEBUG] OFREP ${key}: HTTP ${resp.status}`);
+          return def;
+        }
+        const body = await resp.json();
+        return body.value !== undefined ? body.value : def;
+      } catch (e) {
+        if (debugEnabled) console.log(`[DEBUG] OFREP ${key} lookup failed: ${e.message}`);
+        return def;
+      }
+    }
+
     function getProductIds() {
       const envProductIds = (process.env.PRODUCT_IDS || '').trim();
       if (envProductIds) {
@@ -214,6 +250,16 @@ data:
         }
 
         const base = buildBaseUrl();
+
+        // Feature-flag check, run every cycle before product selection so a
+        // flagd-ui toggle takes effect on the very next loop. rumLoadGenPanicMode
+        // is the first test hook for the OFREP integration — real behaviour
+        // change comes later; for now it just proves live flag reactivity.
+        const panicMode = await getFlag('rumLoadGenPanicMode', false);
+        if (panicMode) {
+          console.log('🚨 rum-loadgen Panic mode is on!');
+        }
+
         const productsToOrder = getRandomProducts();
         const cycleCurrency = pickCurrency();
         console.log(`🛒 Ordering ${productsToOrder.length} product(s) in ${cycleCurrency}: ${productsToOrder.join(', ')}`);

--- a/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
+++ b/src/astronomy-loadgen/astronomy-loadgen-k8s.yaml
@@ -85,6 +85,19 @@ data:
     const FLAGD_OFREP_ENABLED = (process.env.FLAGD_OFREP_ENABLED || 'true').toLowerCase() !== 'false';
     const FLAGD_OFREP_URL = (process.env.FLAGD_OFREP_URL || 'http://flagd:8016').replace(/\/+$/, '');
 
+    // --- Panic path (angry rage-click) tuning -------------------------------
+    // When the rumLoadGenPanicMode flag is on, every Nth load cycle takes a
+    // DIFFERENT path: instead of placing an order, the browser rapidly clicks
+    // the intentionally-inert "Show All Reviews" button to mimic a frustrated
+    // user rage-clicking, then clicks away — driving RUM frustration / rage-
+    // click detection. Mirrors the Splunk Synthetics rage-click transaction.
+    // N is a fixed constant here for now; the intent is for it to come from the
+    // same flagd entry (rumLoadGenPanicMode variant value) in a later step.
+    const PANIC_EVERY_N_LOOPS = 10;      // take the angry path once every N cycles
+    const PANIC_RAGE_CLICKS = 6;         // clicks per rage burst (synthetics: 1 + 5 repeats)
+    const PANIC_RAGE_INTERVAL_MS = 80;   // gap between rage clicks (synthetics: 80ms)
+    let panicLoopCounter = 0;            // increments each cycle; angry path on multiples of N
+
     /**
      * Evaluate a single flag via OFREP. Returns `def` on any failure (flagd
      * unreachable, non-2xx, timeout, missing flag) so flag lookups never block
@@ -109,6 +122,35 @@ data:
         if (debugEnabled) console.log(`[DEBUG] OFREP ${key} lookup failed: ${e.message}`);
         return def;
       }
+    }
+
+    /**
+     * Angry rage-click path. Rapidly clicks the intentionally-inert "Show All
+     * Reviews" button (id btn-show-all-reviews, data-cy ShowAllReviews) to
+     * simulate a frustrated user, then clicks away to the recommendations
+     * section — the same sequence as the Splunk Synthetics rage-click test.
+     * Best-effort: missing elements are logged and skipped, never thrown.
+     */
+    async function rageClickReviews(page) {
+      const reviewBtn = "[data-cy='ShowAllReviews']";
+      try {
+        await page.waitForSelector(reviewBtn, { timeout: 8000, visible: true });
+      } catch {
+        console.log('⚠️ Panic path: "Show All Reviews" button not found, skipping rage clicks');
+        return;
+      }
+      console.log(`🚨 rum-loadgen Panic mode: rage-clicking "Show All Reviews" ${PANIC_RAGE_CLICKS}x @ ${PANIC_RAGE_INTERVAL_MS}ms`);
+      for (let i = 0; i < PANIC_RAGE_CLICKS; i++) {
+        await page.click(reviewBtn).catch(() => {});
+        await delay(PANIC_RAGE_INTERVAL_MS);
+      }
+      // Click away to the recommendations section, like the synthetics test.
+      const away = "[data-cy='recommendation-list']";
+      await page.waitForSelector(away, { timeout: 5000, visible: true })
+        .then(() => page.click(away))
+        .then(() => console.log('👋 Panic path: clicked away to recommendations'))
+        .catch(() => console.log('⚠️ Panic path: recommendations click-away skipped'));
+      await delay(1500); // let the RUM batcher flush the rage-click beacon
     }
 
     function getProductIds() {
@@ -251,13 +293,17 @@ data:
 
         const base = buildBaseUrl();
 
-        // Feature-flag check, run every cycle before product selection so a
-        // flagd-ui toggle takes effect on the very next loop. rumLoadGenPanicMode
-        // is the first test hook for the OFREP integration — real behaviour
-        // change comes later; for now it just proves live flag reactivity.
+        // Feature-flag check each cycle, before product selection, so a
+        // flagd-ui toggle takes effect on the very next loop. When
+        // rumLoadGenPanicMode is on, every PANIC_EVERY_N_LOOPS-th cycle takes
+        // the angry rage-click path instead of placing an order.
+        panicLoopCounter += 1;
         const panicMode = await getFlag('rumLoadGenPanicMode', false);
-        if (panicMode) {
-          console.log('🚨 rum-loadgen Panic mode is on!');
+        const angry = panicMode && (panicLoopCounter % PANIC_EVERY_N_LOOPS === 0);
+        if (angry) {
+          console.log(`🚨 rum-loadgen Panic mode: ANGRY rage-click path this cycle (loop #${panicLoopCounter}, every ${PANIC_EVERY_N_LOOPS})`);
+        } else if (panicMode) {
+          console.log(`rum-loadgen Panic mode on; normal path (loop #${panicLoopCounter}, angry every ${PANIC_EVERY_N_LOOPS})`);
         }
 
         const productsToOrder = getRandomProducts();
@@ -367,10 +413,24 @@ data:
             console.log('⏭️ Skipping quick prompts (next run in ' + Math.round((QUICK_PROMPT_INTERVAL_MS - (now - lastQuickPromptTime)) / 1000) + 's)');
           }
 
+          // Angry path: rage-click the reviews button on this product page and
+          // leave — no add-to-cart, no remaining products, no order this cycle.
+          if (angry) {
+            await rageClickReviews(page);
+            break;
+          }
+
           const addSel = "[data-cy='product-add-to-cart']";
           await page.waitForSelector(addSel);
           console.log(`🖱️ Clicking "Add To Cart" for product ${productId}`);
           await page.click(addSel);
+        }
+
+        // Angry cycles already rage-clicked and clicked away above — skip
+        // ordering entirely (the frustrated user never checks out).
+        if (angry) {
+          await fetchShippingInfo(page);
+          return;
         }
 
         // Place order after all products are added to cart

--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://flagd.dev/schema/v0/flags.json",
   "flags": {
+    "rumLoadGenPanicMode": {
+      "description": "RUM loadgen reacts to this flag each cycle. On = loadgen logs a panic-mode line (test hook for the flagd OFREP integration; real action TBD).",
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
     "orderValidationThrottle": {
       "description": "order-validation runs full CPU-bound compliance/audit path, exposing k8s CPU throttle scenario. Off returns precomputed stub.",
       "state": "ENABLED",

--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -2,7 +2,7 @@
   "$schema": "https://flagd.dev/schema/v0/flags.json",
   "flags": {
     "rumLoadGenPanicMode": {
-      "description": "RUM loadgen reacts to this flag each cycle. On = loadgen logs a panic-mode line (test hook for the flagd OFREP integration; real action TBD).",
+      "description": "RUM loadgen reacts to this flag each cycle via OFREP. On = every Nth load cycle (N fixed at 10 in the loadgen for now) takes an angry rage-click path: rapidly clicks the inert 'Show All Reviews' button then clicks away, no order — drives RUM frustration/rage-click detection. Off = normal order flow every cycle.",
       "state": "ENABLED",
       "variants": {
         "on": true,


### PR DESCRIPTION
Early loadgen changes staged for the 2.0.8 cycle. Adds live flagd reactivity to the RUM loadgen and a first behavioral hook off it.

## Commits
- **feat(loadgen): react to flagd `rumLoadGenPanicMode` via OFREP** — loadgen evaluates the flag each cycle over OpenFeature Remote Evaluation Protocol (HTTP POST to flagd:8016), no SDK/gRPC deps. Flipping the flag in flagd-ui takes effect on the next loop, no restart. Fails safe (returns default on any error). Toggle via `FLAGD_OFREP_ENABLED`, endpoint via `FLAGD_OFREP_URL`.
- **feat(loadgen): angry rage-click path every N loops on panic flag** — when panic mode is on, every Nth cycle takes an angry path instead of placing an order: rapidly rage-clicks the inert "Show All Reviews" button (6× @ 80ms, ~mirrors the Splunk Synthetics rage-click transaction), then clicks away to recommendations. Drives RUM frustration / rage-click detection.

## Notes
- Panic-mode `rumLoadGenPanicMode` flag defaults to `off`.
- Scope: `src/astronomy-loadgen/astronomy-loadgen-k8s.yaml` only.
- No image rebuild — loadgen logic is inline JS in the manifest.