### PR TITLE
benderbot-I: CVE remediation batch

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "react-dom": "19.2.5",
         "sharp": "0.34.5",
         "styled-components": "6.4.0",
-        "uuid": "13.0.0"
+        "uuid": "13.0.1"
       },
       "devDependencies": {
         "@splunk/rum-cli": "1.0.0",
@@ -13346,9 +13346,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -10625,9 +10625,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -16,7 +16,6 @@
     "@openfeature/flagd-provider": "0.15.0",
     "@openfeature/flagd-web-provider": "0.7.4",
     "@openfeature/react-sdk": "1.2.1",
-    "@splunk/otel": "^4.5.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.78.0",
     "@opentelemetry/auto-instrumentations-web": "0.59.0",
@@ -37,6 +36,7 @@
     "@opentelemetry/sdk-trace-base": "2.6.1",
     "@opentelemetry/sdk-trace-node": "2.6.1",
     "@opentelemetry/sdk-trace-web": "2.6.1",
+    "@splunk/otel": "^4.5.1",
     "@tanstack/react-query": "5.97.0",
     "cookies-next": "6.1.1",
     "currency-symbol-map": "5.1.0",
@@ -47,7 +47,7 @@
     "react-dom": "19.2.5",
     "sharp": "0.34.5",
     "styled-components": "6.4.0",
-    "uuid": "13.0.0"
+    "uuid": "13.0.1"
   },
   "devDependencies": {
     "@splunk/rum-cli": "1.0.0",

--- a/src/payment/package-lock.json
+++ b/src/payment/package-lock.json
@@ -29,7 +29,7 @@
         "pino": "^10.3.1",
         "pino-opentelemetry-transport": "^3.0.0",
         "simple-card-validator": "1.1.0",
-        "uuid": "13.0.0"
+        "uuid": "13.0.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -5175,9 +5175,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/src/payment/package.json
+++ b/src/payment/package.json
@@ -13,7 +13,6 @@
     "@grpc/proto-loader": "0.8.0",
     "@openfeature/flagd-provider": "0.15.0",
     "@openfeature/server-sdk": "1.20.2",
-    "@splunk/otel": "^4.5.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.78.0",
     "@opentelemetry/core": "2.6.1",
@@ -27,11 +26,12 @@
     "@opentelemetry/resources": "2.6.1",
     "@opentelemetry/sdk-metrics": "2.6.1",
     "@opentelemetry/sdk-node": "0.220.0",
+    "@splunk/otel": "^4.5.1",
     "grpc-js-health-check": "1.2.2",
     "pino": "^10.3.1",
     "pino-opentelemetry-transport": "^3.0.0",
     "simple-card-validator": "1.1.0",
-    "uuid": "13.0.0"
+    "uuid": "13.0.1"
   },
   "overrides": {
     "@opentelemetry/otlp-transformer": {

--- a/src/react-native-app/Gemfile.lock
+++ b/src/react-native-app/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.4.0)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
     securerandom (0.3.2)
     typhoeus (1.4.1)

--- a/src/react-native-app/Gemfile.lock
+++ b/src/react-native-app/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     connection_pool (2.4.1)
     drb (2.2.1)
     escape (0.0.4)

--- a/src/react-native-app/package-lock.json
+++ b/src/react-native-app/package-lock.json
@@ -7801,9 +7801,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8920,9 +8920,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -12705,9 +12705,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/src/react-native-app/package-lock.json
+++ b/src/react-native-app/package-lock.json
@@ -16757,9 +16757,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/react-native-app/package-lock.json
+++ b/src/react-native-app/package-lock.json
@@ -16878,9 +16878,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/src/react-native-app/package-lock.json
+++ b/src/react-native-app/package-lock.json
@@ -19391,9 +19391,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/src/shop-dc-loadgenerator/requirements.txt
+++ b/src/shop-dc-loadgenerator/requirements.txt
@@ -1,3 +1,3 @@
 # Shop Datacenter Load Generator Dependencies
 requests>=2.31.0
-urllib3>=2.0.0
+urllib3>=2.7.0

--- a/src/shop-dc-shim/build.gradle
+++ b/src/shop-dc-shim/build.gradle
@@ -39,6 +39,12 @@ ext['json-smart.version'] = '2.5.2'
 // Spring Framework 6.1.13; override to 6.2.18 to clear the cluster.
 ext['spring-framework.version'] = '6.2.18'
 
+// CVE-2026-40984: Micrometer HTTP metrics DoS via crafted requests. Spring
+// Boot 3.3.4 BOM manages micrometer-core 1.13.4; the 1.13 line has no fix
+// (affected through 1.13.18, no 1.13.19 released). Override to 1.15.12, the
+// earliest published fixed version.
+ext['micrometer.version'] = '1.15.12'
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/src/shop-dc-shim/build.gradle
+++ b/src/shop-dc-shim/build.gradle
@@ -32,6 +32,13 @@ ext['mssql-jdbc.version'] = '12.8.2.jre11'
 // Fixed in 2.5.2.
 ext['json-smart.version'] = '2.5.2'
 
+// CVE-2024-38819 (WebMvc.fn/WebFlux.fn static-resource path traversal — not
+// exploitable here: this app has no functional-web/static-resource routes,
+// only @RestController endpoints) plus the 2026 spring-web CVE cluster
+// (CVE-2026-22740/22737/22745/22741/22735). Spring Boot 3.3.4 BOM manages
+// Spring Framework 6.1.13; override to 6.2.18 to clear the cluster.
+ext['spring-framework.version'] = '6.2.18'
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)


### PR DESCRIPTION
## Benderbot-I — CVE remediation batch (opentelemetry-demo)

Dependency CVE fixes from the current FOSSA/VULN batch. Each commit is one CVE/ticket; verified where a build was runnable.

### Fixes
| Component | Change | CVE |
|-----------|--------|-----|
| product-catalog | order-ledger DB semconv (prior work) | — |
| react-native-app | rexml 3.4.0 → 3.4.4 | rexml cluster / CVE-2025-58767 |
| react-native-app | shell-quote 1.8.2 → 1.10.0 | CVE-2026-9277 |
| react-native-app | node-forge 1.3.3 → 1.4.0 | CVE-2026-33895 + cluster |
| react-native-app | nanoid 3.3.15 → 3.3.18 | CVE-2026-67214 |
| react-native-app | brace-expansion → 2.1.4 / 1.1.18 | CVE-2026-33750 |
| react-native-app | concurrent-ruby 1.3.4 → 1.3.7 | CVE-2026-54904 |
| frontend | nanoid 3.3.16 → 3.3.18 | CVE-2026-67213 |
| frontend + payment | uuid 13.0.0 → 13.0.1 | CVE-2026-41907 |
| shop-dc-loadgenerator | urllib3 floor → ≥2.7.0 | CVE-2026-21441 |
| shop-dc-shim | Spring Framework → 6.2.18 (build-verified) | CVE-2024-38819 + 2026 cluster (also clears spring-core, spring-webmvc tickets) |
| shop-dc-shim | Micrometer → 1.15.12 (build-verified) | CVE-2026-40984 |

### Not in scope (documented in the tickets)
- **secureapp-loadgen** CVEs (ejs, PyYAML, axios, XWork, commons-io/lang3, …) → **Won't Fix**, intentional demo vulns per `SECURITY.md` / @Min Choi.
- tar / image-size → no released fix (VEX), build-tooling in non-deployed react-native-app.
- Several shop-dc-shim Spring Boot CVEs → Not Affected (no Spring Security).
- Insecure internal gRPC (SAST) → risk-accepted, by-design cluster-internal plaintext.
