### PR TITLE
docs+chore: deprecate Docker Compose, document Kubernetes deploy path

### DIFF
--- a/HOW-TO-DEPLOY-AND-RUN.md
+++ b/HOW-TO-DEPLOY-AND-RUN.md
@@ -1,0 +1,155 @@
+# How to Deploy and Run the Splunk OpenTelemetry Demo
+
+**Supported deployment target: Kubernetes.**
+
+This fork ships as a set of **stitched Kubernetes manifests + a Helm values
+file**, published as assets on each GitHub Release. That is the one and only
+path we build, test, and promote.
+
+> **Docker Compose is deprecated and unmaintained.** The `docker-compose*.yml`
+> files and `make start` target are inherited from the upstream OpenTelemetry
+> demo and are **not** kept in sync with this fork's Splunk instrumentation,
+> image tags, or database wiring. They are known-broken on a fresh clone (see
+> issues #298 and #299) and will be removed. **Do not use Docker Compose to run
+> this demo.** Use the Kubernetes manifests below.
+
+---
+
+## What you deploy
+
+Every release attaches these assets (current promoted version: see
+[`kubernetes/PROMOTED-VERSION`](kubernetes/PROMOTED-VERSION)):
+
+| Asset | Purpose |
+|-------|---------|
+| `splunk-astronomy-shop-<VERSION>.yaml` | **Core** Astronomy Shop services |
+| `splunk-astronomy-shop-<VERSION>-diab.yaml` | Demo-in-a-Box (adds Traefik ingress) |
+| `splunk-astronomy-shop-<VERSION>-lambda.yaml` | Lambda / planning services |
+| `splunk-astronomy-shop-<VERSION>-throttle-demo.yaml` | order-validation (k8s CPU-throttle scenario) |
+| `splunk-astronomy-shop-<VERSION>-dc-shim.yaml` | Datacenter shim + db + loadgen |
+| `splunk-astronomy-shop-<VERSION>-values.yaml` | Helm values (for the collector / reference) |
+
+The app manifest is plain Kubernetes YAML — apply it with `kubectl apply -f`.
+It does **not** need Helm. Telemetry is sent to Splunk Observability Cloud by
+the **Splunk OpenTelemetry Collector**, which you install separately with Helm
+(see [DEPLOYMENT.md](DEPLOYMENT.md)).
+
+---
+
+## Prerequisites
+
+- A Kubernetes cluster. Minimum ~8 CPU / 16 GB RAM.
+- `kubectl` and `helm` (v3+).
+
+### Tested platforms
+
+| Platform | Status |
+|----------|--------|
+| **k3d** (k3s-in-Docker) | ✅ Tested / known-good — recommended for laptop-scale |
+| **Docker Desktop – Kubernetes** | ⚠️ Has worked previously; not continuously verified |
+| EKS / GKE / AKS | ✅ Production-like targets |
+| Splunk Show Demo-in-a-Box | ✅ Use the `-diab.yaml` variant |
+| minikube | ⚠️ Should work; not continuously verified |
+- A Splunk Observability Cloud account (realm, access token, RUM token) and,
+  for logs, a Splunk Cloud HEC token.
+
+Full collector install, secrets, ingress, and troubleshooting live in
+**[DEPLOYMENT.md](DEPLOYMENT.md)** — this page is the short "get it running"
+path.
+
+---
+
+## Getting the manifests — three ways
+
+### 1. Direct from the GitHub Release (self-serve)
+
+Pull the version you want straight from the release tag:
+
+```bash
+VERSION=2.0.7
+BASE=https://github.com/splunk/opentelemetry-demo/releases/download/v${VERSION}
+
+# core app manifest + values
+curl -sSLO ${BASE}/splunk-astronomy-shop-${VERSION}.yaml
+curl -sSLO ${BASE}/splunk-astronomy-shop-${VERSION}-values.yaml
+```
+
+Release page: <https://github.com/splunk/opentelemetry-demo/releases/tag/v2.0.7>
+
+### 2. Splunk Show / Demo-in-a-Box (promoted)
+
+Promoted releases are pushed automatically to
+[`splunk/o11y-field-demos`](https://github.com/splunk/o11y-field-demos) by the
+**Astronomy Shop – Promote** GitHub Action (this also updates
+`kubernetes/PROMOTED-VERSION`). If you deploy through Splunk Show / DIAB, the
+manifests are already staged there — use the `-diab.yaml` variant.
+
+### 3. Workshop repo
+
+Workshop deployments consume the same released assets via the workshop
+repository. Point the workshop at the pinned `<VERSION>` manifest + values so it
+stays reproducible.
+
+> In all three cases it's the **same** release assets. Direct-from-release is
+> the source of truth; o11y-field-demos and the workshop are promotion targets.
+
+---
+
+## Deploy (core app)
+
+```bash
+VERSION=2.0.7
+
+# 1. (once) install the Splunk OTel Collector via Helm — see DEPLOYMENT.md
+#    and create your secret (example: kubernetes/example-secrets.yaml)
+
+# 2. deploy the Astronomy Shop
+kubectl apply -f splunk-astronomy-shop-${VERSION}.yaml
+
+# 3. watch it come up
+kubectl get pods -w
+```
+
+For Demo-in-a-Box (with ingress) use the DIAB variant instead:
+
+```bash
+kubectl apply -f splunk-astronomy-shop-${VERSION}-diab.yaml
+```
+
+Optional add-on scenarios (apply on top of core):
+
+```bash
+kubectl apply -f splunk-astronomy-shop-${VERSION}-lambda.yaml         # lambda/planning
+kubectl apply -f splunk-astronomy-shop-${VERSION}-throttle-demo.yaml  # CPU-throttle demo
+kubectl apply -f splunk-astronomy-shop-${VERSION}-dc-shim.yaml        # datacenter shim
+```
+
+---
+
+## Verify
+
+```bash
+# all core pods Ready
+kubectl get pods
+
+# reach the store UI (frontend-proxy) via port-forward
+kubectl port-forward svc/frontend-proxy 8080:8080
+# then open http://localhost:8080
+```
+
+Then confirm traces/metrics/logs are arriving in Splunk Observability Cloud for
+your `deployment.environment`.
+
+---
+
+## Why not Docker Compose?
+
+This fork's value is in the Splunk-specific instrumentation, image tags,
+database wiring (single `astroshop` Postgres), and the stitched k8s manifests —
+all of which are exercised by the Kubernetes path and the release pipeline. The
+upstream `docker-compose*.yml` files are not part of that pipeline, drift out of
+sync, and break on a fresh clone. Use the manifests above.
+
+If you need a laptop-scale cluster, run the manifests on **k3d** (tested,
+known-good) — that exercises the exact same artifacts we ship. **Docker Desktop's
+built-in Kubernetes** has also worked in the past.

--- a/Makefile
+++ b/Makefile
@@ -185,28 +185,43 @@ check-clean-work-tree:
 	  exit 1; \
 	fi
 
+# ==============================================================================
+# Docker Compose is NOT supported in this Splunk fork.
+#
+# The docker-compose*.yml files are inherited from the upstream OpenTelemetry
+# demo and are intentionally NOT maintained against this fork's Splunk
+# instrumentation, image tags, and database wiring. They are known-broken on a
+# fresh clone (see issues #298 and #299). Deploy on Kubernetes instead.
+#
+# See HOW-TO-DEPLOY-AND-RUN.md and DEPLOYMENT.md.
+# ==============================================================================
+define COMPOSE_UNSUPPORTED
+	@echo ""
+	@echo "=============================================================================="
+	@echo " Docker Compose is NOT supported in this Splunk fork."
+	@echo ""
+	@echo " These compose files come from upstream OpenTelemetry and are not kept in"
+	@echo " sync with Splunk instrumentation, image tags, or DB wiring. They are"
+	@echo " known-broken on a fresh clone (issues #298, #299)."
+	@echo ""
+	@echo " Deploy on Kubernetes instead:"
+	@echo "   - HOW-TO-DEPLOY-AND-RUN.md   (short path: released manifests + values)"
+	@echo "   - DEPLOYMENT.md              (full Splunk Observability Cloud setup)"
+	@echo "   - Release: https://github.com/splunk/opentelemetry-demo/releases/tag/v2.0.7"
+	@echo ""
+	@echo " For laptop-scale, run the same manifests on k3d/minikube."
+	@echo "=============================================================================="
+	@echo ""
+	@exit 1
+endef
+
 .PHONY: start
 start:
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) up --force-recreate --remove-orphans --detach
-	@echo ""
-	@echo "OpenTelemetry Demo is running."
-	@echo "Go to http://localhost:8080 for the demo UI."
-	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
-	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
-	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
-	@echo "Go to http://localhost:8080/feature/ to change feature flags."
-	@echo "Go to http://localhost:8080/telemetry/ for the Weaver generated telemetry documentation."
+	$(COMPOSE_UNSUPPORTED)
 
 .PHONY: start-minimal
 start-minimal:
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) -f docker-compose.minimal.yml up --force-recreate --remove-orphans --detach
-	@echo ""
-	@echo "OpenTelemetry Demo in minimal mode is running."
-	@echo "Go to http://localhost:8080 for the demo UI."
-	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
-	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
-	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
-	@echo "Go to https://opentelemetry.io/docs/demo/feature-flags/ to learn how to change feature flags."
+	$(COMPOSE_UNSUPPORTED)
 
 .PHONY: stop
 stop:

