### PR TITLE
fix(release): repair non-beta hotfix path (.hotfix.yaml) + add 2.0.7 secureapp routing

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -385,7 +385,15 @@ jobs:
 
       - name: Update hotfix tracking
         if: ${{ needs.determine-version.outputs.is_hotfix == 'true' }}
-        run: echo "Hotfix already tracked in determine-version step"
+        run: |
+          # determine-version ran manage-hotfix in a separate job (separate
+          # runner/filesystem), so .hotfix.yaml does not exist in this job's
+          # checkout. Regenerate it here with the SAME first-service logic so
+          # the Create Pull Request step can `git add .hotfix.yaml`. Both jobs
+          # start from the same committed baseline on main, so the increment is
+          # deterministic and matches the computed version.
+          SERVICE_NAME=$(echo "${{ inputs.services }}" | tr ',' '\n' | head -1 | xargs)
+          python3 .github/scripts/manage-hotfix.py add "$SERVICE_NAME"
 
       - name: Update source manifests with new image references
         run: |

--- a/kubernetes/splunk-astronomy-shop-2.0.7-values.yaml
+++ b/kubernetes/splunk-astronomy-shop-2.0.7-values.yaml
@@ -226,6 +226,18 @@ agent:
             flush_timeout: 15s
             max_size: 10485760 # 10 MiB
             sizer: bytes
+      # Exports secureapp security events as logs -> SecureApp /v3/event.
+      # Fed by the routing/logs connector below (scope == "secureapp").
+      otlp_http/secureapp:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+          X-splunk-instrumentation-library: secureapp
+        logs_endpoint: https://ingest.${WORKSHOP_REALM}.signalfx.com/v3/event
+        sending_queue:
+          batch:
+            flush_timeout: 15s
+            max_size: 10485760 # 10 MiB
+            sizer: bytes
     processors:
       # Inject environment as a resource attribute for traces
       resource/add_environment:
@@ -356,6 +368,18 @@ agent:
             statements:
               - set(resource.attributes["service.instance.id"], Concat([resource.attributes["deployment.environment"], " - ", resource.attributes["k8s.pod.name"]], ""))
 
+    connectors:
+      # Split OTLP logs by instrumentation scope. Security-event records emitted
+      # by the secureapp sidecars' "secureapp" logger (scope == "secureapp") are
+      # routed to logs/secureapp -> /v3/event; all other logs stay on the
+      # default logs pipeline (HEC).
+      routing/logs:
+        default_pipelines: [logs]
+        table:
+          - context: log
+            condition: instrumentation_scope.name == "secureapp"
+            pipelines: [logs/secureapp]
+
     service:
       pipelines:
         metrics:
@@ -375,6 +399,23 @@ agent:
           receivers: [receiver_creator]
           processors: [memory_limiter, batch, resourcedetection, resource, resource/add_environment, transform/dbmon]
           exporters: [otlp_http/dbmon]
+        # SecureApp logs routing. otlp logs enter via logs/split, the
+        # routing/logs connector splits scope=="secureapp" off to /v3/event,
+        # everything else falls through to the default logs pipeline (HEC).
+        # The logs pipeline below overrides the chart default to swap the otlp
+        # receiver for routing/logs; receivers/processors/exporters otherwise
+        # mirror the chart default (splunk-otel-collector logs pipeline).
+        logs:
+          receivers: [file_log, routing/logs]
+          processors: [memory_limiter, k8s_attributes, filter/logs, batch, resourcedetection, resource, resource/logs, resource/add_environment]
+          exporters: [splunk_hec/o11y, splunk_hec/platform_logs]
+        logs/split:
+          receivers: [otlp]
+          exporters: [routing/logs]
+        logs/secureapp:
+          receivers: [routing/logs]
+          processors: [memory_limiter, batch]
+          exporters: [otlp_http/secureapp]
 
 logsCollection:
   extraFileLogs:


### PR DESCRIPTION
Two fixes needed to complete the secureapp hotfix release (PR #294 follow-up).

## 1. prod-release.yml — non-beta hotfix path broken
Run 31487540128 failed:
```
Create Pull Request (non-beta): fatal: pathspec '.hotfix.yaml' did not match any files
```
The `Update hotfix tracking` step was `echo "Hotfix already tracked in determine-version step"` — but `determine-version` runs in a separate job/runner, so the `.hotfix.yaml` it wrote there is absent when `Create Pull Request` does `git add .hotfix.yaml`. (The beta path avoids this by creating a pre-release, no PR.)

Fix: regenerate `.hotfix.yaml` in the `update-and-release` job using the same first-service logic. Both jobs start from the same committed baseline on main, so the increment is deterministic and matches the computed version.

## 2. 2.0.7 collector values — missing secureapp routing
The 2.0.7 values were missing the secureapp log routing that 2.0.8 got in #294 (the commit was never pushed). Adds the same dbmon-style block (otlp_http/secureapp → /v3/event, routing/logs connector, logs/split + logs/secureapp pipelines) so the deployed 2.0.7 clusters route scope=="secureapp" logs correctly.

After merge, re-running the non-beta hotfix build for the 3 secureapp services will complete cleanly (images already built as ...-java-1; re-run will produce the source PR + stitched promotable manifest).