### PR TITLE
fix(checkout): honor runtime flagd changes (disable cache) — fixes #297

### DIFF
--- a/src/checkout/main.go
+++ b/src/checkout/main.go
@@ -189,7 +189,12 @@ func main() {
 		logger.Error((err.Error()))
 	}
 
-	provider, err := flagd.NewProvider()
+	// WithoutCache: evaluate every flag against flagd live. The default RPC
+	// provider caches per-flag and only invalidates on configuration_change
+	// events; runtime flag changes (e.g. via flagd-ui) were not being picked
+	// up, so checkout kept routing to payment-vB after paymentFailure was set
+	// to off. Disabling the cache makes routing honor the current flag value.
+	provider, err := flagd.NewProvider(flagd.WithoutCache())
 	if err != nil {
 		logger.Error(fmt.Sprintf("Error creating flagd provider: %v", err))
 	}


### PR DESCRIPTION
## Fixes #297

**Symptom:** with `paymentFailure` set to `off`, checkout→payment still errors — payment-vB returns `401 Invalid API Token`.

**Root cause:** `paymentFailure` controls A/B routing (checkout routes to payment-vB with probability = flag value); vB always 401s. checkout used `flagd.NewProvider()` — the default RPC resolver with an **in-process cache**. It cached the flag at startup and only invalidates on `configuration_change` events, so a runtime change (flagd-ui → `off`) never cleared the cache. checkout kept routing ~50% to vB indefinitely.

**Verified on dev-astronomy:**
- flagd served `paymentFailure=off` on both eval ports (8013 + 8016).
- payment-vB kept receiving charges + 401ing for 14+ min after the flag went off.
- Restarting checkout → **0 new vB charges**; 100% to vA. Confirms stale cache.

**Fix:** `flagd.NewProvider(flagd.WithoutCache())` — every evaluation hits flagd live, so routing honors the current flag value. `go build` OK.

> Note (out of scope): `demo.flagd.json` `paymentFailure.defaultVariant` is `50%`, so a fresh deploy routes 50% to vB by default. Worth reconsidering separately whether the default should be lower/`off`.