--- a/README.md
+++ b/README.md
@@ -56,8 +56,15 @@ See [PRODUCTION-WORKFLOW-GUIDE.md](./PRODUCTION-WORKFLOW-GUIDE.md) for workflow 
 
 ## Quick start
 
-You can be up and running with the demo in a few minutes. Check out the docs for
-your preferred deployment method:
+**This Splunk fork deploys on Kubernetes using released manifests.** See
+**[HOW-TO-DEPLOY-AND-RUN.md](HOW-TO-DEPLOY-AND-RUN.md)** for the short path and
+**[DEPLOYMENT.md](DEPLOYMENT.md)** for the full Splunk Observability Cloud setup.
+
+> **Note:** Docker Compose (`make start` / `docker-compose*.yml`) is inherited
+> from upstream, is **not maintained** in this fork, and is known-broken on a
+> fresh clone (issues #298/#299). Use the Kubernetes manifests instead.
+
+Upstream (generic, non-Splunk) deployment docs:
 
 - [Docker](https://opentelemetry.io/docs/demo/docker_deployment/)
 - [Kubernetes](https://opentelemetry.io/docs/demo/kubernetes_deployment/)

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,6 +1,12 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# ============================================================================
+#  UNSUPPORTED IN THIS SPLUNK FORK — Docker Compose is not maintained here.
+#  Inherited from upstream; known-broken on a fresh clone (issues #298, #299).
+#  Deploy on Kubernetes instead — see HOW-TO-DEPLOY-AND-RUN.md / DEPLOYMENT.md.
+# ============================================================================
+
 include:
   - path:
       - docker-compose.yml     # depend on the main docker-compose file

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -1,6 +1,19 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# ============================================================================
+#  UNSUPPORTED IN THIS SPLUNK FORK — DO NOT RUN WITH DOCKER COMPOSE
+#
+#  Inherited from upstream OpenTelemetry; NOT maintained against this fork's
+#  Splunk instrumentation, image tags, or DB wiring. Known-broken on a fresh
+#  clone (issues #298, #299).
+#
+#  Deploy on Kubernetes instead:
+#    - HOW-TO-DEPLOY-AND-RUN.md   (released manifests + values)
+#    - DEPLOYMENT.md              (full Splunk Observability Cloud setup)
+#    - https://github.com/splunk/opentelemetry-demo/releases/tag/v2.0.7
+# ============================================================================
+
 x-default-logging: &logging
   driver: "json-file"
   options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# ============================================================================
+#  UNSUPPORTED IN THIS SPLUNK FORK — DO NOT RUN WITH DOCKER COMPOSE
+#
+#  This file is inherited from the upstream OpenTelemetry demo. It is NOT
+#  maintained against this fork's Splunk instrumentation, image tags, or
+#  database wiring, and is known-broken on a fresh clone (issues #298, #299).
+#  It is retained only as the `docker buildx bake` image-build definition.
+#
+#  Deploy on Kubernetes instead:
+#    - HOW-TO-DEPLOY-AND-RUN.md   (released manifests + values)
+#    - DEPLOYMENT.md              (full Splunk Observability Cloud setup)
+#    - https://github.com/splunk/opentelemetry-demo/releases/tag/v2.0.7
+# ============================================================================
+
 x-default-logging: &logging
   driver: "json-file"
   options:


### PR DESCRIPTION
## What

Deprecate Docker Compose in this fork and document the supported Kubernetes deploy path.

Docker Compose (`make start` / `docker-compose*.yml`) is inherited from the upstream OpenTelemetry demo and is **not maintained** here — it drifts out of sync with this fork's Splunk instrumentation, image tags, and DB wiring, and is known-broken on a fresh clone. Keeping it in semi-sync with upstream isn't worth it. This PR makes the unsupported status clear and obvious without deleting the files.

## Changes

**Docs**
- Add `HOW-TO-DEPLOY-AND-RUN.md` — the supported Kubernetes path: released manifests + values from GitHub Releases, promoted to `splunk/o11y-field-demos` (Splunk Show / DIAB) and the workshop repo. Lists tested platforms (**k3d** known-good; **Docker Desktop Kubernetes** has worked previously).
- Point README Quick start at it; flag Compose as deprecated. Full Splunk O11y setup remains in `DEPLOYMENT.md`.

**Make Compose fail obviously** (files kept — they remain the `docker buildx bake` image-build definition and ease upstream sync)
- `make start` / `start-minimal` now print an UNSUPPORTED banner and `exit 1` instead of running `docker compose up`.
- Prominent UNSUPPORTED banner atop `docker-compose.yml`, `docker-compose.minimal.yml`, `docker-compose-tests.yml`.

## Closes

Addresses (both closed as not-planned, Compose is unsupported):
- #298 — build error on fresh pull (deleted `grafana.ini` / `jaeger/config.yml`, compose refs left)
- #299 — compose DB wiring mismatch (`astronomy_user`/`astronomy_db` vs init.sql `otelu`/`otelp`/`astroshop`)

> Note: #297 (payment flagd-off 401) is a separate, real bug and is **not** addressed here.
