### PR TITLE
fix(secureapp): deliver attack/security events to SecureApp /v3/event

### DIFF
--- a/.github/scripts/stitch-manifests.sh
+++ b/.github/scripts/stitch-manifests.sh
@@ -154,11 +154,17 @@ stitch_service() {
     # The full tag is replaced wholesale by SERVICE_VERSION — no trailing capture group,
     # which previously caused double-suffix bugs (e.g., 2.0.1-beta-beta).
     if [ -n "$REGISTRY_URL" ] && [ "$SHOULD_REPLACE" = "true" ]; then
+        # Registry + pod-level version labels use the pod's SERVICE_VERSION;
+        # image tags are set per-image (apply_image_versions) so embedded
+        # sidecar images keep their own service version.
+        local TMP; TMP=$(mktemp)
         sed -e "s|ghcr.io/[^/]*/[^/]*|${REGISTRY_URL}|g" \
-            -e "s|\(${REGISTRY_URL}/[^:]*\):[0-9][0-9.]*[^[:space:]]*|\1:${SERVICE_VERSION}|" \
             -e "s|app.kubernetes.io/version: [0-9][0-9.]*[^\"[:space:]]*|app.kubernetes.io/version: ${SERVICE_VERSION}|g" \
             -e "s|service.version=[0-9][0-9.]*[^,[:space:]]*|service.version=${SERVICE_VERSION}|g" \
-            "$MANIFEST_FILE" >> "$OUT_FILE"
+            "$MANIFEST_FILE" > "$TMP"
+        apply_image_versions "$TMP"
+        cat "$TMP" >> "$OUT_FILE"
+        rm -f "$TMP"
     elif [ "$SHOULD_REPLACE" = "false" ]; then
         cat "$MANIFEST_FILE" >> "$OUT_FILE"
         echo "  (using original registry and versions)"
@@ -171,6 +177,31 @@ stitch_service() {
     echo "" >> "$OUT_FILE"
     echo "---" >> "$OUT_FILE"
     return 0
+}
+
+# ============================================================
+# Function: apply_image_versions
+# Retag each image line by the version of the service that image
+# belongs to (image name is otel-<service>). This ensures sidecar
+# images embedded in another pod's manifest (e.g. secureapp-loadgen-*
+# inside recommendation-k8s.yaml) get their OWN service version rather
+# than the host pod's — otherwise a single-service build retags the
+# sidecar to a tag that was never built (ImagePullBackOff).
+# Operates in place on an already registry-normalized file.
+# ============================================================
+apply_image_versions() {
+    local FILE="$1"
+    local IMG NAME V
+    for IMG in $(grep -oE "${REGISTRY_URL}/otel-[A-Za-z0-9._-]+:[0-9][0-9.]*[^[:space:]]*" "$FILE" \
+                 | sed -E 's|:[0-9].*$||' | sort -u); do
+        NAME="${IMG##*/otel-}"
+        V=$(get_service_version "$NAME")
+        # Escape regex-significant chars in the image path for the LHS.
+        local IMG_RE
+        IMG_RE=$(printf '%s' "$IMG" | sed -e 's/[.[\*^$/]/\\&/g')
+        sed -i.bak "s|\(${IMG_RE}\):[0-9][0-9.]*[^[:space:]]*|\1:${V}|g" "$FILE"
+        rm -f "${FILE}.bak"
+    done
 }
 
 # ============================================================
@@ -214,11 +245,14 @@ stitch_payment() {
         echo "# === $LABEL ===" >> "$OUT_FILE"
 
         if [ -n "$REGISTRY_URL" ] && [ "$SHOULD_REPLACE" = "true" ]; then
+            local TMP; TMP=$(mktemp)
             sed -e "s|ghcr.io/[^/]*/[^/]*|${REGISTRY_URL}|g" \
-                -e "s|\(${REGISTRY_URL}/[^:]*\):[0-9][0-9.]*[^[:space:]]*|\1:${SERVICE_VERSION}|" \
                 -e "s|app.kubernetes.io/version: [0-9][0-9.]*[^\"[:space:]]*|app.kubernetes.io/version: ${SERVICE_VERSION}|g" \
                 -e "s|service.version=[0-9][0-9.]*[^,[:space:]]*|service.version=${SERVICE_VERSION}|g" \
-                "$CURRENT_MANIFEST" >> "$OUT_FILE"
+                "$CURRENT_MANIFEST" > "$TMP"
+            apply_image_versions "$TMP"
+            cat "$TMP" >> "$OUT_FILE"
+            rm -f "$TMP"
         elif [ "$SHOULD_REPLACE" = "false" ]; then
             cat "$CURRENT_MANIFEST" >> "$OUT_FILE"
         else

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -315,18 +315,16 @@ agent:
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["postgresql.database.name"]], ""))
           # PostgreSQL fallback: use injected db.name from pod annotation
+          # NOTE: conditions in a list are ORed, so they must be AND-joined into a
+          # single expression — otherwise the guards don't restrict and the
+          # pod-name last-resort rule (below) overwrites this with an unstable name.
           - conditions:
-              - resource.attributes["db.name"] != nil
-              - resource.attributes["postgresql.database.name"] == nil
-              - resource.attributes["sqlserver.instance.name"] == nil
+              - resource.attributes["db.name"] != nil and resource.attributes["postgresql.database.name"] == nil and resource.attributes["sqlserver.instance.name"] == nil
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["db.name"]], ""))
           # PostgreSQL last resort: use k8s pod name
           - conditions:
-              - resource.attributes["k8s.pod.name"] != nil
-              - resource.attributes["postgresql.database.name"] == nil
-              - resource.attributes["db.name"] == nil
-              - resource.attributes["sqlserver.instance.name"] == nil
+              - resource.attributes["k8s.pod.name"] != nil and resource.attributes["postgresql.database.name"] == nil and resource.attributes["db.name"] == nil and resource.attributes["sqlserver.instance.name"] == nil
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
         log_statements:
@@ -341,18 +339,16 @@ agent:
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["postgresql.database.name"]], ""))
           # PostgreSQL fallback: use injected db.name from pod annotation
+          # NOTE: conditions in a list are ORed, so they must be AND-joined into a
+          # single expression — otherwise the guards don't restrict and the
+          # pod-name last-resort rule (below) overwrites this with an unstable name.
           - conditions:
-              - resource.attributes["db.name"] != nil
-              - resource.attributes["postgresql.database.name"] == nil
-              - resource.attributes["sqlserver.instance.name"] == nil
+              - resource.attributes["db.name"] != nil and resource.attributes["postgresql.database.name"] == nil and resource.attributes["sqlserver.instance.name"] == nil
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["db.name"]], ""))
           # PostgreSQL last resort: use k8s pod name
           - conditions:
-              - resource.attributes["k8s.pod.name"] != nil
-              - resource.attributes["postgresql.database.name"] == nil
-              - resource.attributes["db.name"] == nil
-              - resource.attributes["sqlserver.instance.name"] == nil
+              - resource.attributes["k8s.pod.name"] != nil and resource.attributes["postgresql.database.name"] == nil and resource.attributes["db.name"] == nil and resource.attributes["sqlserver.instance.name"] == nil
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
 

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -282,6 +282,18 @@ agent:
             flush_timeout: 15s
             max_size: 10485760 # 10 MiB
             sizer: bytes
+      # Exports secureapp security events as logs -> SecureApp /v3/event.
+      # Fed by the routing/logs connector below (scope == "secureapp").
+      otlp_http/secureapp:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+          X-splunk-instrumentation-library: secureapp
+        logs_endpoint: https://ingest.${WORKSHOP_REALM}.signalfx.com/v3/event
+        sending_queue:
+          batch:
+            flush_timeout: 15s
+            max_size: 10485760 # 10 MiB
+            sizer: bytes
     processors:
       # Inject environment as a resource attribute for traces
       resource/add_environment:
@@ -437,6 +449,18 @@ agent:
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
 
+    connectors:
+      # Split OTLP logs by instrumentation scope. Security-event records emitted
+      # by the secureapp sidecars' "secureapp" logger (scope == "secureapp") are
+      # routed to logs/secureapp -> /v3/event; all other logs stay on the
+      # default logs pipeline (HEC).
+      routing/logs:
+        default_pipelines: [logs]
+        table:
+          - context: log
+            condition: instrumentation_scope.name == "secureapp"
+            pipelines: [logs/secureapp]
+
     service:
       pipelines:
         metrics:
