### PR TITLE
feat(validate-order): Java order-lookup service for DB<->APM correlation

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -168,6 +168,11 @@ services:
     manifest: true
     group: throttle-demo
 
+  - name: validate-order
+    build: true
+    manifest: true
+    group: validate-order   # opt-in variant: DB-query <-> APM correlation demo
+
   - name: shipping
     build: false
     manifest: true

--- a/src/product-catalog/main.go
+++ b/src/product-catalog/main.go
@@ -123,12 +123,18 @@ func initDatabase() error {
 		return fmt.Errorf("DB_CONNECTION_STRING environment variable not set")
 	}
 
-	// otelsql + semconv v1.38 emits the new db.namespace attribute only.
-	// Also emit the old db.name key (parsed from the DSN) so the inferred DB
-	// service resolves consistently with the other services that still use it.
+	// otelsql.AttributesFromDSN only sets server.address/server.port — it does
+	// NOT emit the database name. Set it explicitly under both the new
+	// (db.namespace) and old (db.name) semconv keys, parsed from the DSN, so
+	// product-catalog's DB identity resolves to "astroshop" consistently with
+	// the services that emit new semconv (e.g. validate-order via the Java
+	// agent) and those still on the old key.
 	attrs := append(otelsql.AttributesFromDSN(connStr), semconv.DBSystemNamePostgreSQL)
 	if dbName := dsnField(connStr, "dbname"); dbName != "" {
-		attrs = append(attrs, attribute.String("db.name", dbName))
+		attrs = append(attrs,
+			semconv.DBNamespace(dbName),         // new semconv: db.namespace
+			attribute.String("db.name", dbName), // old semconv: db.name
+		)
 	}
 	dbAttrs := otelsql.WithAttributes(attrs...)
 

--- a/src/validate-order/Dockerfile
+++ b/src/validate-order/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# --- build: compile the single source file against the JDBC driver ---
+FROM --platform=${BUILDPLATFORM} eclipse-temurin:21-jdk AS builder
+WORKDIR /build
+
+# Postgres JDBC driver (baked into the image so runtime needs no egress).
+ADD --chmod=644 https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar /build/postgresql.jar
+
+COPY ./src/validate-order/ValidateOrder.java .
+RUN javac -cp /build/postgresql.jar ValidateOrder.java
+
+# --- runtime ---
+FROM eclipse-temurin:21-jre
+WORKDIR /usr/src/app
+
+# Splunk OpenTelemetry Java agent (CSA). Applied via JAVA_TOOL_OPTIONS in the
+# k8s manifest, matching the other Java services in this fork.
+ADD --chmod=644 https://repo1.maven.org/maven2/com/splunk/splunk-otel-javaagent-csa/2.27.0/splunk-otel-javaagent-csa-2.27.0.jar /usr/src/app/splunk-otel-javaagent-csa.jar
+
+COPY --from=builder /build/ValidateOrder.class /build/postgresql.jar /usr/src/app/
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-cp", "/usr/src/app:/usr/src/app/postgresql.jar", "ValidateOrder"]

--- a/src/validate-order/README.md
+++ b/src/validate-order/README.md
@@ -1,0 +1,50 @@
+# validate-order
+
+Minimal Java support service for **accounting**. Demonstrates
+**database-query ↔ APM-trace correlation** (Splunk DB Query Performance ↔ APM).
+
+## What it does
+
+Accounting fire-and-forgets `POST /validate/{orderId}` for every Kafka order it
+consumes (its `ORDER_VALIDATION_ADDR` env). This service looks that order up in
+the `accounting."order"` table and returns whether it exists:
+
+```
+POST /validate/{orderId}   ->  {"orderId":"...","found":true|false}
+GET  /health               ->  {"ok":true}
+```
+
+## How the correlation works
+
+The Splunk OpenTelemetry Java agent (baked into the image, applied via
+`JAVA_TOOL_OPTIONS`) instruments both the incoming HTTP request and the JDBC
+call. With `OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED=true` the DB statement
+carries trace context, so the query correlates with the APM trace — and the
+server span is created from accounting's `traceparent`, nesting the lookup under
+the order's trace.
+
+## Build & deploy
+
+Standard service — defined in `services.yaml` (`build: true`, `manifest: true`,
+`group: validate-order`). It builds to
+`ghcr.io/splunk/opentelemetry-demo/otel-validate-order` and stitches into its own
+opt-in manifest variant `splunk-astronomy-shop-<VERSION>-validate-order.yaml`.
+
+## Activating the accounting call
+
+Set on the **accounting** deployment:
+
+```
+ORDER_VALIDATION_ADDR=http://validate-order:8080
+```
+
+> This shares accounting's single validation hook with
+> `order-validation`/throttle-demo — only one target can be wired at a time.
+
+## Config
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `PG_URL` | `jdbc:postgresql://postgresql:5432/astroshop` | DB connection |
+| `PG_USER` / `PG_PASS` | `otelu` / `otelp` | has SELECT on `accounting` schema |
+| `PORT` | `8080` | HTTP listen port |

