### PR TITLE
fix: namespace-relative sql-server-fraud host in fraud-detection + setup — fixes #293

### DIFF
--- a/src/fraud-detection/fraud-detection-k8s.yaml
+++ b/src/fraud-detection/fraud-detection-k8s.yaml
@@ -65,7 +65,7 @@ spec:
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.1.3,service.kafka=propagation
         - name: SQL_SERVER_HOST
-          value: sql-server-fraud.default.svc.cluster.local
+          value: sql-server-fraud
         - name: SQL_SERVER_PORT
           value: '1433'
         - name: SQL_SERVER_DATABASE
@@ -100,7 +100,7 @@ spec:
       - command:
         - sh
         - -c
-        - until nc -z -v -w30 sql-server-fraud.default.svc.cluster.local 1433; do echo
+        - until nc -z -v -w30 sql-server-fraud 1433; do echo
           waiting for sql-server-fraud; sleep 2; done;
         image: busybox:latest
         name: wait-for-sqlserver

--- a/src/sql-server-fraud-setup/sql-server-fraud-setup-k8s.yaml
+++ b/src/sql-server-fraud-setup/sql-server-fraud-setup-k8s.yaml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 stringData:
   SA_PASSWORD: ChangeMe_SuperStrong123!
-  DB_CONNECTION_STRING: Server=tcp:sql-server-fraud.astronomy-shop.svc.cluster.local,1433;Database=FraudDetection;User
+  DB_CONNECTION_STRING: Server=tcp:sql-server-fraud,1433;Database=FraudDetection;User
     Id=sa;Password=ChangeMe_SuperStrong123!;Encrypt=True;TrustServerCertificate=True
 ---
 apiVersion: v1


### PR DESCRIPTION
## Fixes #293

fraud-detection hardcoded `sql-server-fraud.default.svc.cluster.local` in two places:
- `SQL_SERVER_HOST` env
- the `wait-for-sqlserver` init container (`nc -z ... 1433`)

So it could only reach the SQL Server when the astronomy shop ran in the **`default`** namespace. In any other namespace, fraud-detection could never connect and never started.

**Fix:** use the bare service name `sql-server-fraud`, which resolves within the pod's own namespace via the k8s DNS search path — works in any namespace. (`kafka:9092` was already namespace-relative.)

No `.default.svc` references remain in any `src/*/*-k8s.yaml`.
