### PR TITLE
feat(order-ledger): make it a core service (not opt-in)

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -170,8 +170,7 @@ services:
 
   - name: order-ledger
     build: true
-    manifest: true
-    group: order-ledger   # opt-in variant: DB-query <-> APM correlation demo
+    manifest: true   # core service: accounting calls it per order (DB-query <-> APM correlation)
 
   - name: shipping
     build: false

--- a/src/accounting/accounting-k8s.yaml
+++ b/src/accounting/accounting-k8s.yaml
@@ -72,11 +72,14 @@ spec:
           value: http://$(OTEL_COLLECTOR_NAME):4318
         - name: DB_CONNECTION_STRING
           value: Host=postgresql;Username=otelu;Password=otelp;Database=astroshop
-        # Optional fire-and-forget call to order-validation (throttle-demo).
-        # Disabled by default (unset). To enable, set to the service URL
-        # e.g. http://order-validation:8080 — throttle-demo manifest deploys
-        # that service. When set but service absent, TriggerValidation
-        # swallows DNS NXDOMAIN / connection refused / timeout (120s cap).
+        # Fire-and-forget order lookup per Kafka order. order-ledger is a core
+        # service (POST /validate/{orderId} -> DB lookup, DB-query <-> APM
+        # correlation). TriggerValidation swallows DNS NXDOMAIN / connection
+        # refused / timeout if the target is absent, so this is safe even
+        # without order-ledger. throttle-demo overrides this to its own
+        # order-validation service.
+        - name: ORDER_VALIDATION_ADDR
+          value: http://order-ledger:8080
         - name: OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED
           value: 'true'
         # Emit both old (db.name) and new (db.namespace) DB semconv attributes.


### PR DESCRIPTION
order-ledger should be part of the base manifest, not an opt-in variant.

- `services.yaml`: drop `group: order-ledger` → stitches into the main manifest `splunk-astronomy-shop-<VER>.yaml`.
- `accounting-k8s.yaml`: set `ORDER_VALIDATION_ADDR=http://order-ledger:8080` by default so accounting calls order-ledger per Kafka order out of the box. `TriggerValidation` swallows errors if the target is absent (safe); throttle-demo overrides this to its own order-validation service.

Follow-up to the order-ledger service (#302/#304).