--- a/src/validate-order/ValidateOrder.java
+++ b/src/validate-order/ValidateOrder.java
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// validate-order — minimal Java support service for accounting.
+//
+// Accounting fires a fire-and-forget POST /validate/{orderId} for every Kafka
+// order it consumes (ORDER_VALIDATION_ADDR env). This service looks that order
+// up in the accounting."order" table and returns whether it exists.
+//
+// Instrumented by the Splunk OpenTelemetry Java agent (added via JAVA_TOOL_OPTIONS
+// in the k8s manifest). With OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED=true the
+// DB lookup is correlated with the APM trace (DB Query Performance <-> APM), and
+// the agent creates a server span from accounting's traceparent so the lookup
+// nests under the order's trace.
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+public class ValidateOrder {
+    static String url, user, pass;
+
+    public static void main(String[] args) throws Exception {
+        url  = env("PG_URL",  "jdbc:postgresql://postgresql:5432/astroshop");
+        user = env("PG_USER", "otelu");
+        pass = env("PG_PASS", "otelp");
+        int port = Integer.parseInt(env("PORT", "8080"));
+
+        HttpServer s = HttpServer.create(new InetSocketAddress(port), 0);
+        s.createContext("/validate", ValidateOrder::handleValidate);
+        s.createContext("/health", ex -> respond(ex, 200, "{\"ok\":true}"));
+        s.setExecutor(null);
+        System.out.println("validate-order listening on :" + port + " -> " + url);
+        s.start();
+    }
+
+    // POST /validate/{orderId} — look the order up in accounting."order".
+    static void handleValidate(HttpExchange ex) throws java.io.IOException {
+        String path = ex.getRequestURI().getPath();
+        String prefix = "/validate/";
+        String orderId = path.length() > prefix.length() ? path.substring(prefix.length()) : "";
+        ex.getRequestBody().readAllBytes(); // accounting POSTs a JSON body; not needed here
+
+        boolean found = false;
+        String err = null;
+        if (!orderId.isEmpty()) {
+            String sql = "SELECT order_id FROM accounting.\"order\" WHERE order_id = ?";
+            try (Connection c = DriverManager.getConnection(url, user, pass);
+                 PreparedStatement ps = c.prepareStatement(sql)) {
+                ps.setString(1, orderId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    found = rs.next();
+                }
+            } catch (Exception e) {
+                err = e.getMessage();
+            }
+        }
+
+        int code = (err != null) ? 500 : 200;
+        String body = (err != null)
+            ? "{\"orderId\":\"" + esc(orderId) + "\",\"error\":\"" + esc(err) + "\"}"
+            : "{\"orderId\":\"" + esc(orderId) + "\",\"found\":" + found + "}";
+        System.out.println("validate order=" + orderId + " found=" + found + (err != null ? " err=" + err : ""));
+        respond(ex, code, body);
+    }
+
+    static void respond(HttpExchange ex, int code, String body) throws java.io.IOException {
+        byte[] b = body.getBytes();
+        ex.getResponseHeaders().set("Content-Type", "application/json");
+        ex.sendResponseHeaders(code, b.length);
+        try (OutputStream os = ex.getResponseBody()) { os.write(b); }
+    }
+
+    static String esc(String s) {
+        return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    static String env(String k, String d) {
+        String v = System.getenv(k);
+        return (v == null || v.isEmpty()) ? d : v;
+    }
+}

--- a/src/validate-order/validate-order-k8s.yaml
+++ b/src/validate-order/validate-order-k8s.yaml
@@ -1,0 +1,129 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# Kubernetes manifest for validate-order
+#
+# Demo intent: database-query <-> APM trace correlation.
+# Accounting fire-and-forgets POST /validate/{orderId} for every Kafka order it
+# consumes (its ORDER_VALIDATION_ADDR env). This service looks the order up in
+# accounting."order". The Splunk Java agent instruments the incoming request and
+# the JDBC call; with OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED=true the DB query
+# correlates with the APM trace (DB Query Performance <-> APM), nested under the
+# order's trace via accounting's traceparent.
+#
+# To activate: set ORDER_VALIDATION_ADDR=http://validate-order:8080 on the
+# accounting deployment. (This shares accounting's single validation hook with
+# order-validation/throttle-demo — only one target can be wired at a time.)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: validate-order
+  labels:
+    opentelemetry.io/name: validate-order
+    app.kubernetes.io/component: validate-order
+    app.kubernetes.io/name: validate-order
+    app.kubernetes.io/version: 2.0.7
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    name: tcp-service
+    targetPort: 8080
+  selector:
+    opentelemetry.io/name: validate-order
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: validate-order
+  labels:
+    opentelemetry.io/name: validate-order
+    app.kubernetes.io/component: validate-order
+    app.kubernetes.io/name: validate-order
+    app.kubernetes.io/version: 2.0.7
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      opentelemetry.io/name: validate-order
+  template:
+    metadata:
+      labels:
+        opentelemetry.io/name: validate-order
+        app.kubernetes.io/component: validate-order
+        app.kubernetes.io/name: validate-order
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+      - name: validate-order
+        image: ghcr.io/splunk/opentelemetry-demo/otel-validate-order:2.0.7
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: service
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['app.kubernetes.io/component']
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_COLLECTOR_NAME
+          value: $(NODE_IP)
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://$(OTEL_COLLECTOR_NAME):4317
+        - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          value: cumulative
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.7
+        # Splunk Java agent (baked into the image).
+        - name: JAVA_TOOL_OPTIONS
+          value: -javaagent:/usr/src/app/splunk-otel-javaagent-csa.jar
+        # Correlate DB queries with APM traces (DB Query Performance <-> APM).
+        # https://help.splunk.com/en/splunk-observability-cloud/monitor-databases/correlate-database-queries-with-splunk-apm-traces/correlate-database-queries-with-java-traces
+        - name: OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED
+          value: 'true'
+        - name: OTEL_METRICS_EXPORTER
+          value: none
+        - name: SPLUNK_PROFILER_ENABLED
+          value: 'false'
+        # astroshop DB — otelu has SELECT on the accounting schema.
+        - name: PG_URL
+          value: jdbc:postgresql://postgresql:5432/astroshop
+        - name: PG_USER
+          value: otelu
+        - name: PG_PASS
+          value: otelp
+        - name: PORT
+          value: '8080'
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 384Mi
+        # The Splunk agent + JVM take ~15-25s to boot the HTTP server; the
+        # startupProbe gates readiness/liveness until then so health checks
+        # don't fail during startup.
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 5
+          failureThreshold: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 15


### PR DESCRIPTION
## What

Adds **validate-order**, a first-class Java support service that demonstrates **database-query ↔ APM-trace correlation** (Splunk DB Query Performance ↔ APM).

## How it works

Accounting already fire-and-forgets `POST /validate/{orderId}` for every Kafka order it consumes (its existing `ORDER_VALIDATION_ADDR` hook — **no accounting change needed**). validate-order looks the order up in `accounting."order"` and returns whether it exists.

The Splunk OpenTelemetry Java agent instruments both the incoming HTTP request and the JDBC call; with `OTEL_INSTRUMENTATION_SPLUNK_JDBC_ENABLED=true` the DB query correlates with the APM trace, nested under the order's trace via accounting's `traceparent`.

## Changes

- `src/validate-order/`
  - `ValidateOrder.java` — single-file JDK 21 HTTP service (`POST /validate/{orderId}`, `GET /health`)
  - `Dockerfile` — multi-stage; Splunk Java agent (CSA) + Postgres JDBC driver baked in (no runtime egress)
  - `validate-order-k8s.yaml` — Service + Deployment (agent via `JAVA_TOOL_OPTIONS`, OTLP to node-local collector, startup/readiness/liveness probes)
  - `README.md`
- `services.yaml` — `build: true`, `manifest: true`, `group: validate-order` → opt-in variant `splunk-astronomy-shop-<VERSION>-validate-order.yaml`

## Activate

Set `ORDER_VALIDATION_ADDR=http://validate-order:8080` on the accounting deployment. (Shares accounting's single validation hook with `order-validation`/throttle-demo — one target at a time.)

## Verified

- `javac` compile OK; `services.yaml` parses; `get-services.py` lists the service + new `validate-order` group/variant; k8s manifest is schema-valid (server dry-run).
- Behaviour proven on dev-astronomy with a source-launch test build: real order → `found:true`, fake → `found:false`, live accounting-driven lookups flowing under the order traces.

> Image build runs in CI (docker not available locally).
