### PR TITLE
feat(release): stage-values-with-header reuses an in-repo values header

### DIFF
--- a/.github/scripts/stage-values-with-header.sh
+++ b/.github/scripts/stage-values-with-header.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
-# Copy the git-tracked values.yaml into a staging dir with a version header
-# prepended. The git-tracked file in kubernetes/ stays untouched; the header
-# only lands on the release asset copy.
+# Copy the git-tracked values.yaml into a staging dir with release provenance
+# stamped into its header. The git-tracked file in kubernetes/ stays untouched;
+# the changes only land on the release asset copy.
 #
 # Usage: stage-values-with-header.sh <VERSION> [STAGING_DIR]
 # Prints the staged file path on stdout (empty if source values.yaml missing).
 #
-# Header is YAML `#` comments so helm / kubectl ignore it.
+# The in-repo values file carries a `# Version:` comment header (see the top of
+# kubernetes/splunk-astronomy-shop-*-values.yaml). When present, this script
+# stamps the release VERSION onto that line and injects Generated/Source
+# provenance right after it — reusing the existing header instead of prepending
+# a second one. Older values files without the header get a header prepended
+# (legacy behaviour). Header lines are YAML `#` comments, so helm/kubectl ignore
+# them.
 
 set -e
 
@@ -27,18 +33,34 @@ GIT_SHA_SHORT="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 GIT_SHA_SHORT="${GIT_SHA_SHORT:0:7}"
 GEN_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-{
-  echo "# splunk-astronomy-shop helm values"
-  echo "# Version:    ${VERSION}"
-  echo "# Generated:  ${GEN_TS}"
-  echo "# Source:     ${SRC} @ ${GIT_SHA_SHORT}"
-  echo "#"
-  echo "# Deploy:"
-  echo "#   helm upgrade --install splunk-otel-collector \\"
-  echo "#     splunk-otel-collector-chart/splunk-otel-collector \\"
-  echo "#     -f splunk-astronomy-shop-${VERSION}-values.yaml"
-  echo "#"
-  cat "$SRC"
-} > "$DEST"
+if grep -qE '^# Version:' "$SRC"; then
+  # Reuse the in-repo header: replace its `# Version:` line with the release
+  # version and add Generated/Source provenance immediately after it.
+  awk -v ver="$VERSION" -v ts="$GEN_TS" -v src="${SRC} @ ${GIT_SHA_SHORT}" '
+    /^# Version:/ && !done {
+      print "# Version:    " ver
+      print "# Generated:  " ts
+      print "# Source:     " src
+      done = 1
+      next
+    }
+    { print }
+  ' "$SRC" > "$DEST"
+else
+  # Legacy: source has no header — prepend one.
+  {
+    echo "# splunk-astronomy-shop helm values"
+    echo "# Version:    ${VERSION}"
+    echo "# Generated:  ${GEN_TS}"
+    echo "# Source:     ${SRC} @ ${GIT_SHA_SHORT}"
+    echo "#"
+    echo "# Deploy:"
+    echo "#   helm upgrade --install splunk-otel-collector \\"
+    echo "#     splunk-otel-collector-chart/splunk-otel-collector \\"
+    echo "#     -f splunk-astronomy-shop-${VERSION}-values.yaml"
+    echo "#"
+    cat "$SRC"
+  } > "$DEST"
+fi
 
 echo "$DEST"


### PR DESCRIPTION
## What
`stage-values-with-header.sh` prepends a version/provenance header to the values.yaml release asset. This teaches it to **reuse an in-repo header** when the source values file already carries one.

## Behaviour
- **Source file has a `# Version:` header** → stamp the release version onto that line and inject `Generated`/`Source` provenance right after it. One header, no duplication.
- **Source file has no header** (older versions) → prepend a full header, exactly as before.

Backward-compatible: for any values file that doesn't have the header today, the output is identical to the previous script. The in-repo source files are never modified — only the staged release-asset copy.

## Why
A follow-up change adds a self-documenting `# Version:`/usage header to the committed values files. Without this, the script would prepend a second header and the asset would carry two.