@@ -456,6 +480,23 @@ agent:
           receivers: [receiver_creator]
           processors: [memory_limiter, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
           exporters: [otlp_http/dbmon]
+        # SecureApp logs routing. otlp logs enter via logs/split, the
+        # routing/logs connector splits scope=="secureapp" off to /v3/event,
+        # everything else falls through to the default logs pipeline (HEC).
+        # The logs pipeline below overrides the chart default to swap the otlp
+        # receiver for routing/logs; receivers/processors/exporters otherwise
+        # mirror the chart default (splunk-otel-collector logs pipeline).
+        logs:
+          receivers: [file_log, routing/logs]
+          processors: [memory_limiter, k8s_attributes, filter/logs, batch, resourcedetection, resource, resource/logs, resource/add_environment]
+          exporters: [splunk_hec/o11y, splunk_hec/platform_logs]
+        logs/split:
+          receivers: [otlp]
+          exporters: [routing/logs]
+        logs/secureapp:
+          receivers: [routing/logs]
+          processors: [memory_limiter, batch]
+          exporters: [otlp_http/secureapp]
 
 logsCollection:
   extraFileLogs:

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -8,10 +8,15 @@
 #
 # Version: 2.0.8
 #
+# Requires: splunk-otel-collector-chart >= 0.157.0
+#   (0.157.0 renamed the kubeletstats receiver to kubelet_stats and ships the
+#    postgresql receiver query-sample fix this config relies on; older charts
+#    fail schema validation on kubelet_stats.)
+#
 # Deploy:
 #   helm upgrade --install splunk-otel-collector \
 #     splunk-otel-collector-chart/splunk-otel-collector \
-#     --version <chart-version> -n <namespace> \
+#     --version 0.157.0 -n <namespace> \
 #     -f splunk-astronomy-shop-2.0.8-values.yaml
 #
 # Note: at release time stage-values-with-header.sh stamps the release version

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -69,14 +69,6 @@ agent:
       receiver_creator:
         watch_observers: [k8s_observer]
         receivers:
-          mysql/online-boutique:
-            rule: type == "port" && pod.name matches "mysql" && port == 3306
-            config:
-              tls:
-                insecure: true
-              username: root
-              password: root
-              database: LxvGChW075
           redis:
             rule: type == "port" && pod.name matches "(redis|valkey)-cart" && port == 6379
             config:

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -1,3 +1,23 @@
+# =============================================================================
+# Splunk Astronomy Shop — Splunk OpenTelemetry Collector Helm values
+# =============================================================================
+# Purpose: values file for the splunk-otel-collector-chart Helm chart. Configures
+#          the OTel Collector (agent daemonset + cluster-receiver) that ingests
+#          the demo's telemetry and forwards it to Splunk Observability Cloud /
+#          Splunk Platform. This is NOT a demo app manifest.
+#
+# Version: 2.0.8
+#
+# Deploy:
+#   helm upgrade --install splunk-otel-collector \
+#     splunk-otel-collector-chart/splunk-otel-collector \
+#     --version <chart-version> -n <namespace> \
+#     -f splunk-astronomy-shop-2.0.8-values.yaml
+#
+# Note: the release pipeline prepends its own Version/Generated/Source header to
+#       the published release-asset copy (stage-values-with-header.sh); this
+#       in-repo header documents the source file itself.
+# =============================================================================
 clusterReceiver:
   extraEnvs:
   - name: WORKSHOP_REALM

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -1,0 +1,396 @@
+clusterReceiver:
+  extraEnvs:
+  - name: WORKSHOP_REALM
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: realm
+  - name: WORKSHOP_ENVIRONMENT
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: instance
+  # Disabled eventsEnabled and k8s_objects - these generate non-HEC data
+  # that gets refused by Splunk Platform endpoints
+  eventsEnabled: true
+  # Bump from 500Mi/200m — pod was OOM-restarting under export back-pressure
+  # (memorylimiter soft=450Mi vs pod limit=500Mi had only 50Mi headroom).
+  # 149 restarts in 14d on dev-astronomy traced to signalfx/HEC exporter
+  # timeouts back-pressuring the pipeline. Chart does not expose liveness/
+  # readiness probe tuning — if restarts persist post-upgrade, patch
+  # deployment probes via kubectl after helm install.
+  resources:
+    requests:
+      cpu: 200m
+      memory: 500Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+agent:
+  extraEnvs:
+  - name: WORKSHOP_REALM
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: realm
+  - name: WORKSHOP_ENVIRONMENT
+    valueFrom:
+      secretKeyRef:
+        name: workshop-secret
+        key: instance
+  config:
+    receivers:
+      receiver_creator:
+        watch_observers: [k8s_observer]
+        receivers:
+          mysql/online-boutique:
+            rule: type == "port" && pod.name matches "mysql" && port == 3306
+            config:
+              tls:
+                insecure: true
+              username: root
+              password: root
+              database: LxvGChW075
+          redis:
+            rule: type == "port" && pod.name matches "(redis|valkey)-cart" && port == 6379
+            config:
+              endpoint: '`endpoint`'
+              collection_interval: 10s
+          # SQL Server receivers - discovered by agent on same node as database pod
+          sqlserver/shopshim:
+            rule: type == "port" && pod.name matches "shop-dc-shim-db" && port == 1433
+            config:
+              collection_interval: 10s
+              top_query_collection:
+                lookback_time: 300s
+              username: sa
+              password: ShopPass123!
+              server: '`host`'
+              port: 1433
+              resource_attributes:
+                sqlserver.instance.name:
+                  enabled: true
+                sqlserver.computer.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+              metrics:
+                sqlserver.batch.request.rate:
+                  enabled: true
+                sqlserver.batch.sql_compilation.rate:
+                  enabled: true
+                sqlserver.batch.sql_recompilation.rate:
+                  enabled: true
+                sqlserver.database.count:
+                  enabled: true
+                sqlserver.database.io:
+                  enabled: true
+                sqlserver.database.latency:
+                  enabled: true
+                sqlserver.database.operations:
+                  enabled: true
+                sqlserver.deadlock.rate:
+                  enabled: true
+                sqlserver.lock.wait.count:
+                  enabled: true
+                sqlserver.lock.wait.rate:
+                  enabled: true
+                sqlserver.os.wait.duration:
+                  enabled: true
+                sqlserver.page.buffer_cache.hit_ratio:
+                  enabled: true
+                sqlserver.processes.blocked:
+                  enabled: true
+                sqlserver.resource_pool.disk.operations:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.read.rate:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.write.rate:
+                  enabled: true
+                sqlserver.user.connection.count:
+                  enabled: true
+          sqlserver/fraud:
+            rule: type == "port" && pod.name matches "sql-server-fraud" && port == 1433
+            config:
+              collection_interval: 10s
+              top_query_collection:
+                lookback_time: 300s
+              username: sa
+              password: "ChangeMe_SuperStrong123!"
+              server: '`host`'
+              port: 1433
+              resource_attributes:
+                sqlserver.instance.name:
+                  enabled: true
+                sqlserver.computer.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+              metrics:
+                sqlserver.batch.request.rate:
+                  enabled: true
+                sqlserver.batch.sql_compilation.rate:
+                  enabled: true
+                sqlserver.batch.sql_recompilation.rate:
+                  enabled: true
+                sqlserver.database.count:
+                  enabled: true
+                sqlserver.database.io:
+                  enabled: true
+                sqlserver.database.latency:
+                  enabled: true
+                sqlserver.database.operations:
+                  enabled: true
+                sqlserver.deadlock.rate:
+                  enabled: true
+                sqlserver.lock.wait.count:
+                  enabled: true
+                sqlserver.lock.wait.rate:
+                  enabled: true
+                sqlserver.os.wait.duration:
+                  enabled: true
+                sqlserver.page.buffer_cache.hit_ratio:
+                  enabled: true
+                sqlserver.processes.blocked:
+                  enabled: true
+                sqlserver.resource_pool.disk.operations:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.read.rate:
+                  enabled: true
+                sqlserver.resource_pool.disk.throttled.write.rate:
+                  enabled: true
+                sqlserver.user.connection.count:
+                  enabled: true
+          # PostgreSQL receiver - discovered by agent on same node as database pod
+          postgresql/main:
+            rule: type == "port" && pod.name matches "postgres" && port == 5432
+            resource_attributes:
+              # Inject pod name for fallback identification in transform rules
+              k8s.pod.name: '`pod.name`'
+              # Inject database name from pod annotation
+              db.name: '`pod.annotations["splunk.com/postgresql.database"]`'
+            config:
+              endpoint: '`endpoint`'
+              transport: tcp
+              username: root
+              password: otel
+              databases: '`pod.annotations["splunk.com/postgresql.database"]`'
+              tls:
+                insecure: true
+              collection_interval: 10s
+              resource_attributes:
+                postgresql.database.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
+              metrics:
+                postgresql.commits:
+                  enabled: true
+                postgresql.operations:
+                  enabled: true
+                postgresql.deadlocks:
+                  enabled: true
+                postgresql.connection.max:
+                  enabled: true
+      receiver_creator/kafka:
+        watch_observers: [k8s_observer]
+        receivers:
+          kafka_metrics:
+            rule: type == "pod" && labels["app.kubernetes.io/component"] == "kafka"
+            config:
+              cluster_alias: kafka-${WORKSHOP_ENVIRONMENT}
+              brokers: ["`endpoint`:9092"]
+              scrapers:
+                - brokers
+                - topics
+                - consumers
+    exporters:
+      # Exports dbmon events as logs
+      otlp_http/dbmon:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+          X-splunk-instrumentation-library: dbmon
+        logs_endpoint: https://ingest.${WORKSHOP_REALM}.signalfx.com/v3/event
+        sending_queue:
+          batch:
+            flush_timeout: 15s
+            max_size: 10485760 # 10 MiB
+            sizer: bytes
+    processors:
+      # Inject environment as a resource attribute for traces
+      resource/add_environment:
+        attributes:
+          # `insert` (not `upsert`): only inject WORKSHOP_ENVIRONMENT when the
+          # service hasn't set deployment.environment itself. Services like
+          # planning and report-generator set their own variant suffix
+          # (e.g. ${WORKSHOP_ENV}-lambda, ${WORKSHOP_ENV}-throttle-demo) and
+          # were getting clobbered by upsert.
+          - key: deployment.environment
+            value: ${WORKSHOP_ENVIRONMENT}
+            action: insert
+      # Strip verbose/duplicative resource attrs on metrics pipeline so
+      # SignalFx exporter stays under its 36-dimension cap. Python OTel
+      # SDK metrics (recommendation, secureapp-loadgen-python) emit
+      # 37-44 dims baseline; without this they drop entirely with
+      # "number of dimensions is larger than 36".
+      #
+      # 7 process/service dupes stripped:
+      #   process.runtime.description, process.executable.path,
+      #   process.command_line, process.command_args, process.parent_pid,
+      #   process.owner, service.kafka
+      # 7 http/host dupes stripped (needed for HTTP server metrics from
+      # gunicorn/Flask/etc):
+      #   http.flavor, http.server_name, net.host.port, os.type,
+      #   host.arch, container.image.tag, deployment.environment
+      #   (legacy semconv dup of deployment.environment.name)
+      # Keeps container.id (queried in Splunk UI).
+      resource/strip_verbose:
+        attributes:
+          - {action: delete, key: process.runtime.description}
+          - {action: delete, key: process.executable.path}
+          - {action: delete, key: process.command_line}
+          - {action: delete, key: process.command_args}
+          - {action: delete, key: process.parent_pid}
+          - {action: delete, key: process.owner}
+          - {action: delete, key: service.kafka}
+          - {action: delete, key: http.flavor}
+          - {action: delete, key: http.server_name}
+          - {action: delete, key: net.host.port}
+          - {action: delete, key: os.type}
+          - {action: delete, key: host.arch}
+          - {action: delete, key: container.image.tag}
+          - {action: delete, key: deployment.environment}
+      filter/drop_flagd:
+        traces:
+          span:
+          - attributes["rpc.method"] == "EventStream"
+          - attributes["rpc.method"] == "ResolveAll"
+          - attributes["rpc.method"] == "ResolveBoolean"
+          - attributes["rpc.method"] == "ResolveFloat"
+          - attributes["rpc.method"] == "ResolveInt"
+          - attributes["http.url"] == "http://flagd:8016/ofrep/v1/evaluate/flags/loadGeneratorFloodHomepage"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v1.Service/ResolveBoolean"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v2.Service/ResolveBoolean"
+          - attributes["otel.scope.name"] == "flagd.evaluation.v1"
+          - attributes["otel.scope.name"] == "flagd.evaluation.v2"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v1.Service/EventStream"
+          - attributes["url.full"] == "http://flagd:8013/flagd.evaluation.v2.Service/EventStream"
+          - attributes["url.path"] == "/live/longpoll"
+      transform/dc_not_error:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            statements:
+              # Treat "DC" (Downstream Connection closed) as normal, not error
+              # This happens when users navigate away before response completes
+              - set(status.code, STATUS_CODE_UNSET) where attributes["response_flags"] == "DC"
+              - set(attributes["error"], "false") where attributes["response_flags"] == "DC"
+              - set(name, Concat([name, " (user navigated away)"], "")) where attributes["response_flags"] == "DC"
+              # Also handle egress cancellations (proxy cancels outbound when client disconnects)
+              - set(status.code, STATUS_CODE_UNSET) where attributes["canceled"] == "true"
+              - set(attributes["error"], "false") where attributes["canceled"] == "true"
+              - set(name, Concat([name, " (backend interaction terminated due to client disconnect)"], "")) where attributes["canceled"] == "true"
+      # Transform processor for dbmon - sets service.instance.id for database identification
+      transform/dbmon:
+        error_mode: ignore
+        metric_statements:
+          # SQL Server: use instance name for identification
+          - conditions:
+              - resource.attributes["sqlserver.instance.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["sqlserver.instance.name"]], ""))
+          # PostgreSQL database-level metrics: use database name for identification
+          - conditions:
+              - resource.attributes["postgresql.database.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["postgresql.database.name"]], ""))
+          # PostgreSQL fallback: use injected db.name from pod annotation
+          - conditions:
+              - resource.attributes["db.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["db.name"]], ""))
+          # PostgreSQL last resort: use k8s pod name
+          - conditions:
+              - resource.attributes["k8s.pod.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["db.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
+        log_statements:
+          # SQL Server: use instance name for identification
+          - conditions:
+              - resource.attributes["sqlserver.instance.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["sqlserver.instance.name"]], ""))
+          # PostgreSQL database-level logs: use database name for identification
+          - conditions:
+              - resource.attributes["postgresql.database.name"] != nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["postgresql.database.name"]], ""))
+          # PostgreSQL fallback: use injected db.name from pod annotation
+          - conditions:
+              - resource.attributes["db.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["db.name"]], ""))
+          # PostgreSQL last resort: use k8s pod name
+          - conditions:
+              - resource.attributes["k8s.pod.name"] != nil
+              - resource.attributes["postgresql.database.name"] == nil
+              - resource.attributes["db.name"] == nil
+              - resource.attributes["sqlserver.instance.name"] == nil
+            statements:
+              - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
+
+    service:
+      pipelines:
+        metrics:
+          exporters: [signalfx]
+          processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, resource/strip_verbose, transform/dbmon]
+          receivers: [host_metrics, kubeletstats, otlp, receiver_creator, receiver_creator/kafka]
+        traces:
+          # signalfx exporter removed from traces — chart 0.153.1 align.
+          # OTLP alone is sufficient for trace correlation; dropping signalfx
+          # here reduces load on the exporter currently timing out under
+          # back-pressure on the cluster-receiver.
+          exporters: [otlp_http]
+          processors: [memory_limiter, filter/drop_flagd, transform/dc_not_error, k8s_attributes, batch, resourcedetection, resource, resource/add_environment]
+          receivers: [otlp, jaeger, zipkin]
+        # DBMon logs pipeline - sends query samples and top queries to Splunk O11y
+        logs/dbmon:
+          receivers: [receiver_creator]
+          processors: [memory_limiter, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
+          exporters: [otlp_http/dbmon]
+
+logsCollection:
+  extraFileLogs:
+    filelog/syslog:
+      include: [/var/log/syslog]
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.source: /var/log/syslog
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: syslog
+    filelog/auth_log:
+      include: [/var/log/auth.log]
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.source: /var/log/auth.log
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: auth_log

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -329,6 +329,14 @@ agent:
       transform/dbmon:
         error_mode: ignore
         metric_statements:
+          # PostgreSQL: the postgresql receiver emits no server.address/server.port
+          # (the sqlserver receiver does), which the monitored-DB entity keys on.
+          # Inject them so postgres resolves to a monitored node, not inferred.
+          - conditions:
+              - resource.attributes["db.system.name"] == "postgresql" and resource.attributes["server.address"] == nil
+            statements:
+              - set(resource.attributes["server.address"], "postgresql")
+              - set(resource.attributes["server.port"], 5432)
           # SQL Server: use instance name for identification
           - conditions:
               - resource.attributes["sqlserver.instance.name"] != nil
@@ -353,6 +361,15 @@ agent:
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
         log_statements:
+          # PostgreSQL: inject server.address/server.port (the postgresql receiver
+          # emits neither, unlike sqlserver) so it resolves to a monitored DB node.
+          # On dbmon log events these are RECORD-level attributes (matching where
+          # the sqlserver receiver puts server.address), so use attributes[...].
+          - conditions:
+              - log.attributes["db.system.name"] == "postgresql" and log.attributes["server.address"] == nil
+            statements:
+              - set(log.attributes["server.address"], "postgresql")
+              - set(log.attributes["server.port"], 5432)
           # SQL Server: use instance name for identification
           - conditions:
               - resource.attributes["sqlserver.instance.name"] != nil

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -361,7 +361,7 @@ agent:
         metrics:
           exporters: [signalfx]
           processors: [memory_limiter, k8s_attributes, batch, resourcedetection, resource, resource/add_environment, resource/strip_verbose, transform/dbmon]
-          receivers: [host_metrics, kubeletstats, otlp, receiver_creator, receiver_creator/kafka]
+          receivers: [host_metrics, kubelet_stats, otlp, receiver_creator, receiver_creator/kafka]
         traces:
           # signalfx exporter removed from traces — chart 0.153.1 align.
           # OTLP alone is sufficient for trace correlation; dropping signalfx

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -14,9 +14,9 @@
 #     --version <chart-version> -n <namespace> \
 #     -f splunk-astronomy-shop-2.0.8-values.yaml
 #
-# Note: the release pipeline prepends its own Version/Generated/Source header to
-#       the published release-asset copy (stage-values-with-header.sh); this
-#       in-repo header documents the source file itself.
+# Note: at release time stage-values-with-header.sh stamps the release version
+#       onto the `# Version:` line above and injects Generated/Source provenance
+#       into the published asset copy; this in-repo file stays untouched.
 # =============================================================================
 clusterReceiver:
   extraEnvs:

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -227,6 +227,25 @@ agent:
                   enabled: true
                 postgresql.connection.max:
                   enabled: true
+          # MySQL receiver - discovered by agent on same node as the mysql pod.
+          mysql/main:
+            rule: type == "port" && pod.name matches "mysql-telescope" && port == 3306
+            resource_attributes:
+              k8s.pod.name: '`pod.name`'
+              db.name: '`pod.annotations["splunk.com/mysql.database"]`'
+            config:
+              endpoint: '`endpoint`'
+              username: otel-user
+              password: otel-user-password
+              collection_interval: 10s
+              resource_attributes:
+                mysql.instance.endpoint:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
       receiver_creator/kafka:
         watch_observers: [k8s_observer]
         receivers:
@@ -370,6 +389,12 @@ agent:
             statements:
               - set(log.attributes["server.address"], "postgresql")
               - set(log.attributes["server.port"], 5432)
+          # MySQL: same gap — inject server.address/server.port on dbmon events.
+          - conditions:
+              - log.attributes["db.system.name"] == "mysql" and log.attributes["server.address"] == nil
+            statements:
+              - set(log.attributes["server.address"], "mysql-telescope")
+              - set(log.attributes["server.port"], 3306)
           # SQL Server: use instance name for identification
           - conditions:
               - resource.attributes["sqlserver.instance.name"] != nil

--- a/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.8-values.yaml
@@ -246,6 +246,26 @@ agent:
                   enabled: true
                 db.server.top_query:
                   enabled: true
+          # Oracle receiver - connects as SYSTEM to the FREEPDB1 pluggable DB.
+          oracledb/main:
+            rule: type == "port" && pod.name matches "oracle-telescope" && port == 1521
+            resource_attributes:
+              k8s.pod.name: '`pod.name`'
+              db.name: '`pod.annotations["splunk.com/oracledb.service"]`'
+            config:
+              endpoint: '`endpoint`'
+              service: FREEPDB1
+              username: system
+              password: oracle
+              collection_interval: 10s
+              resource_attributes:
+                oracledb.instance.name:
+                  enabled: true
+              events:
+                db.server.query_sample:
+                  enabled: true
+                db.server.top_query:
+                  enabled: true
       receiver_creator/kafka:
         watch_observers: [k8s_observer]
         receivers:
@@ -395,6 +415,12 @@ agent:
             statements:
               - set(log.attributes["server.address"], "mysql-telescope")
               - set(log.attributes["server.port"], 3306)
+          # Oracle: same gap — inject server.address/server.port on dbmon events.
+          - conditions:
+              - log.attributes["db.system.name"] == "oracle" and log.attributes["server.address"] == nil
+            statements:
+              - set(log.attributes["server.address"], "oracle-telescope")
+              - set(log.attributes["server.port"], 1521)
           # SQL Server: use instance name for identification
           - conditions:
               - resource.attributes["sqlserver.instance.name"] != nil

--- a/kubernetes/test/mysql-cartesian-tester.yaml
+++ b/kubernetes/test/mysql-cartesian-tester.yaml
@@ -1,0 +1,141 @@
+# =============================================================================
+# mysql-cartesian-tester — Java+Splunk-agent service, cartesian query -> MySQL
+# =============================================================================
+# Mirror of pg-cartesian-tester, aimed at the "telescope" MySQL DB. Runs the
+# cartesian bad query every 3s so the mysql receiver captures it as a top query.
+#
+# Deploy:  kubectl apply -f kubernetes/test/mysql-cartesian-tester.yaml
+# Remove:  kubectl delete -f kubernetes/test/mysql-cartesian-tester.yaml
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-cartesian-tester-src
+  namespace: default
+data:
+  Cartesian.java: |
+    import java.sql.*;
+    import java.util.Random;
+
+    public class Cartesian {
+        public static void main(String[] args) throws Exception {
+            String url  = env("MY_URL",  "jdbc:mysql://mysql-telescope:3306/telescope");
+            String user = env("MY_USER", "demo_app_user");
+            String pass = env("MY_PASS", "demo_password");
+            long   ms   = Long.parseLong(env("INTERVAL_SECONDS", "3")) * 1000L;
+
+            String sql = "SELECT p.product_id, p.name, p.price, pt.tag, pt.relevance_score "
+                       + "FROM products p JOIN product_tags pt ON 1=1 "
+                       + "WHERE p.category = ? AND pt.tag = ? "
+                       + "ORDER BY pt.relevance_score DESC LIMIT 10";
+            String[] cats = {"telescope","eyepiece","mount","camera","filter"};
+            String[] tags = {"beginner","advanced","astrophotography","visual","planetary"};
+            Random rnd = new Random();
+
+            System.out.println("mysql-cartesian-tester: firing every " + (ms/1000) + "s against " + url);
+            while (true) {
+                long t0 = System.currentTimeMillis();
+                try (Connection c = DriverManager.getConnection(url, user, pass);
+                     PreparedStatement ps = c.prepareStatement(sql)) {
+                    ps.setString(1, cats[rnd.nextInt(cats.length)]);
+                    ps.setString(2, tags[rnd.nextInt(tags.length)]);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        int n = 0; while (rs.next()) n++;
+                        System.out.println("cartesian: " + n + " rows in " + (System.currentTimeMillis()-t0) + "ms");
+                    }
+                } catch (Exception e) {
+                    System.err.println("query failed: " + e.getMessage());
+                }
+                Thread.sleep(ms);
+            }
+        }
+        static String env(String k, String d) {
+            String v = System.getenv(k);
+            return (v == null || v.isEmpty()) ? d : v;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-cartesian-tester
+  namespace: default
+  labels:
+    app.kubernetes.io/component: mysql-cartesian-tester
+    app.kubernetes.io/name: mysql-cartesian-tester
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mysql-cartesian-tester
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mysql-cartesian-tester
+        app.kubernetes.io/name: mysql-cartesian-tester
+    spec:
+      initContainers:
+      - name: fetch-deps
+        image: curlimages/curl:8.10.1
+        command: ["sh", "-c"]
+        args:
+          - |
+            set -e
+            echo "downloading mysql JDBC driver + splunk java agent..."
+            curl -fsSL -o /deps/mysql.jar \
+              https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.1.0/mysql-connector-j-9.1.0.jar
+            curl -fsSL -o /deps/splunk-otel-javaagent.jar \
+              https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent.jar
+            ls -l /deps
+        volumeMounts:
+        - name: deps
+          mountPath: /deps
+      containers:
+      - name: tester
+        image: eclipse-temurin:21-jdk
+        command: ["sh", "-c"]
+        args:
+          - exec java -javaagent:/deps/splunk-otel-javaagent.jar -cp /deps/mysql.jar /app/Cartesian.java
+        env:
+        - name: OTEL_SERVICE_NAME
+          value: mysql-cartesian-tester
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(NODE_IP):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=mysql-cartesian-tester,service.namespace=opentelemetry-demo
+        - name: OTEL_METRICS_EXPORTER
+          value: none
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: MY_URL
+          value: jdbc:mysql://mysql-telescope:3306/telescope
+        - name: MY_USER
+          value: demo_app_user
+        - name: MY_PASS
+          value: demo_password
+        - name: INTERVAL_SECONDS
+          value: "3"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 384Mi
+        volumeMounts:
+        - name: deps
+          mountPath: /deps
+        - name: src
+          mountPath: /app
+      volumes:
+      - name: deps
+        emptyDir: {}
+      - name: src
+        configMap:
+          name: mysql-cartesian-tester-src

--- a/kubernetes/test/mysql-telescope.yaml
+++ b/kubernetes/test/mysql-telescope.yaml
@@ -1,0 +1,142 @@
+# =============================================================================
+# mysql-telescope — MySQL DBmon test instance
+# =============================================================================
+# A MySQL 8 instance (database "telescope") seeded with the cartesian demo
+# tables (products + product_tags), a monitoring user for the mysql receiver,
+# and an app user for the cartesian tester. Annotated for collector discovery.
+#
+# Deploy:  kubectl apply -f kubernetes/test/mysql-telescope.yaml
+# Remove:  kubectl delete -f kubernetes/test/mysql-telescope.yaml ; \
+#          kubectl delete pvc -l app.kubernetes.io/component=mysql-telescope
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-telescope-init
+  namespace: default
+data:
+  init.sql: |
+    -- Monitoring user for the Splunk mysql receiver (grants per Splunk docs).
+    CREATE USER IF NOT EXISTS 'otel-user'@'%' IDENTIFIED BY 'otel-user-password';
+    GRANT REPLICATION CLIENT ON *.* TO 'otel-user'@'%';
+    GRANT PROCESS ON *.* TO 'otel-user'@'%';
+    GRANT SELECT ON performance_schema.* TO 'otel-user'@'%';
+
+    -- App user the cartesian tester connects as.
+    CREATE USER IF NOT EXISTS 'demo_app_user'@'%' IDENTIFIED BY 'demo_password';
+    GRANT SELECT ON telescope.* TO 'demo_app_user'@'%';
+    FLUSH PRIVILEGES;
+
+    USE telescope;
+    SET SESSION cte_max_recursion_depth = 1000000;
+
+    CREATE TABLE IF NOT EXISTS products (
+        id          INT AUTO_INCREMENT PRIMARY KEY,
+        product_id  VARCHAR(64) UNIQUE NOT NULL,
+        name        VARCHAR(255),
+        category    VARCHAR(64),
+        price       DECIMAL(10,2)
+    );
+    CREATE TABLE IF NOT EXISTS product_tags (
+        id              INT AUTO_INCREMENT PRIMARY KEY,
+        product_id      VARCHAR(64) NOT NULL,
+        tag             VARCHAR(64),
+        relevance_score DECIMAL(4,3)
+    );
+
+    -- 5,000 products
+    INSERT INTO products (product_id, name, category, price)
+    WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 5000)
+    SELECT CONCAT('prod_', n), CONCAT('Product ', n),
+           ELT(FLOOR(1+RAND()*5), 'telescope','eyepiece','mount','camera','filter'),
+           ROUND(RAND()*2000+50, 2)
+    FROM seq;
+
+    -- 100,000 tags (5,000 products x 20)
+    INSERT INTO product_tags (product_id, tag, relevance_score)
+    WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 5000),
+                   twenty AS (SELECT 1 AS k UNION ALL SELECT k+1 FROM twenty WHERE k < 20)
+    SELECT CONCAT('prod_', s.n),
+           ELT(FLOOR(1+RAND()*10), 'beginner','advanced','astrophotography','visual','planetary',
+                                   'deepsky','portable','goto','wifi','budget'),
+           ROUND(RAND(), 3)
+    FROM seq s CROSS JOIN twenty t;
+    -- No indexes on the join columns: keeps the ON 1=1 cartesian join slow.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-telescope
+  namespace: default
+  labels:
+    app.kubernetes.io/component: mysql-telescope
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3306
+    targetPort: 3306
+    name: mysql
+  selector:
+    app.kubernetes.io/component: mysql-telescope
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-telescope
+  namespace: default
+  labels:
+    app.kubernetes.io/component: mysql-telescope
+    app.kubernetes.io/name: mysql-telescope
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mysql-telescope
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: mysql
+        splunk.com/mysql.database: telescope
+      labels:
+        app.kubernetes.io/component: mysql-telescope
+        app.kubernetes.io/name: mysql-telescope
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.4
+        imagePullPolicy: IfNotPresent
+        args:
+          - --performance-schema=ON
+        ports:
+        - containerPort: 3306
+          name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: "rootpass"
+        - name: MYSQL_DATABASE
+          value: "telescope"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+        volumeMounts:
+        - name: init
+          mountPath: /docker-entrypoint-initdb.d
+        - name: data
+          mountPath: /var/lib/mysql
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "mysqladmin ping -h127.0.0.1 -uroot -prootpass"]
+          initialDelaySeconds: 20
+          periodSeconds: 10
+      volumes:
+      - name: init
+        configMap:
+          name: mysql-telescope-init
+      - name: data
+        emptyDir: {}

--- a/kubernetes/test/oracle-cartesian-tester.yaml
+++ b/kubernetes/test/oracle-cartesian-tester.yaml
@@ -1,0 +1,147 @@
+# =============================================================================
+# oracle-cartesian-tester — Java+Splunk-agent service, cartesian query -> Oracle
+# =============================================================================
+# Mirror of the mysql/pg testers, aimed at the "telescope" Oracle DB (FREEPDB1).
+# Oracle's optimizer avoids the naive cartesian, so the query carries hints
+# (ORDERED USE_NL FULL) to force a slow nested-loop full-scan join.
+#
+# Deploy:  kubectl apply -f kubernetes/test/oracle-cartesian-tester.yaml
+# Remove:  kubectl delete -f kubernetes/test/oracle-cartesian-tester.yaml
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oracle-cartesian-tester-src
+  namespace: default
+data:
+  Cartesian.java: |
+    import java.sql.*;
+    import java.util.Random;
+
+    public class Cartesian {
+        public static void main(String[] args) throws Exception {
+            String url  = env("OR_URL",  "jdbc:oracle:thin:@//oracle-telescope:1521/FREEPDB1");
+            String user = env("OR_USER", "demo_app_user");
+            String pass = env("OR_PASS", "demo_password");
+            long   ms   = Long.parseLong(env("INTERVAL_SECONDS", "3")) * 1000L;
+
+            // Hints force a slow nested-loop full-scan cartesian (Oracle's CBO
+            // would otherwise optimize the naive join away).
+            String sql = "SELECT * FROM ("
+                       + "  SELECT /*+ ORDERED USE_NL(pt) FULL(p) FULL(pt) */ "
+                       + "         p.product_id, p.name, p.price, pt.tag, pt.relevance_score "
+                       + "  FROM products p, product_tags pt "
+                       + "  WHERE p.category = ? AND pt.tag = ? "
+                       + "  ORDER BY pt.relevance_score DESC) "
+                       + "WHERE ROWNUM <= 10";
+            String[] cats = {"telescope","eyepiece","mount","camera","filter"};
+            String[] tags = {"beginner","advanced","astrophotography","visual","planetary"};
+            Random rnd = new Random();
+
+            System.out.println("oracle-cartesian-tester: firing every " + (ms/1000) + "s against " + url);
+            while (true) {
+                long t0 = System.currentTimeMillis();
+                try (Connection c = DriverManager.getConnection(url, user, pass);
+                     PreparedStatement ps = c.prepareStatement(sql)) {
+                    ps.setString(1, cats[rnd.nextInt(cats.length)]);
+                    ps.setString(2, tags[rnd.nextInt(tags.length)]);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        int n = 0; while (rs.next()) n++;
+                        System.out.println("cartesian: " + n + " rows in " + (System.currentTimeMillis()-t0) + "ms");
+                    }
+                } catch (Exception e) {
+                    System.err.println("query failed: " + e.getMessage());
+                }
+                Thread.sleep(ms);
+            }
+        }
+        static String env(String k, String d) {
+            String v = System.getenv(k);
+            return (v == null || v.isEmpty()) ? d : v;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oracle-cartesian-tester
+  namespace: default
+  labels:
+    app.kubernetes.io/component: oracle-cartesian-tester
+    app.kubernetes.io/name: oracle-cartesian-tester
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: oracle-cartesian-tester
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: oracle-cartesian-tester
+        app.kubernetes.io/name: oracle-cartesian-tester
+    spec:
+      initContainers:
+      - name: fetch-deps
+        image: curlimages/curl:8.10.1
+        command: ["sh", "-c"]
+        args:
+          - |
+            set -e
+            echo "downloading oracle JDBC driver + splunk java agent..."
+            curl -fsSL -o /deps/ojdbc.jar \
+              https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.5.0.24.07/ojdbc11-23.5.0.24.07.jar
+            curl -fsSL -o /deps/splunk-otel-javaagent.jar \
+              https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent.jar
+            ls -l /deps
+        volumeMounts:
+        - name: deps
+          mountPath: /deps
+      containers:
+      - name: tester
+        image: eclipse-temurin:21-jdk
+        command: ["sh", "-c"]
+        args:
+          - exec java -javaagent:/deps/splunk-otel-javaagent.jar -cp /deps/ojdbc.jar /app/Cartesian.java
+        env:
+        - name: OTEL_SERVICE_NAME
+          value: oracle-cartesian-tester
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(NODE_IP):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=oracle-cartesian-tester,service.namespace=opentelemetry-demo
+        - name: OTEL_METRICS_EXPORTER
+          value: none
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: OR_URL
+          value: jdbc:oracle:thin:@//oracle-telescope:1521/FREEPDB1
+        - name: OR_USER
+          value: demo_app_user
+        - name: OR_PASS
+          value: demo_password
+        - name: INTERVAL_SECONDS
+          value: "3"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+        volumeMounts:
+        - name: deps
+          mountPath: /deps
+        - name: src
+          mountPath: /app
+      volumes:
+      - name: deps
+        emptyDir: {}
+      - name: src
+        configMap:
+          name: oracle-cartesian-tester-src

--- a/kubernetes/test/oracle-telescope.yaml
+++ b/kubernetes/test/oracle-telescope.yaml
@@ -1,0 +1,127 @@
+# =============================================================================
+# oracle-telescope — Oracle Database Free (DBmon test instance)
+# =============================================================================
+# Oracle Database Free 23 (gvenzl community image, fast-start). Default PDB
+# FREEPDB1, app user demo_app_user, seeded with the cartesian tables. The
+# oracledb receiver connects as SYSTEM (has the dictionary access it needs).
+#
+# Deploy:  kubectl apply -f kubernetes/test/oracle-telescope.yaml
+# Remove:  kubectl delete -f kubernetes/test/oracle-telescope.yaml
+# Service name (PDB): FREEPDB1   Port: 1521
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oracle-telescope-init
+  namespace: default
+data:
+  # gvenzl runs *.sql here on first init, connected to FREEPDB1 as APP_USER
+  # (demo_app_user), which has the RESOURCE role — enough to create + seed.
+  01-cartesian.sql: |
+    CREATE TABLE products (
+        id          NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        product_id  VARCHAR2(64) UNIQUE,
+        name        VARCHAR2(255),
+        category    VARCHAR2(64),
+        price       NUMBER(10,2)
+    );
+    CREATE TABLE product_tags (
+        id              NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        product_id      VARCHAR2(64),
+        tag             VARCHAR2(64),
+        relevance_score NUMBER(4,3)
+    );
+
+    INSERT INTO products (product_id, name, category, price)
+    SELECT 'prod_' || level, 'Product ' || level,
+           CASE MOD(level,5) WHEN 0 THEN 'telescope' WHEN 1 THEN 'eyepiece'
+                             WHEN 2 THEN 'mount' WHEN 3 THEN 'camera' ELSE 'filter' END,
+           ROUND(DBMS_RANDOM.VALUE(50,2050),2)
+    FROM dual CONNECT BY LEVEL <= 5000;
+
+    INSERT INTO product_tags (product_id, tag, relevance_score)
+    SELECT 'prod_' || (MOD(level-1,5000)+1),
+           CASE MOD(level,10) WHEN 0 THEN 'beginner' WHEN 1 THEN 'advanced'
+                              WHEN 2 THEN 'astrophotography' WHEN 3 THEN 'visual'
+                              WHEN 4 THEN 'planetary' WHEN 5 THEN 'deepsky'
+                              WHEN 6 THEN 'portable' WHEN 7 THEN 'goto'
+                              WHEN 8 THEN 'wifi' ELSE 'budget' END,
+           ROUND(DBMS_RANDOM.VALUE(0,1),3)
+    FROM dual CONNECT BY LEVEL <= 100000;
+    COMMIT;
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oracle-telescope
+  namespace: default
+  labels:
+    app.kubernetes.io/component: oracle-telescope
+spec:
+  type: ClusterIP
+  ports:
+  - port: 1521
+    targetPort: 1521
+    name: oracle
+  selector:
+    app.kubernetes.io/component: oracle-telescope
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oracle-telescope
+  namespace: default
+  labels:
+    app.kubernetes.io/component: oracle-telescope
+    app.kubernetes.io/name: oracle-telescope
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: oracle-telescope
+  template:
+    metadata:
+      annotations:
+        splunk.com/monitor: oracledb
+        splunk.com/oracledb.service: FREEPDB1
+      labels:
+        app.kubernetes.io/component: oracle-telescope
+        app.kubernetes.io/name: oracle-telescope
+    spec:
+      containers:
+      - name: oracle
+        image: gvenzl/oracle-free:23-slim-faststart
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 1521
+          name: oracle
+        env:
+        - name: ORACLE_PASSWORD          # SYS / SYSTEM password
+          value: "oracle"
+        - name: APP_USER
+          value: "demo_app_user"
+        - name: APP_USER_PASSWORD
+          value: "demo_password"
+        resources:
+          requests:
+            cpu: 300m
+            memory: 2Gi
+          limits:
+            memory: 4Gi
+        volumeMounts:
+        - name: init
+          mountPath: /container-entrypoint-initdb.d
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "healthcheck.sh"]
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          timeoutSeconds: 15   # Oracle healthcheck queries the DB; 1s default times out
+          failureThreshold: 30
+      volumes:
+      - name: init
+        configMap:
+          name: oracle-telescope-init

--- a/kubernetes/test/pg-cartesian-tester.yaml
+++ b/kubernetes/test/pg-cartesian-tester.yaml
@@ -1,0 +1,153 @@
+# =============================================================================
+# pg-cartesian-tester — throwaway Java test service
+# =============================================================================
+# A tiny Java (JDBC) service, instrumented with the Splunk Java agent, that runs
+# the cartesian bad query against the astroshop PostgreSQL DB every 3s. Purpose:
+# test whether the Java agent produces the DB span attributes needed for the
+# APM node <-> DBmon "Database Instances" correlation (vs Python/.NET).
+#
+# No custom image build: an init container downloads the postgres JDBC driver +
+# the Splunk Java agent; the main container runs the .java source directly
+# (Java 21 single-file source mode) with the agent attached.
+#
+# Deploy:   kubectl apply -f kubernetes/test/pg-cartesian-tester.yaml
+# Remove:   kubectl delete -f kubernetes/test/pg-cartesian-tester.yaml
+# Requires: dev-astronomy egress to repo1.maven.org + github.com (for the jars).
+# =============================================================================
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pg-cartesian-tester-src
+  namespace: default
+data:
+  Cartesian.java: |
+    import java.sql.*;
+    import java.util.Random;
+
+    public class Cartesian {
+        public static void main(String[] args) throws Exception {
+            String url  = env("PG_URL",  "jdbc:postgresql://postgresql:5432/astroshop");
+            String user = env("PG_USER", "demo_app_user");
+            String pass = env("PG_PASS", "demo_password");
+            long   ms   = Long.parseLong(env("INTERVAL_SECONDS", "3")) * 1000L;
+
+            // Bad query: JOIN ... ON 1=1 -> Cartesian product (same as the demo).
+            String sql = "SELECT p.product_id, p.name, p.price, pt.tag, pt.relevance_score "
+                       + "FROM products p JOIN product_tags pt ON 1=1 "
+                       + "WHERE p.category = ? AND pt.tag = ? "
+                       + "ORDER BY pt.relevance_score DESC LIMIT 10";
+            String[] cats = {"telescope","eyepiece","mount","camera","filter"};
+            String[] tags = {"beginner","advanced","astrophotography","visual","planetary"};
+            Random rnd = new Random();
+
+            System.out.println("pg-cartesian-tester: firing every " + (ms/1000) + "s against " + url);
+            while (true) {
+                long t0 = System.currentTimeMillis();
+                try (Connection c = DriverManager.getConnection(url, user, pass);
+                     PreparedStatement ps = c.prepareStatement(sql)) {
+                    ps.setString(1, cats[rnd.nextInt(cats.length)]);
+                    ps.setString(2, tags[rnd.nextInt(tags.length)]);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        int n = 0; while (rs.next()) n++;
+                        System.out.println("cartesian: " + n + " rows in " + (System.currentTimeMillis()-t0) + "ms");
+                    }
+                } catch (Exception e) {
+                    System.err.println("query failed: " + e.getMessage());
+                }
+                Thread.sleep(ms);
+            }
+        }
+        static String env(String k, String d) {
+            String v = System.getenv(k);
+            return (v == null || v.isEmpty()) ? d : v;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pg-cartesian-tester
+  namespace: default
+  labels:
+    app.kubernetes.io/component: pg-cartesian-tester
+    app.kubernetes.io/name: pg-cartesian-tester
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pg-cartesian-tester
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: pg-cartesian-tester
+        app.kubernetes.io/name: pg-cartesian-tester
+    spec:
+      initContainers:
+      - name: fetch-deps
+        image: curlimages/curl:8.10.1
+        command: ["sh", "-c"]
+        args:
+          - |
+            set -e
+            echo "downloading postgres JDBC driver + splunk java agent..."
+            curl -fsSL -o /deps/postgresql.jar \
+              https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar
+            curl -fsSL -o /deps/splunk-otel-javaagent.jar \
+              https://github.com/signalfx/splunk-otel-java/releases/latest/download/splunk-otel-javaagent.jar
+            ls -l /deps
+        volumeMounts:
+        - name: deps
+          mountPath: /deps
+      containers:
+      - name: tester
+        image: eclipse-temurin:21-jdk
+        command: ["sh", "-c"]
+        args:
+          - exec java -javaagent:/deps/splunk-otel-javaagent.jar -cp /deps/postgresql.jar /app/Cartesian.java
+        env:
+        - name: OTEL_SERVICE_NAME
+          value: pg-cartesian-tester
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        # Send OTLP to the node-local Splunk collector agent (HTTP 4318 —
+        # the Splunk Java agent defaults to the OTLP http/protobuf exporter).
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(NODE_IP):4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        # deployment.environment is injected by the collector (resource/add_environment).
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=pg-cartesian-tester,service.namespace=opentelemetry-demo
+        # Keep the agent lean for a test client.
+        - name: OTEL_METRICS_EXPORTER
+          value: none
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: PG_URL
+          value: jdbc:postgresql://postgresql:5432/astroshop
+        - name: PG_USER
+          value: demo_app_user
+        - name: PG_PASS
+          value: demo_password
+        - name: INTERVAL_SECONDS
+          value: "3"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 384Mi
+        volumeMounts:
+        - name: deps
+          mountPath: /deps
+        - name: src
+          mountPath: /app
+      volumes:
+      - name: deps
+        emptyDir: {}
+      - name: src
+        configMap:
+          name: pg-cartesian-tester-src

--- a/src/accounting/Consumer.cs
+++ b/src/accounting/Consumer.cs
@@ -75,8 +75,12 @@ internal class Consumer : IDisposable
             {
                 try
                 {
-                    using var activity = MyActivitySource.StartActivity("order-consumed",  ActivityKind.Internal);
+                    // Consume() blocks waiting for the next message. Start the
+                    // span AFTER it returns so the span measures only message
+                    // processing, not idle poll wait (which otherwise inflated
+                    // order-consumed to the inter-order gap, e.g. 30s).
                     var consumeResult = _consumer.Consume();
+                    using var activity = MyActivitySource.StartActivity("order-consumed", ActivityKind.Consumer);
                     ProcessMessage(consumeResult.Message);
                 }
                 catch (ConsumeException e)

--- a/src/accounting/accounting-k8s.yaml
+++ b/src/accounting/accounting-k8s.yaml
@@ -78,7 +78,7 @@ spec:
         # that service. When set but service absent, TriggerValidation
         # swallows DNS NXDOMAIN / connection refused / timeout (120s cap).
         - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
-          value: 'false'
+          value: 'true'
         # Emit both old (db.name) and new (db.namespace) DB semconv attributes.
         - name: OTEL_SEMCONV_STABILITY_OPT_IN
           value: 'database/dup'

--- a/src/accounting/accounting-k8s.yaml
+++ b/src/accounting/accounting-k8s.yaml
@@ -71,7 +71,7 @@ spec:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://$(OTEL_COLLECTOR_NAME):4318
         - name: DB_CONNECTION_STRING
-          value: Host=postgresql;Username=otelu;Password=otelp;Database=otel
+          value: Host=postgresql;Username=otelu;Password=otelp;Database=astroshop
         # Optional fire-and-forget call to order-validation (throttle-demo).
         # Disabled by default (unset). To enable, set to the service URL
         # e.g. http://order-validation:8080 — throttle-demo manifest deploys
@@ -79,6 +79,9 @@ spec:
         # swallows DNS NXDOMAIN / connection refused / timeout (120s cap).
         - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
           value: 'false'
+        # Emit both old (db.name) and new (db.namespace) DB semconv attributes.
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: 'database/dup'
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.1.3,service.kafka=spanlink
         - name: SPLUNK_PROFILER_ENABLED

--- a/src/ad/ad-k8s.yaml
+++ b/src/ad/ad-k8s.yaml
@@ -140,6 +140,12 @@ spec:
           value: http://$(OTEL_COLLECTOR_NAME):4318
         - name: OTEL_EXPORTER_OTLP_PROTOCOL
           value: http/protobuf
+        # Export the OTLP logs signal so the Java agent's log4j appender ships
+        # the "secureapp"-scoped attack records to the collector (-> /v3/event).
+        # Without this the Splunk Java agent emits traces/metrics only and the
+        # security log records never leave the pod. (node/python set this too.)
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp
         - name: SERVER_PORT
           value: "8180"
         - name: SPLUNK_PROFILER_ENABLED

--- a/src/flagd/demo.flagd.json
+++ b/src/flagd/demo.flagd.json
@@ -166,11 +166,14 @@
       "defaultVariant": "off"
     },
     "recommendationCartesianQuery": {
-      "description": "DBMon Demo: Triggers a Cartesian join query (500M rows) in recommendation service PostgreSQL calls. Query returns correct results but processes 500M intermediate rows, taking 12+ seconds.",
+      "description": "DBMon Demo: Triggers a Cartesian join query in recommendation service PostgreSQL calls. Returns correct results but scans ~10M intermediate rows (~4s). Variant sets how often the slow query fires (base interval +/- jitter): off=disabled, normal=5min+/-20s, fast=3min+/-15s, faster=1min+/-10s, fastest=30s+/-5s. Jitter models a cache that refreshes after N queries rather than on a fixed clock.",
       "state": "ENABLED",
       "variants": {
-        "on": true,
-        "off": false
+        "off": "off",
+        "normal": "normal",
+        "fast": "fast",
+        "faster": "faster",
+        "fastest": "fastest"
       },
       "defaultVariant": "off"
     },

--- a/src/postgresql-setup/postgresql-setup-k8s.yaml
+++ b/src/postgresql-setup/postgresql-setup-k8s.yaml
@@ -31,7 +31,7 @@ data:
     -- SPDX-License-Identifier: Apache-2.0
 
     -- Enable pg_stat_statements for database monitoring (top query tracking)
-    -- Note: This runs in the 'otel' database. The extension is also created
+    -- Note: This runs in the 'astroshop' database. The extension is also created
     -- in the 'postgres' database by 00-pg-stat-statements.sh for top query monitoring.
     CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 

--- a/src/postgresql/00-pg-stat-statements.sh
+++ b/src/postgresql/00-pg-stat-statements.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Create pg_stat_statements extension in the postgres database
 # This is required for PostgreSQL receiver top query monitoring
-# The extension is also created in the otel database via init.sql
+# The extension is also created in the astroshop database via init.sql
 
 set -e
 

--- a/src/postgresql/init.sql
+++ b/src/postgresql/init.sql
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- Enable pg_stat_statements for database monitoring (top query tracking)
--- Note: This runs in the 'otel' database. The extension must also be created
+-- Note: This runs in the 'astroshop' database. The extension must also be created
 -- in the 'postgres' database for top query monitoring to work. This is handled
 -- by the 00-pg-stat-statements.sh script.
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;

--- a/src/postgresql/postgresql-k8s.yaml
+++ b/src/postgresql/postgresql-k8s.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       annotations:
         splunk.com/monitor: postgresql
-        splunk.com/postgresql.database: otel
+        splunk.com/postgresql.database: astroshop
       labels:
         opentelemetry.io/name: postgresql
         app.kubernetes.io/component: postgresql

--- a/src/postgresql/postgresql-k8s.yaml
+++ b/src/postgresql/postgresql-k8s.yaml
@@ -78,7 +78,7 @@ spec:
         - name: POSTGRES_PASSWORD
           value: otel
         - name: POSTGRES_DB
-          value: otel
+          value: astroshop
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.1.3,service.kafka=no
         resources:

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -106,15 +106,31 @@ func init() {
 	logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 }
 
+// dsnField extracts a key=value field from a libpq keyword/value DSN
+// (e.g. "host=postgresql dbname=astroshop"). Returns "" if absent.
+func dsnField(dsn, key string) string {
+	for _, part := range strings.Fields(dsn) {
+		if k, v, ok := strings.Cut(part, "="); ok && k == key {
+			return v
+		}
+	}
+	return ""
+}
+
 func initDatabase() error {
 	connStr := os.Getenv("DB_CONNECTION_STRING")
 	if connStr == "" {
 		return fmt.Errorf("DB_CONNECTION_STRING environment variable not set")
 	}
 
-	dbAttrs := otelsql.WithAttributes(
-		append(otelsql.AttributesFromDSN(connStr), semconv.DBSystemNamePostgreSQL)...,
-	)
+	// otelsql + semconv v1.38 emits the new db.namespace attribute only.
+	// Also emit the old db.name key (parsed from the DSN) so the inferred DB
+	// service resolves consistently with the other services that still use it.
+	attrs := append(otelsql.AttributesFromDSN(connStr), semconv.DBSystemNamePostgreSQL)
+	if dbName := dsnField(connStr, "dbname"); dbName != "" {
+		attrs = append(attrs, attribute.String("db.name", dbName))
+	}
+	dbAttrs := otelsql.WithAttributes(attrs...)
 
 	var err error
 	db, err = otelsql.Open("postgres", connStr,

--- a/src/product-catalog/product-catalog-k8s.yaml
+++ b/src/product-catalog/product-catalog-k8s.yaml
@@ -77,7 +77,7 @@ spec:
         - name: FLAGD_PORT
           value: '8013'
         - name: DB_CONNECTION_STRING
-          value: "host=postgresql user=otelu password=otelp dbname=otel sslmode=disable"
+          value: "host=postgresql user=otelu password=otelp dbname=astroshop sslmode=disable"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://$(OTEL_COLLECTOR_NAME):4317
         - name: GOMEMLIMIT

--- a/src/product-reviews/product-reviews-k8s.yaml
+++ b/src/product-reviews/product-reviews-k8s.yaml
@@ -73,7 +73,7 @@ spec:
         - name: OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
           value: 'span_only'
         - name: OTEL_SEMCONV_STABILITY_OPT_IN
-          value: 'gen_ai_latest_experimental'
+          value: 'gen_ai_latest_experimental,database/dup'
         - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
           value: python
         - name: FLAGD_HOST
@@ -81,7 +81,7 @@ spec:
         - name: FLAGD_PORT
           value: '8013'
         - name: DB_CONNECTION_STRING
-          value: host=postgresql user=otelu password=otelp dbname=otel
+          value: host=postgresql user=otelu password=otelp dbname=astroshop
         - name: LLM_HOST
           value: llm
         - name: LLM_PORT

--- a/src/recommendation/recommendation-k8s.yaml
+++ b/src/recommendation/recommendation-k8s.yaml
@@ -74,6 +74,9 @@ spec:
           value: product-catalog:8080
         - name: OTEL_PYTHON_LOG_CORRELATION
           value: 'true'
+        # Emit both old (db.name) and new (db.namespace) DB semconv attributes.
+        - name: OTEL_SEMCONV_STABILITY_OPT_IN
+          value: 'database/dup'
         - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
           value: python
         - name: FLAGD_HOST
@@ -96,7 +99,7 @@ spec:
         - name: POSTGRES_PORT
           value: "5432"
         - name: POSTGRES_DB
-          value: "otel"
+          value: "astroshop"
         - name: POSTGRES_USER
           value: "demo_app_user"
         - name: POSTGRES_PASSWORD

--- a/src/recommendation/recommendation_server.py
+++ b/src/recommendation/recommendation_server.py
@@ -122,49 +122,67 @@ TAGS = ['beginner', 'advanced', 'astrophotography', 'visual', 'planetary']
 # PostgreSQL connection pool (lazy initialized)
 pg_pool = None
 
-# Cartesian query rate limiter: spread N executions evenly across a window
-CARTESIAN_WINDOW_SECONDS = int(os.environ.get('CARTESIAN_WINDOW_SECONDS', '900'))  # 15 min
-CARTESIAN_MAX_PER_WINDOW = int(os.environ.get('CARTESIAN_MAX_PER_WINDOW', '3'))
+# Cartesian query rate: flag variant -> (base_interval_seconds, jitter_seconds).
+# The slow query fires at most once per (base +/- jitter). Jitter models a
+# cache that refreshes after ~N queries rather than on a fixed clock, adding
+# realistic variance on top of the steady loadgen cadence.
+CARTESIAN_RATE_TIERS = {
+    'normal':  (300, 20),  # 5 min +/- 20s
+    'fast':    (180, 15),  # 3 min +/- 15s
+    'faster':  (60, 10),   # 1 min +/- 10s
+    'fastest': (30, 5),    # 30s +/- 5s
+}
+# Legacy boolean 'on' maps to this tier for backward compatibility.
+CARTESIAN_LEGACY_ON_TIER = 'normal'
+
 cartesian_last_exec = 0.0
-cartesian_window_count = 0
-cartesian_window_start = 0.0
+cartesian_next_interval = 0.0  # base +/- jitter, recomputed after each fire
+cartesian_tier = None
 
 
-def cartesian_rate_limit_ok():
+def cartesian_variant():
+    """Read the flag as a string variant. Tolerates the legacy boolean 'on'/'off'."""
+    client = api.get_client()
+    variant = client.get_string_value("recommendationCartesianQuery", "off")
+    if variant in ("on", "true", "True"):
+        return CARTESIAN_LEGACY_ON_TIER
+    return variant
+
+
+def cartesian_rate_limit_ok(tier):
     """
-    Spread executions evenly across the window.
-    With defaults (3 per 900s), fires once every ~300s (5 min).
-    First call in a new window always fires immediately.
+    Fire at most once per (base_interval +/- jitter) for the given tier.
+    The first call for a tier (including right after a tier change) fires
+    immediately; spacing is recomputed with fresh jitter after each fire.
+    Unknown/off tier never fires.
     """
-    global cartesian_last_exec, cartesian_window_count, cartesian_window_start
+    global cartesian_last_exec, cartesian_next_interval, cartesian_tier
+    if tier not in CARTESIAN_RATE_TIERS:
+        cartesian_tier = tier
+        return False
+    base, jitter = CARTESIAN_RATE_TIERS[tier]
     now = time.time()
-    min_interval = CARTESIAN_WINDOW_SECONDS / CARTESIAN_MAX_PER_WINDOW
-
-    # New window -- reset counters
-    if now - cartesian_window_start >= CARTESIAN_WINDOW_SECONDS:
-        cartesian_window_start = now
-        cartesian_window_count = 0
-
-    # Already hit max for this window
-    if cartesian_window_count >= CARTESIAN_MAX_PER_WINDOW:
+    # Tier just changed -- fire on this call so flag flips take effect promptly.
+    if tier != cartesian_tier:
+        cartesian_tier = tier
+        cartesian_next_interval = 0.0
+    if now - cartesian_last_exec < cartesian_next_interval:
         return False
-
-    # Enforce minimum spacing between executions
-    if cartesian_window_count > 0 and (now - cartesian_last_exec) < min_interval:
-        return False
-
     cartesian_last_exec = now
-    cartesian_window_count += 1
+    cartesian_next_interval = base + random.uniform(-jitter, jitter)
     return True
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
     def ListRecommendations(self, request, context):
         span = trace.get_current_span()
 
-        # DBMon Cartesian Demo - check feature flag
-        if check_feature_flag("recommendationCartesianQuery"):
+        # DBMon Cartesian Demo - variant controls fire cadence
+        # (off / normal / fast / faster / fastest).
+        tier = cartesian_variant()
+        if tier != "off":
             span.set_attribute("app.cartesian_demo.enabled", True)
-            if cartesian_rate_limit_ok():
+            span.set_attribute("app.cartesian_demo.tier", tier)
+            if cartesian_rate_limit_ok(tier):
                 span.set_attribute("app.cartesian_demo.rate_limited", False)
                 # Execute the slow Cartesian query (bad query = True)
                 cartesian_results = execute_cartesian_query(use_bad_query=True)
@@ -269,7 +287,7 @@ def get_pg_pool():
                 maxconn=5,
                 host=os.environ.get('POSTGRES_HOST', 'postgres'),
                 port=int(os.environ.get('POSTGRES_PORT', '5432')),
-                database=os.environ.get('POSTGRES_DB', 'otel'),
+                database=os.environ.get('POSTGRES_DB', 'astroshop'),
                 user=os.environ.get('POSTGRES_USER', 'demo_app_user'),
                 password=os.environ.get('POSTGRES_PASSWORD', 'demo_password')
             )
@@ -293,13 +311,16 @@ def execute_cartesian_query(use_bad_query: bool):
     category = random.choice(CATEGORIES)
     tag = random.choice(TAGS)
 
-    db_name = os.environ.get('POSTGRES_DB', 'otel')
+    db_name = os.environ.get('POSTGRES_DB', 'astroshop')
     db_user = os.environ.get('POSTGRES_USER', 'demo_app_user')
 
     tracer = trace.get_tracer_provider().get_tracer('recommendationservice')
     with tracer.start_as_current_span('db.get_product_recommendations') as span:
         span.set_attribute('db.system', 'postgresql')
+        # Emit both old (db.name) and new (db.namespace) semconv keys so the
+        # inferred DB service resolves consistently across all languages.
         span.set_attribute('db.name', db_name)
+        span.set_attribute('db.namespace', db_name)
         span.set_attribute('db.user', db_user)
         span.set_attribute('db.operation', 'SELECT')
         span.set_attribute('db.statement', query_normalized)

--- a/src/recommendation/requirements.txt
+++ b/src/recommendation/requirements.txt
@@ -1,7 +1,7 @@
 grpcio-health-checking==1.78.0
 openfeature-hooks-opentelemetry==0.3.1
 openfeature-provider-flagd==0.2.3
-splunk-opentelemetry==2.10.1
+splunk-opentelemetry==2.12.1
 psutil==7.0.0 # Importing this will also import opentelemetry-instrumentation-system-metrics when running opentelemetry-bootstrap
 python-dotenv==1.2.2
 python-json-logger==4.0.0

--- a/src/secureapp-loadgen/unified-v2/apps/java-secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
+++ b/src/secureapp-loadgen/unified-v2/apps/java-secureapp-loadgen/src/main/java/com/appd/e2e/JavaSecureAppTestApp.java
@@ -173,7 +173,7 @@ public class JavaSecureAppTestApp {
             try {
                 Class<?> logManagerClass = Class.forName("org.apache.logging.log4j.LogManager");
                 Method getLoggerMethod = logManagerClass.getMethod("getLogger", String.class);
-                Object logger = getLoggerMethod.invoke(null, "TeamPortal");
+                Object logger = getLoggerMethod.invoke(null, "secureapp");
                 Method errorMethod = logger.getClass().getMethod("error", String.class);
                 errorMethod.invoke(logger, "${jndi:ldap://127.0.0.1:1389/log4j-test}");
                 result = "{\"status\": \"failed\", \"message\": \"Invalid credentials\"}";
@@ -416,7 +416,7 @@ public class JavaSecureAppTestApp {
             try {
                 Class<?> logManagerClass = Class.forName("org.apache.logging.log4j.LogManager");
                 Method getLoggerMethod = logManagerClass.getMethod("getLogger", String.class);
-                Object logger = getLoggerMethod.invoke(null, "TeamPortal");
+                Object logger = getLoggerMethod.invoke(null, "secureapp");
                 Method errorMethod = logger.getClass().getMethod("error", String.class);
                 errorMethod.invoke(logger, "${jndi:ldap://127.0.0.1:1389/log4j-test}");
                 log.append("log4j:ok ");

--- a/src/secureapp-loadgen/unified-v2/apps/node-secureapp-loadgen/package.json
+++ b/src/secureapp-loadgen/unified-v2/apps/node-secureapp-loadgen/package.json
@@ -12,6 +12,7 @@
     "start:plain": "node src/server.js"
   },
   "dependencies": {
+    "@opentelemetry/api-logs": "^0.219.0",
     "@splunk/otel": "^4.9.0",
     "axios": "0.21.1",
     "better-sqlite3": "^11.7.0",

--- a/src/secureapp-loadgen/unified-v2/apps/node-secureapp-loadgen/src/attacks.js
+++ b/src/secureapp-loadgen/unified-v2/apps/node-secureapp-loadgen/src/attacks.js
@@ -6,8 +6,15 @@ const Database = require('better-sqlite3');
 const yaml = require('js-yaml');
 const serialize = require('node-serialize');
 
+const { logs, SeverityNumber } = require('@opentelemetry/api-logs');
+
 const { vulnerabilityMetadata, ROTATE_ORDER } = require('./vulnerabilities');
 const { attackScenarioEnabled } = require('./config');
+
+// OTel logger whose instrumentation scope name is "secureapp" — the collector
+// routes log records with scope == "secureapp" to the SecureApp /v3/event ingest.
+// Mirrors the Java/Python apps' "secureapp" logger name.
+const secureappLogger = logs.getLogger('secureapp');
 
 let db;
 
@@ -75,9 +82,14 @@ function triggerLog4j() {
   } catch {
     // unsafe load path exercised
   }
-  console.error(
-    'Authentication failure for user: ${jndi:ldap://127.0.0.1:1389/log4j-test}',
-  );
+  const message =
+    'Authentication failure for user: ${jndi:ldap://127.0.0.1:1389/log4j-test}';
+  console.error(message);
+  secureappLogger.emit({
+    severityNumber: SeverityNumber.ERROR,
+    severityText: 'ERROR',
+    body: message,
+  });
   return result('log4j', { status: 'failed', message: 'Invalid credentials' });
 }
 

--- a/src/secureapp-loadgen/unified-v2/apps/python-secureapp-loadgen/src/team_portal/attacks.py
+++ b/src/secureapp-loadgen/unified-v2/apps/python-secureapp-loadgen/src/team_portal/attacks.py
@@ -15,7 +15,7 @@ from sqlalchemy.pool import StaticPool
 
 from team_portal.vulnerabilities import vulnerability_metadata
 
-logger = logging.getLogger("TeamPortal")
+logger = logging.getLogger("secureapp")
 
 SQLALCHEMY_URL = "sqlite:///:memory:"
 _engine = create_engine(

--- a/src/sql-server-fraud/sql-server-fraud-k8s.yaml
+++ b/src/sql-server-fraud/sql-server-fraud-k8s.yaml
@@ -65,12 +65,19 @@ spec:
               command:
               - /bin/bash
               - -c
-              - 'sleep 30
-
-                /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}"
-                -C -i /docker-entrypoint-initdb.d/init-db.sql
-
-                '
+              # Seed FraudDetection once SQL Server accepts queries. Poll for
+              # readiness instead of a fixed sleep, and NEVER exit non-zero:
+              # a failed postStart hook makes kubelet kill the container, which
+              # on a fresh PVC interrupts first-boot system-DB creation and
+              # leaves model/msdb corrupt -> permanent CrashLoopBackOff. The
+              # seed is idempotent (IF NOT EXISTS), so re-running is safe.
+              - |
+                for i in $(seq 1 60); do
+                  /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -C -Q "SELECT 1" && break
+                  sleep 5
+                done
+                /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -C -i /docker-entrypoint-initdb.d/init-db.sql || true
+                exit 0
         resources:
           requests:
             cpu: 250m
@@ -78,15 +85,27 @@ spec:
           limits:
             cpu: '1'
             memory: 2Gi
+        # Startup probe gates liveness/readiness until SQL Server can actually
+        # answer a query. failureThreshold*periodSeconds = up to 300s for a slow
+        # first boot on local-path storage, so liveness never kills mid-init.
+        startupProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -C -Q "SELECT 1"
+          periodSeconds: 10
+          failureThreshold: 30
         readinessProbe:
-          tcpSocket:
-            port: 1433
-          initialDelaySeconds: 10
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -C -Q "SELECT 1"
           periodSeconds: 10
         livenessProbe:
           tcpSocket:
             port: 1433
-          initialDelaySeconds: 30
           periodSeconds: 20
       volumes:
       - name: init-script


### PR DESCRIPTION
## Problem
SecureApp attack/security events never reached the Splunk SecureApp backend on the running demo clusters (astronomy-shop-us/eu). The loadgen fired and the CSA Java agent detected attacks, but nothing showed in o11y.

## Root cause — three stacked bugs, all required
1. **Logger scope mismatch.** The apps logged security events via a logger named `TeamPortal`, so the OTel log appender set `instrumentation_scope.name = "TeamPortal"`. The collector routing keys on `instrumentation_scope.name == "secureapp"` → never matched → events fell to the default logs pipeline (HEC) instead of `/v3/event`.
2. **Routing missing from shared values.** The secureapp collector routing existed only in the orphaned `unified-v2` standalone collector-configmap, never in `kubernetes/*-values.yaml`.
3. **Java sidecar never exported the OTLP logs signal.** The Java (ad) sidecar had no `OTEL_LOGS_EXPORTER=otlp`, so the Splunk Java agent's log4j appender never shipped the records off-pod. node/python sidecars already set it. This was the final blocker.

## Changes
- Rename security loggers to `secureapp` so emitted scope matches routing: java (2 Log4Shell paths), python (`attacks.py`), node (add OTel Logs API logger `logs.getLogger("secureapp")` + emit; add `@opentelemetry/api-logs@^0.219.0`).
- Add secureapp log routing to `2.0.7` and `2.0.8` collector values (dbmon-style: `otlp_http/secureapp` exporter → `/v3/event`, `routing/logs` connector on scope, `logs/split` + `logs/secureapp` pipelines). No signalfx — aligned with the OTLP-events migration.
- Add `OTEL_LOGS_EXPORTER=otlp` to the Java secureapp sidecar in `ad-k8s.yaml`.

## Verification
Deployed to astronomy-shop-us and -eu (hotfix beta images + collector routing + ad env). Confirmed `ERROR secureapp - ${jndi:...}` emitted and Java attack events landing in o11y SecureApp within ~2min of the fix. node/python execute the CVEs but have no runtime security agent, so only Java produces SecureApp detections (expected).

## Follow-up
Promote targets need the patched Helm values applied to their collector in addition to the stitched manifest — routing lives in values, not the app manifest.